### PR TITLE
Turn seeds into collectibles instead of them being infinite

### DIFF
--- a/config/HungerOverhaul/HungerOverhaul.cfg
+++ b/config/HungerOverhaul/HungerOverhaul.cfg
@@ -29,25 +29,25 @@
 
 delays {
     # Multiplier applied to the delay between breeding entities [vanilla: 1.0] [range: 0.0 ~ 3.4028235E38, default: 4.0]
-    I:breedingTimeoutMultiplier=2
+    I:breedingTimeoutMultiplier=4
 
     # Multiplier on the time it takes cactus to grow [vanilla: 1.0] [range: 0.0 ~ 3.4028235E38, default: 4.0]
-    I:cactusRegrowthMultiplier=2
+    I:cactusRegrowthMultiplier=4
 
     # Multiplier applied to the delay before children become adults [vanilla: 1.0] [range: 0.0 ~ 3.4028235E38, default: 4.0]
-    I:childDurationMultiplier=2
+    I:childDurationMultiplier=4
 
     # Multiplier on the time it takes cocoa to grow [vanilla: 1.0] [range: 0.0 ~ 3.4028235E38, default: 4.0]
-    I:cocoaRegrowthMultiplier=2
+    I:cocoaRegrowthMultiplier=4
 
     # Multiplier on the time it takes a non-tree crop to grow [vanilla: 1.0] [range: 0.0 ~ 3.4028235E38, default: 4.0]
-    I:cropRegrowthMultiplier=2
+    I:cropRegrowthMultiplier=4
 
     # Multiplier on the time it takes food to dry on Tinkers' Construct drying racks [vanilla: 1.0] [range: 0.0 ~ 3.4028235E38, default: 4.0]
-    I:dryingRackTimeMultiplier=2
+    I:dryingRackTimeMultiplier=4
 
     # Multiplier applied to the delay between chicken egg laying [vanilla: 1.0] [range: 0.0 ~ 3.4028235E38, default: 4.0]
-    I:eggTimeoutMultiplier=2
+    I:eggTimeoutMultiplier=4
 
     # Multiplier on the time it takes a WeeeFlower crop to grow [vanilla: 1.0] [range: 0.0 ~ 3.4028235E38, default: 1.0]
     I:flowerRegrowthMultiplier=1
@@ -56,19 +56,19 @@ delays {
     I:milkedTimeout=20
 
     # Multiplier on the time it takes nether wart to grow [vanilla: 1.0] [range: 0.0 ~ 3.4028235E38, default: 4.0]
-    I:netherWartRegrowthMultiplier=2
+    I:netherWartRegrowthMultiplier=4
 
     # Multipier on crop growth time without sunlight (1 to disable feature, 0 to make crops only grow in sunlight) [vanilla: 1.0] [range: 0.0 ~ 3.4028235E38, default: 2.0]
-    I:noSunlightRegrowthMultiplier=1
+    I:noSunlightRegrowthMultiplier=2
 
     # Multiplier on the time it takes a sapling to grow into a tree [vanilla: 1.0] [range: 0.0 ~ 3.4028235E38, default: 4.0]
-    I:saplingRegrowthMultiplier=2
+    I:saplingRegrowthMultiplier=4
 
     # Multiplier on the time it takes sugarcane to grow [vanilla: 1.0] [range: 0.0 ~ 3.4028235E38, default: 4.0]
-    I:sugarcaneRegrowthMultiplier=2
+    I:sugarcaneRegrowthMultiplier=4
 
     # Multiplier on the time it takes a tree crop to grow [vanilla: 1.0] [range: 0.0 ~ 3.4028235E38, default: 4.0]
-    I:treeCropRegrowthMultiplier=2
+    I:treeCropRegrowthMultiplier=4
 
     # Multipier on crop growth time (except sugarcane) in the wrong biome (1 to disable feature, 0 to make crops only grow in correct biome) [vanilla: 1.0] [range: 0.0 ~ 3.4028235E38, default: 2.0]
     I:wrongBiomeRegrowthMultiplier=1
@@ -215,7 +215,7 @@ harvestcraft {
 
 harvesting {
     # Multiplier on the effectiveness of bonemeal; the smaller this is, the more often bonemeal will fail to create growth. Set to 0 to disable bonemeal completely. [vanilla: 1.0] [range: 0.0 ~ 1.0, default: 0.5]
-    S:bonemealEffectiveness=1.0
+    S:bonemealEffectiveness=0.5
 
     # Enables/disables harvest crops by right clicking them [vanilla: false] [default: true]
     B:enableRightClickHarvesting=true

--- a/config/HungerOverhaul/HungerOverhaul.cfg
+++ b/config/HungerOverhaul/HungerOverhaul.cfg
@@ -154,7 +154,7 @@ food {
 
 "getting seeds" {
     # Adds a crafting recipe to turn 1 wheat into 1 seed [vanilla: false] [default: true]
-    B:addSeedsCraftingRecipe=true
+    B:addSeedsCraftingRecipe=false
 
     # Each seed has an equal chance to drop (grass drops and via hoes) [vanilla: false] [default: true]
     B:allSeedsEqual=true
@@ -242,10 +242,10 @@ harvesting {
     S:producePerHarvestRightClickMin=2
 
     # Maximum number of seeds you get when harvesting a non-tree crop by breaking it (modifyCropDrops must be tree) [vanilla: 0] [range: 0 ~ 2147483647, default: 0]
-    I:seedsPerHarvestBreakMax=0
+    I:seedsPerHarvestBreakMax=1
 
     # Minimum number of seeds you get when harvesting a non-tree crop by breaking it (modifyCropDrops must be true) [vanilla: 0] [range: 0 ~ 2147483647, default: 0]
-    I:seedsPerHarvestBreakMin=0
+    I:seedsPerHarvestBreakMin=1
 
     # Maximum number of seeds you get when harvesting a non-tree crop with right click (modifyCropDrops must be true) [vanilla: 0] [range: 0 ~ 2147483647, default: 0]
     I:seedsPerHarvestRightClickMax=0

--- a/config/endercore/endercore.cfg
+++ b/config/endercore/endercore.cfg
@@ -26,7 +26,7 @@ enchants {
 general {
     # Disabling this option will prevent any crops added to the config json from being right clickable.
     # [default: true]
-    B:allowCropRC=true
+    B:allowCropRC=false
 
     # Prevent tick speedup (i.e. torcherino) on any TE that uses the base TE class from EnderCore
     # [default: false]

--- a/config/harvestcraft.cfg
+++ b/config/harvestcraft.cfg
@@ -81,7 +81,7 @@ dimensions {
 gardens {
     B:enableberrygardenGeneration=true
     B:enabledesertgardenGeneration=true
-    B:enablegardenSpread=true
+    B:enablegardenSpread=false
     B:enablegourdgardenGeneration=true
     B:enablegrassgardenGeneration=true
     B:enablegroundgardenGeneration=true
@@ -94,7 +94,7 @@ gardens {
     B:enablewatergardenGeneration=true
     I:gardenRarity=2
     I:gardendropAmount=3
-    B:gardensdropSeeds=false
+    B:gardensdropSeeds=true
     I:gardenspreadRate=100
 }
 
@@ -155,7 +155,7 @@ general {
 
 "miscellaneous recipes" {
     B:enablecropitemsasseeds=true
-    B:enablecroptoseedRecipe=true
+    B:enablecroptoseedRecipe=false
     B:enableharvestcraftfish=true
     B:enablelistAllwaterfreshwater=true
     B:enablelistAllwatervanillawaterbucket=true

--- a/config/harvestthenether.cfg
+++ b/config/harvestthenether.cfg
@@ -3,7 +3,7 @@
 crops {
     I:cropfoodRestore=1
     D:cropsaturationRestore=0.6000000238418579
-    B:cropsdropSeeds=false
+    B:cropsdropSeeds=true
     D:mealsaturation=1.2000000476837158
     D:meatymealsaturation=1.600000023841858
     B:rightclickharvestCrop=true

--- a/config/harvestthenether.cfg
+++ b/config/harvestthenether.cfg
@@ -21,22 +21,22 @@ crops {
 
 
 gardens {
-    B:enablegardenSpread=true
-    B:enableglowflowerSpread=true
+    B:enablegardenSpread=false
+    B:enableglowflowerSpread=false
     B:enablenethergardenGeneration=true
     B:enablenetherglowflowerGeneration=true
     I:gardenRarity=4
     I:gardendropAmount=3
-    B:gardensdropSeeds=false
+    B:gardensdropSeeds=true
     I:gardenspreadRate=100
     I:glowflowerRarity=4
-    B:glowflowersdropSeeds=false
+    B:glowflowersdropSeeds=true
     I:glowflowerspreadRate=100
 }
 
 
 "miscellaneous recipes" {
-    B:enablecroptoseedRecipe=true
+    B:enablecroptoseedRecipe=false
 }
 
 

--- a/scripts/Harvestcraft.zs
+++ b/scripts/Harvestcraft.zs
@@ -175,6 +175,9 @@ recipes.remove(<harvestcraft:blueberryjuiceItem>);
 // --- Lemonade
 recipes.remove(<harvestcraft:lemonaideItem>);
 
+// Seeds
+recipes.remove(<harvestcraft:cottonseedItem>);
+
 
 
 // --- Adding Back Recipes ---

--- a/scripts/Havestcraft-Nether.zs
+++ b/scripts/Havestcraft-Nether.zs
@@ -21,6 +21,11 @@ val Saw = <ore:craftingToolSaw>;
 
 // --- Removing Recipes ---
 
+// Remove "Pam's Harvest the Nether" crop to seed recipes
+recipes.remove(<harvestthenether:bloodleafseedItem>);
+recipes.remove(<harvestthenether:fleshrootseedItem>);
+recipes.remove(<harvestthenether:marrowberryseedItem>);
+recipes.remove(<harvestthenether:glowflowerseedItem>);
 
 
 

--- a/scripts/Natura.zs
+++ b/scripts/Natura.zs
@@ -260,8 +260,6 @@ furnace.remove(<minecraft:coal:1>, <*>);
 recipes.addShapeless(Cotton,
 [<harvestcraft:cottonItem>, <harvestcraft:cottonItem>]);
 
-// --- Cotton Seeds
-recipes.addShapeless(<Natura:barley.seed:1>, [<Natura:barleyFood:3>]);
 
 // --- Imp Leather
 recipes.addShaped(Leather, [
@@ -1210,8 +1208,6 @@ recipes.addShapeless(<harvestcraft:blueberryjuiceItem>, [<harvestcraft:juicerIte
 // -
 recipes.addShapeless(<harvestcraft:blackberryjuiceItem>, [<harvestcraft:juicerItem>, <harvestcraft:blackberryItem>]);
 
-// --- Barley Seeds
-recipes.addShapeless(<Natura:barley.seed>, [<Natura:barleyFood>]);
 
 // --- Nether Furnace
 recipes.addShaped(<Natura:NetherFurnace>, [


### PR DESCRIPTION
This is a change I've been playing with for a few months now. I don't like the idea of the seeds multiplying when you grow plants, I like to collect them. I guess it fits into a hard pack like this. With this change, every seed you get will only result in one plant - if you want more plants you need to get more seeds. Ofc you get the seeds back when you break the plants.

This is a fairly big change, and I'm not sure if you want it - but I find it useful and have been playing since the start with it. If you want a big farm, you actually need to collect a lot of gardens to find all the plants you want - but I didn't find this to be a problem, I have plenty of food and a big farm.

Changes in detail:
- harvest craft gardens don't spread
- harvestcraft gardens drop seed instead of vegetables
- vegetables can't be turned into seeds anymore
- Only seeds can be planted, vegetables can't
- seeds don't multiply when harvesting a crop, but you can't lose them either
- plants grow slower
- Seedoil is thus a lot harder to get (Can use peanuts for example)

This doesn't affect IC2 crops. Potatos and carrots are also unaffected and can still be planted, because there are no seeds for them.