### PR TITLE
Extratrees fixes

### DIFF
--- a/scripts/Extra-Trees.zs
+++ b/scripts/Extra-Trees.zs
@@ -136,7 +136,7 @@ recipes.addShaped(<ExtraTrees:machine:4>, [
 //[<ore:pipeMediumSteel>, <Forestry:sturdyMachine>, <ore:pipeMediumSteel>],
 //[<ore:gearGtSmallBronze>, <gregtech:gt.metaitem.01:32600>, <ore:gearGtSmallBronze>]]);
 
-// --- Destillery
+// --- Distillery
 //recipes.addShaped(<ExtraTrees:machine:6>, [
 //[<BuildCraft|Factory:tankBlock>, <IC2:itemRecipePart:6>, <BuildCraft|Factory:tankBlock>],
 //[<IC2:itemRecipePart:5>, <Forestry:sturdyMachine>, <IC2:itemRecipePart>],
@@ -172,35 +172,35 @@ recipes.addShaped(<ExtraTrees:durableHammer>, [
 [<ore:ingotGold>, <RandomThings:ingredient:1>, <ore:stickWood>],
 [<ore:plateObsidian>, <ore:plateObsidian>, null]]);
 
-// --- Wheat Grain
-recipes.addShaped(<ExtraTrees:misc:8>, [
-[<minecraft:wheat_seeds>, null, null],
-[<ore:craftingToolMortar>, null, null],
-[null, null, null]]);
+// --- Wheat Grain - Removed by extra trees update
+// recipes.addShaped(<ExtraTrees:misc:8>, [
+// [<minecraft:wheat_seeds>, null, null],
+// [<ore:craftingToolMortar>, null, null],
+// [null, null, null]]);
 
-// --- Barley Grain
-recipes.addShaped(<ExtraTrees:misc:9>, [
-[<Natura:barley.seed>, null, null],
-[<ore:craftingToolMortar>, null, null],
-[null, null, null]]);
+// --- Barley Grain - Removed by extra trees update
+// recipes.addShaped(<ExtraTrees:misc:9>, [
+// [<Natura:barley.seed>, null, null],
+// [<ore:craftingToolMortar>, null, null],
+// [null, null, null]]);
 
-// --- Rye Grain
-recipes.addShaped(<ExtraTrees:misc:10>, [
-[<harvestcraft:ryeItem>, null, null],
-[<ore:craftingToolMortar>, null, null],
-[null, null, null]]);
+// --- Rye Grain - Removed by extra trees update
+// recipes.addShaped(<ExtraTrees:misc:10>, [
+// [<harvestcraft:ryeItem>, null, null],
+// [<ore:craftingToolMortar>, null, null],
+// [null, null, null]]);
 
-// --- Corn Grain
-recipes.addShaped(<ExtraTrees:misc:11>, [
-[<harvestcraft:cornItem>, null, null],
-[<ore:craftingToolMortar>, null, null],
-[null, null, null]]);
+// --- Corn Grain - Removed by extra trees update
+// recipes.addShaped(<ExtraTrees:misc:11>, [
+// [<harvestcraft:cornItem>, null, null],
+// [<ore:craftingToolMortar>, null, null],
+// [null, null, null]]);
 
-// --- Hops
-recipes.addShapeless(<ExtraTrees:misc:5>, [<IC2:itemHops>]);
+// --- Hops - Removed by extra trees update
+// recipes.addShapeless(<ExtraTrees:misc:5>, [<IC2:itemHops>]);
 
 // --- Glass Fittings
-recipes.addShaped(<ExtraTrees:misc:13> * 5, [
+recipes.addShaped(<ExtraTrees:misc:5> * 5, [
 [<ore:stickLongAnyIron>, <ore:craftingToolSaw>, <ore:stickLongAnyIron>],
 [null, <ore:stickLongAnyIron>, null],
 [<ore:stickLongAnyIron>, <ore:craftingToolFile>, <ore:stickLongAnyIron>]]);

--- a/scripts/IC2.zs
+++ b/scripts/IC2.zs
@@ -1097,8 +1097,8 @@ recipes.addShaped(<IC2:itemRecipePart:6>, [
 [<ore:screwCopper>, <ore:craftingToolWrench>, <ore:screwCopper>],
 [<IC2:itemCasing>, <IC2:itemCasing>, <IC2:itemCasing>]]);
 
-// --- Hops
-recipes.addShapeless(<IC2:itemHops>, [<ExtraTrees:misc:5>]);
+// --- Hops -- Removed by update to Extratrees
+// recipes.addShapeless(<IC2:itemHops>, [<ExtraTrees:misc:5>]);
 
 // --- Empty booze Barrel
 recipes.addShaped(<IC2:itemBarrel>, [


### PR DESCRIPTION
These code changes are all necessitated by the recent changes to extra trees to remove the booze making functionality with it.  All the commented out items were removed, and as such, the itemid for the glass fittings was changed.

As a side note, glass fittings are not used in any recipes that I can find, might be something to consider in updating future recipes.