### PR TITLE
Sprinkler from OpenBlocks made more usable.

### DIFF
--- a/config/OpenBlocks.cfg
+++ b/config/OpenBlocks.cfg
@@ -362,19 +362,19 @@ sprinkler {
     I:bonemealConsumeRate=600
 
     # 1/chance that crops will be fertilized with bonemeal
-    I:bonemealFertilizeChance=200
+    I:bonemealFertilizeChance=10
 
     # The range in each cardinal direction that crops will be affected.
     I:effectiveRange=4
 
     # 1/chance that crops will be fertilized without bonemeal
-    I:fertilizeChance=500
+    I:fertilizeChance=25
 
     # Capacity (in mB) of internal tank.
-    I:internalTankCapacity=50
+    I:internalTankCapacity=1000
 
     # Consume rate of sprinkler (ticks/mB).
-    I:waterConsumeRate=20
+    I:waterConsumeRate=2
 }
 
 

--- a/scripts/Open-Blocks.zs
+++ b/scripts/Open-Blocks.zs
@@ -296,9 +296,9 @@ recipes.addShaped(<OpenBlocks:vacuumhopper>, [
 
 // --- Sprinkler
 recipes.addShaped(<OpenBlocks:sprinkler>, [
-[<dreamcraft:item.SteelBars>, <ore:stickGold>, <dreamcraft:item.SteelBars>],
-[<ore:pipeSmallSteel>, <ore:pipeSmallSteel>, <ore:pipeSmallSteel>],
-[<dreamcraft:item.SteelBars>, <ore:stickGold>, <dreamcraft:item.SteelBars>]]);
+[<dreamcraft:item.AluminiumBars>, <ore:stickGold>, <dreamcraft:item.AluminiumBars>],
+[<ore:pipeSmallDarkSteel>, <ore:rotorDarkSteel>, <ore:pipeSmallDarkSteel>],
+[<dreamcraft:item.AluminiumBars>, <ore:stickGold>, <dreamcraft:item.AluminiumBars>]]);
 
 // --- Building Guide
 recipes.addShaped(BGuide, [


### PR DESCRIPTION
Hello, @Dream-Master 
Default setting of this device make it useless at all. I bumped all parameters. Now this sprinkler can be compared with basic watering can from ExtraUtilities, but automated.
Because of that, recipe changed (now this gadget available on mid/end MV age).
With these changes I recommend you to add quest for this (now *useful*) device. It (*in my horrible opinion*) fits into Forestry branch after quest "Your first multiblock farm".

//If you want, I'll try to add this quest myself.