### PR TITLE
Replace Pam's salt with Edible Salt

### DIFF
--- a/config/harvestcraft.cfg
+++ b/config/harvestcraft.cfg
@@ -159,7 +159,7 @@ general {
     B:enableharvestcraftfish=true
     B:enablelistAllwaterfreshwater=true
     B:enablelistAllwatervanillawaterbucket=true
-    B:enablesaltfromwaterbucketrecipe=true
+    B:enablesaltfromwaterbucketrecipe=false
     B:enabletofuasmeatinRecipes=true
     B:enabletofuasmilkinRecipes=true
     I:fishtrapbaitrecipeamount=4

--- a/scripts/Harvestcraft.zs
+++ b/scripts/Harvestcraft.zs
@@ -23,8 +23,6 @@ val String = <minecraft:string>;
 val Cotton = <Natura:barleyFood:3>;
 val flour = <ore:dustWheat>;
 
-
-
 // --- Removing Recipes ---
 
 // --- Sink ---
@@ -32,9 +30,6 @@ recipes.remove(<harvestcraft:sink:*>);
 
 // --- Market ---
 recipes.remove(<harvestcraft:market>);
-
-// --- Salt ---
-recipes.remove(<harvestcraft:saltItem>);
 
 // --- Salt Block
 recipes.remove(<harvestcraft:spamcompressedsaltBlockalt>);
@@ -184,6 +179,9 @@ recipes.remove(<harvestcraft:lemonaideItem>);
 
 // --- Adding Back Recipes ---
 
+// --- Edible Salt
+
+recipes.addShapeless(<dreamcraft:item.EdibleSalt>, [<ore:toolPot>, <ore:listAllwater>]);
 
 // --- Woven Cotton
 recipes.addShaped(WovenCloth, [
@@ -393,13 +391,6 @@ recipes.addShapeless(<harvestcraft:freshmilkItem> * 2, [<IguanaTweaksTConstruct:
 recipes.addShapeless(<harvestcraft:freshwaterItem> * 4, [<minecraft:water_bucket>]);
 
 recipes.addShapeless(<harvestcraft:freshwaterItem> * 2, [<IguanaTweaksTConstruct:clayBucketWater>]);
-
-// --- Salt
-recipes.addShapeless(<gregtech:gt.metaitem.01:1817>, [<harvestcraft:potItem>, <harvestcraft:freshwaterItem>]); 
-// -
-recipes.addShapeless(<gregtech:gt.metaitem.01:2817>, [<harvestcraft:potItem>, <minecraft:water_bucket>]);
-// -
-recipes.addShapeless(<gregtech:gt.metaitem.01:1817> * 2, [<harvestcraft:potItem>, <IguanaTweaksTConstruct:clayBucketWater>]);
 
 // --- Wet Tofu
 recipes.addShapeless(<dreamcraft:item.WetTofu>, [<harvestcraft:soybeanItem>, <minecraft:water_bucket>]);


### PR DESCRIPTION
Prevents obtaining infinite sodium and chlorine using the Harvestcraft salt recipe. (Infinite Na is still available from centrifuged ashes, and infinite Cl from centrifuged stone dust.)

This patch requires the corresponding patch in the GTNH coremod: https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/25

Credit to @JasonMcRay for the artwork and original implementation.