### PR TITLE
Add chisel recipes for glass and marble

### DIFF
--- a/scripts/Chisel.zs
+++ b/scripts/Chisel.zs
@@ -8,7 +8,7 @@
 
 
 mods.chisel.Groups.addGroup("glasswork"); 
-
+//mods.chisel.Groups.addGroup("stained_glass_");
 
 
 
@@ -172,7 +172,25 @@ mods.chisel.Groups.addVariation("glasswork", <chisel:glass:14>);
 mods.chisel.Groups.addVariation("glasswork", <chisel:glass:15>);
 // -
 mods.chisel.Groups.addVariation("glasswork", <chisel:glass2>);
+// -
+mods.chisel.Groups.addVariation("glasswork", <TConstruct:GlassBlock>);
+// -
+mods.chisel.Groups.addVariation("glasswork", <EnderIO:blockFusedQuartz:1>);
 
+
+
+// --- Stained Glass (add other stained glass variations later)
+//mods.chisel.Groups.addVariation("stained_glass_", <witchery:shadedglass>);
+// -
+//mods.chisel.Groups.addVariation("stained_glass_", <witchery:shadedglass_active>);
+// -
+//mods.chisel.Groups.addVariation("stained_glass_", <TConstruct:GlassBlock.StainedClear>);
+// -
+//mods.chisel.Groups.addVariation("stained_glass_", <Ztones:tile.glaxx>);
+
+
+// --- Marble
+mods.chisel.Groups.addVariation("marble", <Railcraft:cube:7>)
 
 
 


### PR DESCRIPTION
Squashed commits
5bf056e83c53f7f981499ff85e76ca302d1b200f
ec80d80bf43a5a0a360cd114451609556a8e1381
c53a74676cd9f34e8cacfb94d69d5b22bcc1ba84
51df01db65a911c635a2c5a8520d968d8b2436f6
6857234e12b51349e50bba4be171761d449833c8
from Patches-Arnab into one, coherent branch.

Original commit below
=====================
Add chisel recipes

Clear glass and quite clear glass should be now chiseled into glass and
it types. (Since Clear glass can be made by the player relatively easily
and can also be broken by hand, these recipe wont do harm)

Add Quarried stone to be chiseled into marble (hopefully)

Add future support for stained glass being chiseled into their
equivalent colour blocks from witchery,ztones and tconstruct