### PR TITLE
Tweak HungerOverhaul/SpiceOfLife food properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ config/InvTweaks.cfg
 config/InGameInfoXML.cfg
 config/Dynmap.cfg
 *.ser
+*.lnk

--- a/config/SpiceOfLife.cfg
+++ b/config/SpiceOfLife.cfg
@@ -71,7 +71,7 @@ server {
     D:food.containers.chance.to.drop.food=0.25
 
     # The maximum stacksize per slot in a food container
-    I:food.containers.max.stacksize=2
+    I:food.containers.max.stacksize=64
 
     # The maximum time it takes to eat a food after being modified by food.eating.speed.modifier
     # The default eating duration is 32. Set this to 0 to remove the limit on eating speed.
@@ -84,7 +84,7 @@ server {
     D:food.eating.speed.modifier=1.0
 
     # The maximum amount of eaten foods stored in the history at a time
-    I:food.history.length=21
+    I:food.history.length=24
 
     # If true, food history will not get reset after every death
     B:food.history.persists.through.death=false
@@ -111,7 +111,7 @@ server {
     # 	distinct_food_groups_eaten : The number of distinct food groups in the player's current food history
     # 	total_food_groups : The total number of enabled food groups
     # 
-    S:food.modifier.formula=MAX(0, (1 - count/12))^MIN(8, food_hunger_value)
+    S:food.modifier.formula=IF(count>=3 && distinct_food_groups_eaten<=5,(1 - (count - 3)/4),1)
 
     # If true, a food journal will be given to each player as a starting item
     B:give.food.journal.as.starting.item=false

--- a/config/harvestcraft.cfg
+++ b/config/harvestcraft.cfg
@@ -2,7 +2,7 @@
 
 beekeeping {
     I:beehiveRarity=5
-    B:enablebeehiveGeneration=true
+    B:enablebeehiveGeneration=false
 }
 
 


### PR DESCRIPTION
One will need a lunchbox or two lunchbags (6 types of different food
type) to enjoy the food with 100% of its value eating 4 of the same type
food from a stack at a time.

Also, disables HarvestCraft bees.

Closes #449