### PR TITLE
Downgrading Circuits.

### DIFF
--- a/scripts/Gregtech.zs
+++ b/scripts/Gregtech.zs
@@ -1321,6 +1321,28 @@ mods.tconstruct.Casting.addTableRecipe(<gregtech:gt.metaitem.01:32375>, <liquid:
 
 
 
+// --- Circuit conversion
+// --- MV Tier
+
+
+// --- Yellow to Gold
+recipes.addShapeless(<gregtech:gt.metaitem.03:32079>,
+[<gregtech:gt.metaitem.03:32080>]);
+// --- Gold to Red
+recipes.addShapeless(<gregtech:gt.metaitem.01:32702>,
+[<gregtech:gt.metaitem.03:32079>]);
+
+
+// --- HV Tier
+
+
+// --- Green to Yellow
+recipes.addShapeless(<gregtech:gt.metaitem.01:32703>,
+[<gregtech:gt.metaitem.03:32082>]);
+// --- Yellow to Gold
+recipes.addShapeless(<IC2:itemPartCircuitAdv>,
+[<gregtech:gt.metaitem.01:32703>]);
+
 
 // --- Circuit Tooltips for Tiers ---
 


### PR DESCRIPTION
Added "downgrade" for circuits.
Reason being - carpenter recipes require "old technology" circuits and its really annoying to go backwords and craft old unconvinient circuits.

At first i decided to add oredict to carpenter recipe, but it would not let me.

So i though: "Well this game already has Lv-tier circuits conversion,
why wont add another Circuits same possibility?"

This means you could craft any Tier circuit at any recipe you sit on right now, and can
always convert them "backwards" (and only backwards) to use in recipes such as
circuits for multifarms and engenes from forestry inside carpenter machine.

![image](https://user-images.githubusercontent.com/32778092/40262288-ec31c96a-5b0e-11e8-835c-5a11c9ba9a6d.png)

![image](https://user-images.githubusercontent.com/32778092/40262300-fadb4c52-5b0e-11e8-9f19-5716b8b50ff8.png)

![image](https://user-images.githubusercontent.com/32778092/40262307-07a98d0e-5b0f-11e8-975f-daf50784a865.png)
