### PR TITLE
Fixed gendustry.bee.YellowGarnet

### DIFF
--- a/config/gendustry/bees.cfg
+++ b/config/gendustry/bees.cfg
@@ -2119,7 +2119,7 @@ mutation: 3% "gendustry.bee.CertusQuartz" + "gendustry.bee.Coal" => "gendustry.b
 mutation: 5% "gendustry.bee.Redstone" + "gendustry.bee.Diamond" => "gendustry.bee.Ruby" Req Block B:BiomesOPlenty:gemOre@3
 mutation: 4% "gendustry.bee.Olivine" + "gendustry.bee.Diamond" => "gendustry.bee.Emerald" Req Block B:minecraft:"emerald_block"
 mutation: 4% "gendustry.bee.Diamond" + "gendustry.bee.Ruby" => "gendustry.bee.RedGarnet" Req Block B:gregtech:"gt.blockgem2"@10
-mutation: 3% "gendustry.bee.Emerald" + "gendustry.bee.RedGarnet" => "gendustry.bee.YellowGarnet" Req Block B:"gregtech:gt.blockgem3"@2
+mutation: 3% "gendustry.bee.Emerald" + "gendustry.bee.RedGarnet" => "gendustry.bee.YellowGarnet" Req Block B:gregtech:"gt.blockgem3"@2
 
 
 // Alloy Mutations


### PR DESCRIPTION
`[Client thread/WARN]: Adding mutation failed: Block not found minecraft:gregtech:gt.blockgem3 (RsMutation(gendustry.bee.Emerald,gendustry.bee.RedGarnet,gendustry.bee.YellowGarnet,3.0,false,List(MReqBlock(StackBlock(minecraft,gregtech:gt.blockgem3,2)))))`