### PR TITLE
A few changes that were not made/forgotten/repetitive

### DIFF
--- a/config/GregTech/GregTech.cfg
+++ b/config/GregTech/GregTech.cfg
@@ -45,7 +45,7 @@ general {
     D:MagneticraftBonusOutputPercent=100.0
     I:MaxEqualEntitiesAtOneSpot=3
     I:MillisecondsPassedInGTTileEntityUntilLagWarning=100
-    B:MixedOreOnlyYieldsTwoThirdsOfPureOre=true
+    B:MixedOreOnlyYieldsTwoThirdsOfPureOre=false
     B:NerfCombs=true
     B:NerfCrops=true
     B:NerfDustCrafting=true

--- a/config/GregTech/MachineStats.cfg
+++ b/config/GregTech/MachineStats.cfg
@@ -77,7 +77,7 @@ machineconfig {
     I:ThermalGenerator.efficiency.tier.4_72=72
     I:ThermalGenerator.efficiency.tier.5_65=65
     I:ThermalGenerator.efficiency.tier.6_58=58
-    B:forceFreeFace_true=true
+    B:forceFreeFace_true=false
 }
 
 


### PR DESCRIPTION
Reverted MixedOreOnlyYieldsTwoThirdsOfPureOre to false. This means furnace recipes for pure dusts (non impure/purified dusts) will give an ingots worth of material and EBF recipes will give 3 ingots instead of 2. So overall makes the game more enjoyable and makes the EBF processing a must have for people who want to get the most out of there ores.