### PR TITLE
Focus Upgrade id conflict

### DIFF
--- a/config/ForbiddenMagic.cfg
+++ b/config/ForbiddenMagic.cfg
@@ -35,8 +35,8 @@ enchantments {
 
 
 "focus upgrades" {
-    I:Hellfire=42
-    I:Pandemonium=43
+    I:Hellfire=142
+    I:Pandemonium=143
 }
 
 


### PR DESCRIPTION
```
[18:44:53] [Client thread/FATAL]: Focus Upgrade id 42 already occupied. Ignoring.
[18:44:53] [Client thread/FATAL]: Focus Upgrade id 43 already occupied. Ignoring.
```
I have no idea how to see/dump focus upgrade IDs, but changing it to 142-143 seems works. No more log warn and Forbidden Magic focus upgrades available ingame.