### PR TITLE
Fixing the Thick Neutron Collector (GTTweaker 1.7.0)

### DIFF
--- a/scripts/IC2.zs
+++ b/scripts/IC2.zs
@@ -1531,9 +1531,9 @@ Assembler.addRecipe(<IC2:itemRecipePart>, <gregtech:gt.metaitem.01:23355>, <greg
 Assembler.addRecipe(<IC2:itemPartCoalChunk>, <minecraft:coal_block>, <IC2:itemPartCoalBlock> * 8, 1200, 64);
 
 // --- Thick Neutron Reflector
-Assembler.addRecipe(<IC2:reactorReflectorThick:1>, <IC2:reactorReflector:1> * 4, <gregtech:gt.metaitem.01:18008> * 2, 600, 64);
+Assembler.addRecipe(<IC2:reactorReflectorThick:1>, [<IC2:reactorReflector:1>, <IC2:reactorReflector:1>, <IC2:reactorReflector:1>, <IC2:reactorReflector:1>, <gregtech:gt.metaitem.01:18008> * 2], null, 600, 64);
 // -
-Assembler.addRecipe(<IC2:reactorReflectorThick:1>, <IC2:reactorReflector:1> * 4, <gregtech:gt.metaitem.01:17370> * 2, 600, 64);
+Assembler.addRecipe(<IC2:reactorReflectorThick:1>, [<IC2:reactorReflector:1>, <IC2:reactorReflector:1>, <IC2:reactorReflector:1>, <IC2:reactorReflector:1>, <gregtech:gt.metaitem.01:17370> * 2], null, 600, 64);
 
 // --- Treetap
 Assembler.addRecipe(<IC2:itemTreetap>, <gregtech:gt.blockmachines:5102> * 3, <gregtech:gt.metaitem.01:27809>, 200, 8);


### PR DESCRIPTION
Quick fix for the Thick Neutron Collector for GTTweaker 1.7.0 

Since the Neutron Reflector item doesn't stack