### PR TITLE
Allow Recycling the Gregtech Sensor Card

### DIFF
--- a/scripts/Nuclear-Control.zs
+++ b/scripts/Nuclear-Control.zs
@@ -221,6 +221,8 @@ recipes.addShaped(<IC2NuclearControl:remoteMonitor>, [
 
 
 
+// --- Recycle GregTech Sensor Card
+Assembler.addRecipe(<IC2:itemPartCircuit>*3, <gregtech:gt.sensorcard>, <gregtech:gt.sensorcard>, 6400, 10);
 
 // --- Remote Sensor Kit
 Assembler.addRecipe(<IC2NuclearControl:ItemRemoteSensorKit>, <IC2NuclearControl:ItemToolDigitalThermometer:*>, <IC2:itemFreq>, 1600, 2);

--- a/scripts/Nuclear-Control.zs
+++ b/scripts/Nuclear-Control.zs
@@ -222,7 +222,7 @@ recipes.addShaped(<IC2NuclearControl:remoteMonitor>, [
 
 
 // --- Recycle GregTech Sensor Card
-Assembler.addRecipe(<IC2:itemPartCircuit>*3, <gregtech:gt.sensorcard>, <gregtech:gt.sensorcard>, 6400, 10);
+Assembler.addRecipe(<IC2:itemPartCircuit>*3, <gregtech:gt.sensorcard>, <gregtech:gt.sensorcard>, 200, 32);
 
 // --- Remote Sensor Kit
 Assembler.addRecipe(<IC2NuclearControl:ItemRemoteSensorKit>, <IC2NuclearControl:ItemToolDigitalThermometer:*>, <IC2:itemFreq>, 1600, 2);


### PR DESCRIPTION
Like the other cards, gives back half of the circuits used to craft it.