### PR TITLE
Tweaked growth speed configuration.

### DIFF
--- a/config/HungerOverhaul/HungerOverhaul.cfg
+++ b/config/HungerOverhaul/HungerOverhaul.cfg
@@ -215,7 +215,7 @@ harvestcraft {
 
 harvesting {
     # Multiplier on the effectiveness of bonemeal; the smaller this is, the more often bonemeal will fail to create growth. Set to 0 to disable bonemeal completely. [vanilla: 1.0] [range: 0.0 ~ 1.0, default: 0.5]
-    S:bonemealEffectiveness=0.5
+    S:bonemealEffectiveness=1.0
 
     # Enables/disables harvest crops by right clicking them [vanilla: false] [default: true]
     B:enableRightClickHarvesting=true

--- a/config/OpenBlocks.cfg
+++ b/config/OpenBlocks.cfg
@@ -359,7 +359,7 @@ sponge {
 
 sprinkler {
     # Consume rate of bonemeal (ticks/item).
-    I:bonemealConsumeRate=600
+    I:bonemealConsumeRate=300
 
     # 1/chance that crops will be fertilized with bonemeal
     I:bonemealFertilizeChance=10


### PR DESCRIPTION
These changes are related to my previous PR. Ones don't change so much balance in early-game, but give players some technical "buffs" (like useful sprinkler) in mid-game.

Change in HungerOverhaul doesn't break early-game balance, because main configuration for growth acceleration is ```B:modifyBonemealGrowth=true```. (I tested this)