### PR TITLE
BQ Localisation/Rework/Key holders

### DIFF
--- a/config/betterquesting/DefaultQuests.json
+++ b/config/betterquesting/DefaultQuests.json
@@ -6,8 +6,8 @@
   "questDatabase": [
     {
       "questID": 0,
-      "name": "Your first night",
-      "description": "Your first task will be to find food, and a shelter for the night. The nights will be cruel, as this pack has hardcore darkness. It probably would be a good idea to collect some food now...\n\nNote: You don\u0027t need to keep this book, you can use tilde to open quests without the book.",
+      "name": "tier0.quest1.name",
+      "description": "tier0.quest1.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -52,8 +52,8 @@
     },
     {
       "questID": 1,
-      "name": "Where is the flint?",
-      "description": "As you might have noticed, while collecting gravel, no flint dropped for you. Well, there is a... recipe for that. Look up flint in NEI and craft some!",
+      "name": "tier0.quest3.name",
+      "description": "tier0.quest3.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -110,8 +110,8 @@
     },
     {
       "questID": 2,
-      "name": "Sticks \u0027n Stones",
-      "description": "This book has a built-in reading light, lucky you! Most probably you will read this text while you are waiting for the night to be over. Once it is, go out and collect some gravel and wood. Keep in mind that you need food, so look for Pam\u0027s Harvestcraft gardens. (And save some of the vegetables for seeds!)",
+      "name": "tier0.quest2.name",
+      "description": "tier0.quest2.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -202,8 +202,8 @@
     },
     {
       "questID": 3,
-      "name": "Storage for days",
-      "description": "Now that you\u0027ve unlocked 3x3 crafting, it\u0027s about time to make some storage for your goods. Take some of your wood, and craft a chest. You will need 4 wood, 4 planks and 1 flint.",
+      "name": "tier0.quest6.name",
+      "description": "tier0.quest6.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -277,8 +277,8 @@
     },
     {
       "questID": 4,
-      "name": "Main Quests and Secondary Quests",
-      "description": "Now that you have made it this far notice the two new quests. See how these two quests look different? The quest with a crown is a main quest and is linked to other main quests by a thick line. You must complete the main quests to unlock the next tier. The other quest is an optional quest, and is not needed to unlock new tiers. However, optional quests often introduce you to useful items or processes.\n\nNot all main quests have a connecting line to guide you through your adventure because of book size. If there is not an obvious linked main quest at any point, try completing some of the other main quests available to you to progress.",
+      "name": "tier0.quest5.name",
+      "description": "tier0.quest5.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -325,8 +325,8 @@
     },
     {
       "questID": 5,
-      "name": "Tools",
-      "description": "Now that you\u0027ve got a shelter, crafting table, and a place to store your items, you should make some tools. (Unless you\u0027d like to continue punching trees with your bare hand...)",
+      "name": "tier0.quest8.name",
+      "description": "tier0.quest8.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -495,8 +495,8 @@
     },
     {
       "questID": 6,
-      "name": "You reap...",
-      "description": "You won\u0027t always get food rewards from this book, so it might be a good idea to take care of that problem. As you\u0027ve created a hoe already, go and find some water nearby and make a field. Let\u0027s trade some sticks for a carrot, so you can start your own farm.",
+      "name": "tier0.quest9.name",
+      "description": "tier0.quest9.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -555,8 +555,8 @@
     },
     {
       "questID": 7,
-      "name": "...what you sow",
-      "description": "If you, by chance, did read the previous quest and planted the carrot I gave you, then you\u0027re fine. Meanwhile, you should turn some more fruits and vegetables into seeds, and increase the size of your farm to get a steady supply of food.",
+      "name": "tier0.quest21.name",
+      "description": "tier0.quest21.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -632,8 +632,8 @@
     },
     {
       "questID": 8,
-      "name": "Get that stone",
-      "description": "Look at you, with your shiny flint pickaxe! Time to mine some cobblestone. Yay! (And maybe you can improve this dirt-hut too...)",
+      "name": "tier0.quest14.name",
+      "description": "tier0.quest14.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -703,8 +703,8 @@
     },
     {
       "questID": 9,
-      "name": "Fire, fire, Grandpa!",
-      "description": "Time to burn some stuff, isn\u0027t it? You can\u0027t make charcoal in it, but you sure will find some usage for it soon(tm).",
+      "name": "tier0.quest18.name",
+      "description": "tier0.quest18.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -772,8 +772,8 @@
     },
     {
       "questID": 10,
-      "name": "Rest in pieces",
-      "description": "It\u0027s GLOPPing time! Go kill some pigs to gather meat. (And yes, they will drop cooked porkchops. Now isn\u0027t that useful...)",
+      "name": "tier0.quest25.name",
+      "description": "tier0.quest25.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -962,8 +962,8 @@
     },
     {
       "questID": 11,
-      "name": "Sharpness: Over... 5...",
-      "description": "It\u0027s about time to craft something more useful: A sword!",
+      "name": "tier0.quest17.name",
+      "description": "tier0.quest17.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -1039,8 +1039,8 @@
     },
     {
       "questID": 12,
-      "name": "Fluffy and red",
-      "description": "Epic quest: Kill some sheep! (And try to get some wool, for a bed, obviously...)",
+      "name": "tier0.quest26.name",
+      "description": "tier0.quest26.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -1230,8 +1230,8 @@
     },
     {
       "questID": 13,
-      "name": "SO...TIRED...MUST...SLEEP...",
-      "description": "Sleepy time, and the end of Tier 0. Congratulations, you\u0027ve built your first hideout, and you should have a steady supply of food by now. See you again in tier 1!",
+      "name": "tier0.quest28.name",
+      "description": "tier0.quest28.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -1316,8 +1316,8 @@
     },
     {
       "questID": 14,
-      "name": "What is that...?",
-      "description": "You\u0027ve seen a lot of trees, but there are a few that look really special. You are sure that these trees are much more than just wood to build your home with or used to get charcoal.",
+      "name": "tier0.quest27.name",
+      "description": "tier0.quest27.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -1420,8 +1420,8 @@
     },
     {
       "questID": 15,
-      "name": "Ready, set, go!",
-      "description": "You probably should have a home by now. A steady supply of food is a fundamental requirement at all times. Take this journal to keep track of the things you\u0027ve eaten. You will have to travel far in this tier, better be prepared!",
+      "name": "tier0.5.quest15.name",
+      "description": "tier0.5.quest15.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -1480,8 +1480,8 @@
     },
     {
       "questID": 16,
-      "name": "Better Tank... Iron Tank",
-      "description": "Storing more than 16 buckets of fluid in one tank? Sure! Just make an iron tank or upgrade the Buildcraft tank.\nDiamond tanks carry up to 64 buckets and obsidian ones are blast proof.",
+      "name": "tier1.quest75.name",
+      "description": "tier1.quest75.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -1549,8 +1549,8 @@
     },
     {
       "questID": 17,
-      "name": "Sand: The Gathering",
-      "description": "In a strange vision you saw a big structure which would allow you to make charcoal. Finally some torches! According to your calculations, you will need a lot of sand for that.",
+      "name": "tier0.5.quest23.name",
+      "description": "tier0.5.quest23.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -1632,8 +1632,8 @@
     },
     {
       "questID": 18,
-      "name": "Basic processing",
-      "description": "Most things are unavailable at the moment, so let\u0027s begin with something simple. Take some of your cobblestone and smelt it into regular stone. Since this modpack is evil, you\u0027ll need to use wood for that. How much fun is that?!",
+      "name": "tier0.5.quest14.name",
+      "description": "tier0.5.quest14.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -1698,8 +1698,8 @@
     },
     {
       "questID": 19,
-      "name": "Maceration v0.1 Alpha",
-      "description": "This fancy little device works (almost...) like a macerator. Some people say it\u0027s even better, since it does not require power, yay! You only need to craft one for this quest, but you probably should make some more if you can...",
+      "name": "tier0.5.quest20.name",
+      "description": "tier0.5.quest20.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -1756,8 +1756,8 @@
     },
     {
       "questID": 20,
-      "name": "Gravel: The Gathering",
-      "description": "Your tools will eventually lose durability. You think it would be a good idea to collect more gravel in order to provide yourself with flint for more tools. Try searching near water.",
+      "name": "tier0.5.quest22.name",
+      "description": "tier0.5.quest22.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -1839,8 +1839,8 @@
     },
     {
       "questID": 21,
-      "name": "Clay: The Gathering",
-      "description": "While bored, you thought that it might be a good idea to take up pottery. You should go and find some clay, the riverbanks should have some.",
+      "name": "tier0.5.quest21.name",
+      "description": "tier0.5.quest21.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -1933,8 +1933,8 @@
     },
     {
       "questID": 22,
-      "name": "Finite water!?",
-      "description": "Finite water is a problem, that\u0027s for sure. Last night, you had an idea. If you can drink cacti, you should also be able make water out of 8 cacti and use that for most recipes that require water. How cool is that? So what about another trade? 10 wood for... 3 cacti so you can setup a farm. Deal?",
+      "name": "tier0.5.quest31.name",
+      "description": "tier0.5.quest31.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -1993,8 +1993,8 @@
     },
     {
       "questID": 23,
-      "name": "Something to carry liquids",
-      "description": "You tried to move water with your bare hands, which didn\u0027t work at all. Luckily, you remember how to make a bucket out of clay.",
+      "name": "tier0.5.quest30.name",
+      "description": "tier0.5.quest30.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -2084,8 +2084,8 @@
     },
     {
       "questID": 24,
-      "name": "Getting (char)coal",
-      "description": "It\u0027s time to get yourself some charcoal. For that, we\u0027re going to build a coke oven. Good that you just collected a lot of resources! (What a coincidence...)",
+      "name": "tier0.5.quest33.name",
+      "description": "tier0.5.quest33.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -2154,8 +2154,8 @@
     },
     {
       "questID": 25,
-      "name": "Another brick in the wall",
-      "description": "Your vision becomes more clear, you\u0027ll need bricks for your first multiblock structure. You think that 104 bricks should be enough. However, the bricks you\u0027ll need are somewhat special. Make sure to craft the correct ones!",
+      "name": "tier0.5.quest32.name",
+      "description": "tier0.5.quest32.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -2240,8 +2240,8 @@
     },
     {
       "questID": 26,
-      "name": "Forming press v0.1",
-      "description": "As you may have noticed, you cannot turn clay into bricks directly. Well, to be fair, it wasn\u0027t a good recipe anyway. You\u0027ll probably end up with something bread-shaped. So in order to make bricks, you need a form. Get yourself a knife and a blank pattern, and cut a brick sized piece out. It\u0027s as easy as that.",
+      "name": "tier0.5.quest42.name",
+      "description": "tier0.5.quest42.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -2327,8 +2327,8 @@
     },
     {
       "questID": 27,
-      "name": "Finally, some power",
-      "description": "Now that you have a coke oven, you can start producing charcoal. The more, the better. Don\u0027t worry about the creosote oil; I have another deal for you...",
+      "name": "tier0.5.quest60.name",
+      "description": "tier0.5.quest60.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -2399,8 +2399,8 @@
     },
     {
       "questID": 28,
-      "name": "Copper sky, Iron curtain",
-      "description": "With your newly acquired fuel source, you are now ready to process more advanced materials than stone or clay; Iron or copper, for example. Just in case you don\u0027t know, they spawn in rather large veins. Use the following quests to locate the most important veins.",
+      "name": "tier0.5.quest59.name",
+      "description": "tier0.5.quest59.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -2435,8 +2435,8 @@
     },
     {
       "questID": 29,
-      "name": "Another fuel source",
-      "description": "Lignite and regular coal are the fuel sources you\u0027ll definitely need. The latter can be turned into coal coke, which is a superior fuel source to smelt your first large batch of ore.",
+      "name": "tier0.5.quest52.name",
+      "description": "tier0.5.quest52.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -2506,8 +2506,8 @@
     },
     {
       "questID": 30,
-      "name": "Copper",
-      "description": "Copper ingots can be created by smelting copper, chalcopyrite, or malachite ore.",
+      "name": "tier0.5.quest47.name",
+      "description": "tier0.5.quest47.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -2589,8 +2589,8 @@
     },
     {
       "questID": 31,
-      "name": "Tin",
-      "description": "Tin ingots can be created by smelting tin and cassiterite ore.",
+      "name": "tier0.5.quest48.name",
+      "description": "tier0.5.quest48.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -2672,8 +2672,8 @@
     },
     {
       "questID": 32,
-      "name": "Book parts",
-      "description": "After you found a way to move water around, you had another brilliant idea: Paper! Paper is no longer made with sugarcane, you will now need wood pulp. You will need a lot of wood to craft wood pulp, so better grab your axe and go chop some trees.",
+      "name": "tier0.5.quest41.name",
+      "description": "tier0.5.quest41.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -2754,8 +2754,8 @@
     },
     {
       "questID": 33,
-      "name": "Tinker-time",
-      "description": "While using your flint tools is fun in terms of killing pigs and cows, they are not very good, and can\u0027t be repaired. You discovered how to craft tools that could be repaired and upgraded, but for that you definitely need a more advanced crafting technique.",
+      "name": "tier0.5.quest50.name",
+      "description": "tier0.5.quest50.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -2841,8 +2841,8 @@
     },
     {
       "questID": 34,
-      "name": "Aluminini...um...?",
-      "description": "However it is spelled, you will need it. You can find it in chunks of gravel on the surface. Try searching in rivers. (This quest is optional, but recommended.)",
+      "name": "tier0.5.quest46.name",
+      "description": "tier0.5.quest46.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -2912,8 +2912,8 @@
     },
     {
       "questID": 35,
-      "name": "Making bronze",
-      "description": "Now that you\u0027ve found copper and tin, you should make yourself some bronze. Use your macer... mortar to grind up some copper and tin ingots, and mix them together!",
+      "name": "tier0.5.quest7.name",
+      "description": "tier0.5.quest7.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -3003,8 +3003,8 @@
     },
     {
       "questID": 36,
-      "name": "Important tools",
-      "description": "In order to craft even basic machines, you\u0027ll need new tools. Most of them can be replaced by machines later. For now, you should become familiar with each of their recipes, as you will need a lot of these tools, starting today.\n\nYour new tools can also be used to make Railcraft water tanks, a very useful multiblock considering the finite water feature.",
+      "name": "tier0.5.quest10.name",
+      "description": "tier0.5.quest10.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -3037,6 +3037,12 @@
               "Count": 1,
               "OreDict": "craftingToolHardHammer",
               "Damage": 12
+            },
+            {
+              "id": "gregtech:gt.metatool.01",
+              "Count": 1,
+              "OreDict": "craftingToolSoftHammer",
+              "Damage": 14
             }
           ],
           "taskID": "bq_standard:crafting"
@@ -3119,8 +3125,8 @@
     },
     {
       "questID": 37,
-      "name": "Getting iron",
-      "description": "Iron can be found in multiple veins. Magnetite veins (y 30-180), chalcopyrite veins (y 5-60), and limonite veins (y 10-40) all contain iron ore.",
+      "name": "tier0.5.quest45.name",
+      "description": "tier0.5.quest45.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -3202,8 +3208,8 @@
     },
     {
       "questID": 38,
-      "name": "Making better tools",
-      "description": "With aluminium and copper, you can create a pretty durable material \"Aluminum Brass\", which can be used to cast better tools. These can be used to mine some more advanced ores.\n\nBut first you need a smeltery. See the Multiblock Goals chapter in this book, or find smeltery blocks in a village nearby.",
+      "name": "tier0.5.quest38.name",
+      "description": "tier0.5.quest38.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -3356,8 +3362,8 @@
     },
     {
       "questID": 39,
-      "name": "Better storage",
-      "description": "While standard chests are good for your basic items and goods, they are not ideal for storing a large amount of ore. You should build yourself some barrels in order to keep things organized.",
+      "name": "tier0.5.quest17.name",
+      "description": "tier0.5.quest17.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -3437,8 +3443,8 @@
     },
     {
       "questID": 40,
-      "name": "You shall proceed",
-      "description": "As you\u0027ve gathered and crafted all materials and tools you need for your basic steam machinery, you may now proceed to the next tier. Keep in mind that you\u0027ll need mountains of resources in order to craft even the simplest things, so you probably should stock up on all ores in this tier. But that\u0027s up to you.",
+      "name": "tier0.5.quest6.name",
+      "description": "tier0.5.quest6.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -3607,8 +3613,8 @@
     },
     {
       "questID": 41,
-      "name": "Don\u0027t burn your fingers!",
-      "description": "You have decided it\u0027s time to make some tasty pizza, but your fingers got burned badly. Reading an ancient cookbook you discovered a pair of magical items that would allow you to carry anything hot, even lava in a bucket.\n\nThe gloves have to be placed in the Baubles ring slots of Thaumcraft.",
+      "name": "tier0.5.quest29.name",
+      "description": "tier0.5.quest29.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -3712,8 +3718,8 @@
     },
     {
       "questID": 42,
-      "name": "Cow Tipper",
-      "description": "Before you had to kill some pigs and sheep to complete quests. Now it\u0027s time to kill some cows and hopefully get some leather. If you are lucky and get a cow trophy you may never need to kill another cow in the future.",
+      "name": "tier0.5.quest49.name",
+      "description": "tier0.5.quest49.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -3782,8 +3788,8 @@
     },
     {
       "questID": 43,
-      "name": "Cotton, cotton and more cotton",
-      "description": "You find out that cotton is very useful, it can be used to make string, wool, and some other useful items too. Make a small cotton plantation to get tons of it.",
+      "name": "tier0.5.quest40.name",
+      "description": "tier0.5.quest40.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -3859,8 +3865,8 @@
     },
     {
       "questID": 44,
-      "name": "Welcome to Tier 1",
-      "description": "Welcome, and well done so far! This tier is all about your first machines, getting more stuff from your ores and making bronze ingots in a more efficient manner.",
+      "name": "tier1.quest5.name",
+      "description": "tier1.quest5.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -3937,8 +3943,8 @@
     },
     {
       "questID": 45,
-      "name": "Multiblock tanks... Railcraft tanks",
-      "description": "576 buckets of fluid, that should be enough to store all the creosote you have accumulated thus far. If that isn\u0027t enough you can make this tank bigger. The smallest tanks are 3x4x3 while the biggest are 9x8x9.\n\nHint: Fluid will auto-output (without any pumps) if you place a valve on the bottom side of the tank. You can color the tank with Buildcraft paintbrushes and the GT spray can.\n\nUse only Buckets to move fluids because cells get destroyed.",
+      "name": "multiblock.goals.quest4.name",
+      "description": "multiblock.goals.quest4.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -4006,10 +4012,10 @@
               "Damage": 2
             },
             {
-              "id": "TConstruct:oreBerries",
-              "Count": 10,
+              "id": "TConstruct:ore.berries.one",
+              "Count": 5,
               "OreDict": "",
-              "Damage": 1
+              "Damage": 9
             },
             {
               "id": "enhancedlootbags:lootbag",
@@ -4038,8 +4044,8 @@
     },
     {
       "questID": 46,
-      "name": "More advanced alloys",
-      "description": "Your smeltery does a great job mixing metals into alloys, but it\u0027s not very efficient, and limited in its complexity. You need something new, so why not put your steam to some use? It might also come in handy when processing raw rubber.",
+      "name": "tier1.quest6.name",
+      "description": "tier1.quest6.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -4120,8 +4126,8 @@
     },
     {
       "questID": 47,
-      "name": "Upgrade: High speed alloys",
-      "description": "Like most machines, there is a more advanced version of the alloy smelter. Keep in mind that this machine uses a lot of steam, so you better get some more boilers first. (This quest is optional)",
+      "name": "tier1.quest2.name",
+      "description": "tier1.quest2.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -4195,8 +4201,8 @@
     },
     {
       "questID": 48,
-      "name": "A very important alloy",
-      "description": "The most important alloy (until you reach a higher tier) is undoubtedly red alloy. Fortunately, you have an alloy smelter, so grab some redstone and combine it with copper to get yourself a handful of that.",
+      "name": "tier1.quest7.name",
+      "description": "tier1.quest7.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -4278,8 +4284,8 @@
     },
     {
       "questID": 49,
-      "name": "The hell is that?",
-      "description": "In order to get more machines, you\u0027ll need pistons. But not those amateurish ones, you need special ones, and I shall guide you in the making of them.",
+      "name": "tier1.quest9.name",
+      "description": "tier1.quest9.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -4457,8 +4463,8 @@
     },
     {
       "questID": 50,
-      "name": "Macerator v1.0!",
-      "description": "Finally you are able to make a device that will replace your mortar. However, the \"no-durability\" feature of this device comes with a cost: You need 2 diamonds for the grinding heads.",
+      "name": "tier1.quest10.name",
+      "description": "tier1.quest10.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -4526,8 +4532,8 @@
     },
     {
       "questID": 51,
-      "name": "Extracting stuff",
-      "description": "As you\u0027ll need rubber later to make cables from wires, you should get yourself a steam extractor. You can also use this machine to get more dyes from flowers, or process different fruits into juice.",
+      "name": "tier1.quest41.name",
+      "description": "tier1.quest41.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -4595,8 +4601,8 @@
     },
     {
       "questID": 52,
-      "name": "A clear view",
-      "description": "Are you still living in your dirt hut/cobble hovel? How about letting in some sunlight? Grind up some sand and flint and craft some glass dust. Put it in your smeltery and pour it into a casting basin to make clear glass.\n\nHint: In order to use it for recipes, you have to chisel it.",
+      "name": "tier1.quest20.name",
+      "description": "tier1.quest20.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -4755,8 +4761,8 @@
     },
     {
       "questID": 53,
-      "name": "Hammer time v2",
-      "description": "Using 6 ingots to craft a hammer seems pretty wasteful, as this tool has durability. How nice would it be to have a machine that does the same but without having durability and using three ingots to make two plates? Guess what, there is one! And you should totally get one.",
+      "name": "tier1.quest36.name",
+      "description": "tier1.quest36.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -4824,8 +4830,8 @@
     },
     {
       "questID": 54,
-      "name": "Compressing stuff",
-      "description": "This rather simple device does a very important job: compression. It\u0027s main function is to press 9 ingots into a block, but it\u0027s also useful for a variety of recipes, for example making firm tofu.",
+      "name": "tier1.quest17.name",
+      "description": "tier1.quest17.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -4882,8 +4888,8 @@
     },
     {
       "questID": 55,
-      "name": "Upgrade: A better compressor",
-      "description": "An updated version of the steam compressor. Uses more steam, but is almost twice as fast. (This quest is optional)",
+      "name": "tier1.quest16.name",
+      "description": "tier1.quest16.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -4968,8 +4974,8 @@
     },
     {
       "questID": 56,
-      "name": "Upgrade: Forge hammer",
-      "description": "An updated version of the steam forge hammer. Uses more steam, but is almost twice as fast. (This quest is optional)",
+      "name": "tier1.quest27.name",
+      "description": "tier1.quest27.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -5054,8 +5060,8 @@
     },
     {
       "questID": 57,
-      "name": "Upgrade: Extractor",
-      "description": "An updated version of the steam extractor. Uses more steam, but is almost twice as fast. You probably want to craft this, as the extractor does also extract your nerves... (This quest is optional)",
+      "name": "tier1.quest42.name",
+      "description": "tier1.quest42.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -5140,8 +5146,8 @@
     },
     {
       "questID": 58,
-      "name": "Upgrade: Better macerator",
-      "description": "An updated version of the steam macerator. Uses more steam, but is almost twice as fast. (This quest is optional)",
+      "name": "tier1.quest11.name",
+      "description": "tier1.quest11.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -5226,8 +5232,8 @@
     },
     {
       "questID": 59,
-      "name": "Steam alternatives",
-      "description": "There is more than one way to get steam for your machines. This completely optional quest shows you some alternative methods for producing steam.",
+      "name": "tier1.quest13.name",
+      "description": "tier1.quest13.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -5279,8 +5285,8 @@
     },
     {
       "questID": 60,
-      "name": "Upgrade: Coal boiler",
-      "description": "This is basically just an upgrade to your current coal boiler, however it produces more than twice as much steam. Something you should consider building if you\u0027re planning to get some of the upgraded machines.",
+      "name": "tier1.quest23.name",
+      "description": "tier1.quest23.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -5348,8 +5354,8 @@
     },
     {
       "questID": 61,
-      "name": "Another use for Java, I mean Lava",
-      "description": "With a more durable steel casing, you can use lava to make steam.",
+      "name": "tier1.quest24.name",
+      "description": "tier1.quest24.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -5417,8 +5423,8 @@
     },
     {
       "questID": 62,
-      "name": "The power of the sun",
-      "description": "The sun has quite a bit of power, so why not use it to produce steam? \n\nHint: Just remember that the solar boiler calcifies and becomes less efficient over time.",
+      "name": "tier1.quest12.name",
+      "description": "tier1.quest12.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -5486,8 +5492,8 @@
     },
     {
       "questID": 63,
-      "name": "Using steam to cook things",
-      "description": "A rather slow process, but it\u0027s more efficient than using a regular furnace.",
+      "name": "tier1.quest4.name",
+      "description": "tier1.quest4.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -5555,8 +5561,8 @@
     },
     {
       "questID": 64,
-      "name": "Upgrade: Better furnace",
-      "description": "An updated version of the steam furnace. Uses more steam, but is almost twice as fast. (This quest is optional)",
+      "name": "tier1.quest3.name",
+      "description": "tier1.quest3.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -5641,8 +5647,8 @@
     },
     {
       "questID": 65,
-      "name": "Blastoff!",
-      "description": "It\u0027s about time to make some steel. Look in the Multiblock Goals quest tab and build a Bricked Blast Furnace. Return here when you made at least 8 steel ingots.",
+      "name": "tier1.quest47.name",
+      "description": "tier1.quest47.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -5736,8 +5742,8 @@
     },
     {
       "questID": 66,
-      "name": "Time for some logic",
-      "description": "Good news! You are now able to advance to the next tier! Bad news: You still have to craft a lot of things before you can begin. Fear not mortal, I shall guide you!",
+      "name": "tier1.quest70.name",
+      "description": "tier1.quest70.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -5862,8 +5868,8 @@
     },
     {
       "questID": 67,
-      "name": "Wired, weird?!",
-      "description": "One of the very basic materials which you should memorize how to craft are wires and cables. Basically you just cut a plate into a wire with your wire cutter. Not very efficient, but there will be a better way later.",
+      "name": "tier1.quest71.name",
+      "description": "tier1.quest71.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -5991,8 +5997,8 @@
     },
     {
       "questID": 68,
-      "name": "Your first logic circuit",
-      "description": "Steam machines are quite stupid, they just do one thing over and over again. As you advance into the electrical age, you\u0027ve decided that you want the machines to have more features, like automatic output in order to create some automation. For that, you need logic circuits.",
+      "name": "tier1.quest77.name",
+      "description": "tier1.quest77.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -6063,8 +6069,8 @@
     },
     {
       "questID": 69,
-      "name": "Wire-Wrap",
-      "description": "Placing wires without insulation seems to be a bad idea. Now that you have an extractor to extract raw rubber out of sticky resin and an alloy smelter to further process it using sulphur, you should work on getting some insulating rubber sheets.",
+      "name": "tier1.quest64.name",
+      "description": "tier1.quest64.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -6172,8 +6178,8 @@
     },
     {
       "questID": 70,
-      "name": "Steam-a-licious!",
-      "description": "You almost made it. One last crafting step is required in order to advance to Tier 2. Keep going!",
+      "name": "tier1.quest81.name",
+      "description": "tier1.quest81.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -6249,8 +6255,8 @@
     },
     {
       "questID": 71,
-      "name": "Basic crafting: Motors",
-      "description": "Motors are little devices that can turn electrical power into rotational energy. Very useful for all kind of machines, and not that difficult to craft. The pattern is always the same, only the materials change with tiers. For now you can use redstone to magnetize your iron rod. Later on you will build an Electromagnetic Polarizer.",
+      "name": "tier1.quest72.name",
+      "description": "tier1.quest72.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -6347,8 +6353,8 @@
     },
     {
       "questID": 72,
-      "name": "Basic crafting: Rotors",
-      "description": "Rotors are also crafted using an identical pattern with different materials. A bit annoying to craft at the moment, but you don\u0027t need a lot of them anyway.",
+      "name": "tier1.quest80.name",
+      "description": "tier1.quest80.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -6429,8 +6435,8 @@
     },
     {
       "questID": 73,
-      "name": "Basic crafting: Casings",
-      "description": "All machines need a hull to keep their private parts together. Good news is: They are crafted in the same way for every tier, only the materials change.",
+      "name": "tier1.quest60.name",
+      "description": "tier1.quest60.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -6511,8 +6517,8 @@
     },
     {
       "questID": 74,
-      "name": "You are not prepared!!!",
-      "description": "It\u0027s time for something really big: A smeltery! There\u0027s a lot to craft, so better gather some resources...",
+      "name": "multiblock.goals.quest2.name",
+      "description": "multiblock.goals.quest2.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -6735,10 +6741,10 @@
         {
           "rewards": [
             {
-              "id": "TConstruct:oreBerries",
-              "Count": 20,
+              "id": "TConstruct:ore.berries.two",
+              "Count": 10,
               "OreDict": "",
-              "Damage": 4
+              "Damage": 8
             },
             {
               "id": "enhancedlootbags:lootbag",
@@ -6767,8 +6773,8 @@
     },
     {
       "questID": 75,
-      "name": "The water dilemma",
-      "description": "Finite water is a problem. But fear not, there are solutions! I shall guide you to a steady supply of water.",
+      "name": "multiblock.goals.quest3.name",
+      "description": "multiblock.goals.quest3.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -6913,8 +6919,8 @@
     },
     {
       "questID": 76,
-      "name": "Time to get some steel",
-      "description": "You need steel? Uhh... fine. Let\u0027s get busy...\n\nHint: The bricked blast furnace can share walls with other ones, just like most GT multi blocks. How will this affect the air quality though...",
+      "name": "multiblock.goals.quest11.name",
+      "description": "multiblock.goals.quest11.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -7193,22 +7199,22 @@
         {
           "choices": [
             {
-              "id": "TConstruct:oreBerries",
-              "Count": 20,
+              "id": "TConstruct:ore.berries.two",
+              "Count": 10,
               "OreDict": "",
-              "Damage": 5
+              "Damage": 9
             },
             {
-              "id": "TConstruct:oreBerries",
-              "Count": 20,
+              "id": "TConstruct:ore.berries.one",
+              "Count": 5,
               "OreDict": "",
-              "Damage": 0
+              "Damage": 8
             },
             {
-              "id": "TConstruct:oreBerries",
-              "Count": 20,
+              "id": "TConstruct:ore.berries.one",
+              "Count": 5,
               "OreDict": "",
-              "Damage": 1
+              "Damage": 9
             }
           ],
           "rewardID": "bq_standard:choice"
@@ -7220,8 +7226,8 @@
     },
     {
       "questID": 77,
-      "name": "EBF-Time",
-      "description": "In order to get alumin(i)um ingots, you need an electric blast furnace. It\u0027s another very important step towards victory, so let\u0027s get started.\n\nGetting the heating coils might be a little tricky...\n\n(You need 2 LV hatches with 4A of 32V total, or 3 LV hatches with MOOOORE power if the multiblock is not fully repaired)\n\nA few recipes produce CO2/SO2 as fluid. You need to add an additional fluid hatch to the top layer of the EBF to collect it otherwise it gets auto voided. It depends on the muffler hatch how much fluid you can recover. Max muffler recovers \u003d 78%.\nMoron always says - Make Muffler Moint Mup.  Or point up, anyways.",
+      "name": "multiblock.goals.quest20.name",
+      "description": "multiblock.goals.quest20.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -7405,8 +7411,8 @@
     },
     {
       "questID": 78,
-      "name": "Upgrade #1: More heat",
-      "description": "Better materials need higher temperatures. You can just exchange the old coils with the new ones. You can even recycle the old coils, how fancy is that!",
+      "name": "multiblock.goals.quest38.name",
+      "description": "multiblock.goals.quest38.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -7477,8 +7483,8 @@
     },
     {
       "questID": 79,
-      "name": "Upgrade #2: Higher tier",
-      "description": "To reach the 3600k heat capacity of your EBF, so you can process high-tier materials like tungsten, you need nichrome heating coils.",
+      "name": "multiblock.goals.quest44.name",
+      "description": "multiblock.goals.quest44.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -7548,8 +7554,8 @@
     },
     {
       "questID": 80,
-      "name": "Compress all the things",
-      "description": "Martin\u0027s (DreamMasterXXL) favourite machine. Compress ALL the things! With explosives, of course. Boom today!\n\nNote: You might want to put this far from your living quarters, the pollution can get high really fast.",
+      "name": "multiblock.goals.quest29.name",
+      "description": "multiblock.goals.quest29.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -7646,8 +7652,8 @@
     },
     {
       "questID": 81,
-      "name": "At the end of...",
-      "description": "...the universe everything freezes eventually. But waiting for the heat death of the universe might take too long. Therefore we present you the vacuum freezer. It should be good enough to cool your hot stuff. You will need a minimum of 16 frost proof machine casings, the rest depends on your setup.",
+      "name": "multiblock.goals.quest39.name",
+      "description": "multiblock.goals.quest39.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -7738,8 +7744,8 @@
     },
     {
       "questID": 82,
-      "name": "An unexpected Bonus",
-      "description": "Because we\u0027re nice developers, we decided to add a little bonus if you happen to compress charcoal. Not only does it allow you to process more than 16 steel at a time (not in the bricked blast furnace), it also yields 10 times the burn time of a piece of charcoal. So one charcoal for free. This bonus only occurs on the first compression step. (But for fanciness, you should definitely get a quintuple one!)",
+      "name": "multiblock.goals.quest23.name",
+      "description": "multiblock.goals.quest23.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -7805,8 +7811,8 @@
     },
     {
       "questID": 83,
-      "name": "High speed charcoal",
-      "description": "Sure, those coke ovens are nice, but they aren\u0027t even remotely fast enough to keep up with a large steam boiler. Luckily, there is an upgrade available! The creosote oil will not be produced, but the process will speed up dramatically. Who needs that nasty yellowish flammable stuff anyway...",
+      "name": "multiblock.goals.quest37.name",
+      "description": "multiblock.goals.quest37.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -7954,8 +7960,8 @@
     },
     {
       "questID": 84,
-      "name": "Where I can put all the liquids?",
-      "description": "With your brand new alloy smelter you are able to combine two materials. What happens if you mix some obsidian dust and glass? Obsidian glass, great. Your first tank that you can make would be a Buildcraft tank. This tank can carry up 16 buckets of a single fluid. It\u0027s possible to upgrade those tanks so they can hold up to 64 buckets.",
+      "name": "tier1.quest68.name",
+      "description": "tier1.quest68.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -8084,8 +8090,8 @@
     },
     {
       "questID": 85,
-      "name": "Smelt all the things stack wise...",
-      "description": "...with this great invention! Uses power to smelt up to 2 stacks of items at once! Can\u0027t go any faster! \n\nHint: Parallel smelting depends on coils, consult your local doctor before use.",
+      "name": "multiblock.goals.quest24.name",
+      "description": "multiblock.goals.quest24.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -8170,8 +8176,8 @@
     },
     {
       "questID": 86,
-      "name": "Upgrade #3: Upgrade tier 4",
-      "description": "To process more advanced materials like enderium, enriched naquadah or niobium-titanium you need more than 3600K. Time to upgrade your EBF... again.",
+      "name": "multiblock.goals.quest45.name",
+      "description": "multiblock.goals.quest45.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -8241,8 +8247,8 @@
     },
     {
       "questID": 87,
-      "name": "Steel multiblock tanks",
-      "description": "Do you want to have tanks that can hold double the amount of the iron ones? Go ahead and make a steel tank. All sizes allowed from 3x4x3 to 9x8x9 blocks (X and Z must be the same, and odd). Just like the iron tanks, the Buildcraft paintbrush and GT spray can colorize tanks for identification. Get started on that tank farm full of lube!\n\nHint: Fluid will auto-output (without any pumps) if you place a valve on the bottom side of the tank - valves cannot be on an edge!\n\nOnly use buckets or large fluid cells because 1000L GT cells get destroyed.",
+      "name": "multiblock.goals.quest13.name",
+      "description": "multiblock.goals.quest13.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -8313,7 +8319,7 @@
               "id": "enhancedlootbags:lootbag",
               "Count": 1,
               "OreDict": "",
-              "Damage": 4
+              "Damage": 2
             }
           ],
           "rewardID": "bq_standard:choice"
@@ -8337,8 +8343,8 @@
     },
     {
       "questID": 88,
-      "name": "Welcome to Tier 2",
-      "description": "Why, hello there! Seems you\u0027ve made it into the electrical age. Don\u0027t be so quick to throw away your steam machines, you\u0027ll probably want to use them until you reach tier 3.",
+      "name": "tier2.quest18.name",
+      "description": "tier2.quest18.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -8410,7 +8416,7 @@
       "questID": 89,
       "name": "MV Steam Turbine",
       "description": "If you decide to use steam in MV tier then it\u0027s time to build a steam turbine.",
-      "isMain": false,
+      "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
       "simultaneous": false,
@@ -8443,7 +8449,7 @@
               "id": "gregtech:gt.blockmachines",
               "Count": 1,
               "OreDict": "",
-              "Damage": 1121
+              "Damage": 12
             }
           ],
           "taskID": "bq_standard:retrieval"
@@ -8464,8 +8470,8 @@
         {
           "rewards": [
             {
-              "id": "dreamcraft:item.CoinTechnician",
-              "Count": 25,
+              "id": "dreamcraft:item.CoinTechnicianI",
+              "Count": 5,
               "OreDict": "",
               "Damage": 0
             }
@@ -8479,8 +8485,8 @@
     },
     {
       "questID": 90,
-      "name": "Damn you, wire cutter!",
-      "description": "Enough is enough. No more wasting gazillions of ingots just for a couple of wires. Now that you have power, you should go for a wiremill!",
+      "name": "tier2.quest12.name",
+      "description": "tier2.quest12.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -8550,8 +8556,8 @@
     },
     {
       "questID": 91,
-      "name": "You\u0027re gonna hate this #1",
-      "description": "The first item you\u0027ll need a lot of. If you want to pull items out of chests or barrels you\u0027ll need one. \n\nHint: Goes pretty well with item pipes or GT machines, adjust with a screwdriver.",
+      "name": "tier2.quest21.name",
+      "description": "tier2.quest21.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -8625,8 +8631,8 @@
     },
     {
       "questID": 92,
-      "name": "You\u0027re gonna hate this #4",
-      "description": "The fourth item you\u0027ll need a lot of, and is also a pain to craft. Arguably the most painful item ever. \n\nHint: Works like a conveyor but can work with selected item slots, adjust with a screwdriver.",
+      "name": "tier2.quest43.name",
+      "description": "tier2.quest43.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -8700,8 +8706,8 @@
     },
     {
       "questID": 93,
-      "name": "You\u0027re gonna hate this #2",
-      "description": "The second item you\u0027ll need a lot of. When you want to get fluid out of tanks you\u0027ll need one. \n\nHint: Goes pretty well with fluid pipes or GT machines, adjust with a screwdriver. It can also be further upgraded into a fluid regulator that allows precise control of fluid transfer speed.",
+      "name": "tier2.quest28.name",
+      "description": "tier2.quest28.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -8775,8 +8781,8 @@
     },
     {
       "questID": 94,
-      "name": "Electric macerator",
-      "description": "It is highly recommended to get one of these, as the efficiency in terms of coal/steam used to macerate something is a lot better when using EU.",
+      "name": "tier2.quest24.name",
+      "description": "tier2.quest24.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -8846,8 +8852,8 @@
     },
     {
       "questID": 95,
-      "name": "You\u0027re gonna hate this #3",
-      "description": "A piston, but more .. \"electrical\". The third item you are going to craft a lot of in the future.",
+      "name": "tier2.quest42.name",
+      "description": "tier2.quest42.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -8921,8 +8927,8 @@
     },
     {
       "questID": 96,
-      "name": "Saving redstone",
-      "description": "Tired of using 4 redstone for one magnetic iron rod? Well, good news for you! The polarizer doesn\u0027t need redstone, just a little bit of power. You don\u0027t need to attach this machine to a permanent power source, it runs fine on battery power.",
+      "name": "tier2.quest5.name",
+      "description": "tier2.quest5.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -8992,8 +8998,8 @@
     },
     {
       "questID": 97,
-      "name": "Avengers, assemble!",
-      "description": "An absolute must have for fans of the movie. Oh, and to make all the things, of course.\n\nHint: You can use the battery slot and other extra slot in the GUI to store unused configuration circuits.",
+      "name": "tier2.quest44.name",
+      "description": "tier2.quest44.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -9063,8 +9069,8 @@
     },
     {
       "questID": 98,
-      "name": "No more filing",
-      "description": "Why waste a full ingot to make a rod by using a tool which loses durability and takes even MORE ingots? With this little device, all your rod-needs shall be fulfilled (for now).",
+      "name": "tier2.quest103.name",
+      "description": "tier2.quest103.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -9134,8 +9140,8 @@
     },
     {
       "questID": 99,
-      "name": "Bzzz... Whoom...",
-      "description": "Making some flawless crystals requires a precision laser engraver.\nAt MV level the precision laser engraver becomes more important.",
+      "name": "tier2.quest45.name",
+      "description": "tier2.quest45.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -9206,8 +9212,8 @@
     },
     {
       "questID": 100,
-      "name": "Press all the things",
-      "description": "With the basic forming press you can make different food items, glass arrows and some project red components. At MV/HV stage you can make rotors, various AE components and make copies of your molds and extruder shapes.",
+      "name": "tier2.quest31.name",
+      "description": "tier2.quest31.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -9277,8 +9283,8 @@
     },
     {
       "questID": 101,
-      "name": "Mjolnir!!! (electric forge hammer)",
-      "description": "Not really required, but it is a lot faster than the steam one and it can be automated. If you feel like ore washing is too slow, use this hammer. There are no recipes that require anything more than steam level to hammer something.",
+      "name": "tier2.quest22.name",
+      "description": "tier2.quest22.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -9348,8 +9354,8 @@
     },
     {
       "questID": 102,
-      "name": "Cutting things apart",
-      "description": "An absolutely mandatory machine to have. It will cut rods into bolts, plates into casings, logs into planks, and all of that will be done with the highest possible efficiency. Totally worth it! \n\nHint: Just add water. Later on lubricant will help it run faster.",
+      "name": "tier2.quest116.name",
+      "description": "tier2.quest116.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -9419,8 +9425,8 @@
     },
     {
       "questID": 103,
-      "name": "Get ready for Tier 3",
-      "description": "In order to proceed forward, you need to get aluminium. A lot of it. But for now, one is enough to unlock this quest. Probably the best source for aluminium is clay or hardened clay from canyons, however you need an MV machine for that. So you need to find an alternative until you have enough dusts for your initial setup.",
+      "name": "tier2.quest17.name",
+      "description": "tier2.quest17.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -9511,8 +9517,8 @@
     },
     {
       "questID": 104,
-      "name": "Your magic progression",
-      "description": "Now that you are able to produce aluminium, you may dig into magic. If you haven\u0027t unlocked basic thaumaturgy, try to find a silverwood and a greatwood sapling.",
+      "name": "tier2.quest16.name",
+      "description": "tier2.quest16.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -9555,8 +9561,8 @@
     },
     {
       "questID": 105,
-      "name": "The missing one",
-      "description": "It was once said... \u003cbasdxz\u003e But ffs, add a plate bender to the LV tier book ...and then it popped into existence.",
+      "name": "tier2.quest87.name",
+      "description": "tier2.quest87.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -9627,7 +9633,7 @@
     {
       "questID": 106,
       "name": "Your first automation",
-      "description": "Well, probably not the first, but definitely something big! You will need a cart assembler first.",
+      "description": "Well, probably not the first, but definitely something big! You will need a cart assembler in the first place.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -9701,7 +9707,7 @@
     {
       "questID": 107,
       "name": "Cart modules: Power Coal",
-      "description": "Your cart needs power, obviously. A cart can be powered via coal, solar, or lava. But for now you have to use a simple coal engine.",
+      "description": "Your cart needs power, obviously. A cart can be powered via solar or lava. But for now you have to use a simple coal engine.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -10150,8 +10156,8 @@
     },
     {
       "questID": 113,
-      "name": "Basic transport pipe",
-      "description": "These pipes are rather simple and won\u0027t do anything on their own. But in combination with transfer nodes, you\u0027ll soon find out how great they are. Also, given the correct upgrades, they even surpass most other transfer systems.",
+      "name": "tier2.quest14.name",
+      "description": "tier2.quest14.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -10221,8 +10227,8 @@
     },
     {
       "questID": 114,
-      "name": "Basic transport: Items",
-      "description": "In order to transfer items, you need so called \"nodes\". There are some for pushing items into a pipe system, and later you\u0027ll have access to nodes that are able to pull items from attached inventories.",
+      "name": "tier2.quest7.name",
+      "description": "tier2.quest7.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -10292,8 +10298,8 @@
     },
     {
       "questID": 115,
-      "name": "Basic transport: Fluids",
-      "description": "Just like item nodes, liquid nodes transfer... liquids. But probably the best thing: They can all utilize the same transfer pipe!",
+      "name": "tier2.quest6.name",
+      "description": "tier2.quest6.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -10363,8 +10369,8 @@
     },
     {
       "questID": 116,
-      "name": "Alloy smelter",
-      "description": "Upgrade your steam alloy smelter to an LV one.",
+      "name": "tier2.quest13.name",
+      "description": "tier2.quest13.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -10435,8 +10441,8 @@
     },
     {
       "questID": 117,
-      "name": "Gotta catch \u0027em all",
-      "description": "Sure, you can use wheat/potatoes/carrots to make animals follow you back to your base, but that can be tedious. A golden lasso is a proper solution for animal transportation.",
+      "name": "tier2.quest34.name",
+      "description": "tier2.quest34.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -10512,8 +10518,8 @@
     },
     {
       "questID": 118,
-      "name": "Basic monster protection",
-      "description": "Spawning monsters in or near your base can be annoying. Especially if you happen to get infernal creepers. Luckily, there is a good way to prevent them from spawning at all.",
+      "name": "tier2.quest33.name",
+      "description": "tier2.quest33.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -10583,8 +10589,8 @@
     },
     {
       "questID": 119,
-      "name": "A quite different storage",
-      "description": "Regular chests can fill up rather quickly if you happen to collect mob drops like swords and/or armor. By using a cabinet, you can store up to 270 items of the same type.",
+      "name": "tier1.quest67.name",
+      "description": "tier1.quest67.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -10660,8 +10666,8 @@
     },
     {
       "questID": 120,
-      "name": "Protect your base; Tier 1",
-      "description": "One needs proper protection for ones home. So why not get some turrets for safety? At the moment, 2 Turrets are available: \"Potato\" and \"disposable item\". I assume you can guess what they do and how they work...",
+      "name": "tier2.quest1.name",
+      "description": "tier2.quest1.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -10743,8 +10749,8 @@
     },
     {
       "questID": 121,
-      "name": "Passive defence",
-      "description": "A more \"passive\" approach to base defence are walls and fences. But seriously, where is the fun in that?",
+      "name": "tier2.quest15.name",
+      "description": "tier2.quest15.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -10826,8 +10832,8 @@
     },
     {
       "questID": 122,
-      "name": "Turret base",
-      "description": "Turrets must be placed on top of a turret base. Only the player who initially placed the base can access and configure the turret. So don\u0027t worry about people taking your ammunition.",
+      "name": "tier2.quest2.name",
+      "description": "tier2.quest2.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -10897,8 +10903,8 @@
     },
     {
       "questID": 123,
-      "name": "Who needs that dirt anyway",
-      "description": "You probably have a ton of items floating around in your base. So why not use them to kill your enemies?",
+      "name": "tier2.quest8.name",
+      "description": "tier2.quest8.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -10980,8 +10986,8 @@
     },
     {
       "questID": 124,
-      "name": "Don\u0027t play with your food!",
-      "description": "Use it to kill zombies instead. Does only a little damage, but hey, who cares?",
+      "name": "tier2.quest3.name",
+      "description": "tier2.quest3.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -11063,8 +11069,8 @@
     },
     {
       "questID": 125,
-      "name": "Upgrading intensifies",
-      "description": "Your turrets probably need more space to hold more ammunition, so why not get an upgrade for that?",
+      "name": "tier2.quest9.name",
+      "description": "tier2.quest9.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -11206,7 +11212,7 @@
     },
     {
       "questID": 127,
-      "name": "Project red beginning",
+      "name": "Project red begging",
       "description": "First of all there are 3 types of pipes: null logic, pressurized and routed.\n-Null Logic are the most basic kind. They can\u0027t have any logical thinking. Item transport pipes are of this category and they are used to craft and connect the routed and pressurized pipes. It would be a wise choice to craft some extras.\n \n-Routed pipes are the most advanced. They can communicate with each other in order to create pipe networks, and can be used for very complex tasks.\n \n-Pressurized pipes are too complicated to use and explain. You won\u0027t need them anyway since you can use the routed ones to do anything you want.\n\nHowever, in order to control the logic of the routed pipes you will need special circuit chips.",
       "isMain": false,
       "isSilent": false,
@@ -11301,7 +11307,7 @@
     },
     {
       "questID": 128,
-      "name": "IO, IO, it\u0027s off to EnderIO we go",
+      "name": "Ender not-so-IO",
       "description": "You\u0027ve probably used EnderIO before. It\u0027s quite useful for a lot of things. But a lot of stuff has changed here, so let\u0027s start from scratch.",
       "isMain": false,
       "isSilent": false,
@@ -11513,7 +11519,7 @@
     {
       "questID": 130,
       "name": "Portable tanks",
-      "description": "Until now, you had to use buildcraft tanks to carry liquids around. Which can be a pain to do. These little tanks are able to push and pull liquids by themselves, as they have a built-in pump which is powered by some magic energy source. How convenient.",
+      "description": "Until now, you where required to use buildcraft tanks to carry liquids around. Which can be a pain to do. These little tanks are able to push and pull liquids by themselves, as they have a built-in pump which is powered by some magic energy source. How convenient.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -11744,7 +11750,7 @@
     {
       "questID": 133,
       "name": "The power of enderman",
-      "description": "Elevators are nice, but they are limited to vertical teleportation, and their range is also somewhat limited. Travel anchors do not have that limitation. You can teleport from one anchor to any other within range. You can name them and even set them as private. They have a 2s cooldown.",
+      "description": "Elevators are nice, but they are limited to vertical teleportation, and their range is also somewhat limited. Travel anchors do not have that limitation. You can teleport from one anchor to any other within range. You can name them and even set them as private.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -12123,7 +12129,7 @@
           "requiredItems": [
             {
               "id": "EnderIO:itemMaterial",
-              "Count": 128,
+              "Count": 32,
               "OreDict": "",
               "Damage": 1
             }
@@ -12739,7 +12745,7 @@
     {
       "questID": 144,
       "name": "Automated crafting",
-      "description": "You know, yet another automated crafting solution...",
+      "description": "You know yet another automated crafting solution...",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -13255,7 +13261,7 @@
     {
       "questID": 151,
       "name": "Automated mob-farming",
-      "description": "Of course... zombies loves that... disgusting liquid. While using a small amount per hit, he will attack everything that is within his range. That also includes players, so be careful. Rumors are there might be a weapon that will never break when used in this \"machine\"...",
+      "description": "Of course... zombies loves that... disgusting liquid. While using a small amount per hit, he will attack everything that is within his range. That also includes players, so be careful. Rumors are, that there might be a weapon that will never break when used in this \"machine\"...",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -13415,7 +13421,7 @@
     {
       "questID": 153,
       "name": "Simple item transfer",
-      "description": "Translocators can only transfer items over a distance of 1 block. But they\u0027re quite cheap, and a good solution to build compact machine setups. They include a free simple item filter which can be enabled on the input or output side.  And they support multiple inputs and outputs! Glowstone will make it transfer faster - try investigating other upgrades.",
+      "description": "Translocators can only transfer items over a distance of 1 block. But they\u0027re quite cheap, and a good solution to build compact machine setups.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -13492,7 +13498,7 @@
     {
       "questID": 154,
       "name": "Simple fluid transfer",
-      "description": "Just like the item translocators, the fluid ones transfer... fluids. Same restrictions apply, 1 block distance. These can also be upgraded.",
+      "description": "Just like the item translocators, the fluid ones transfer... fluids. Same restrictions apply, 1 block distance.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -14052,7 +14058,7 @@
     {
       "questID": 161,
       "name": "Paying the highest price",
-      "description": "When regular magic just isn\u0027t enough, you need something... stronger. Which is paid with blood. Your blood, and maybe others.\n\nIn tier 1 you only need to place the blood altar. Plan for the configuration to grow in size",
+      "description": "When regular magic just isn\u0027t enough, you need something... stronger. Which is paid with blood. Your blood, and maybe others.\n\nIn tier 1 you only need to place the blood altar.",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -14125,7 +14131,7 @@
     {
       "questID": 162,
       "name": "Dimensional goal: Moon",
-      "description": "HV is the age where you should focus on reaching the Moon, as soon as possible. You will need titanium in large quantities. \n\nHint: more info will be found in the Space Race quest tab.",
+      "description": "HV is the age where you should focus on reaching the Moon, as soon as possible. Since you will need titanium in large quantities. \n\nHint: more info will be found in the Space Race quest tab.",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -14412,7 +14418,7 @@
     {
       "questID": 165,
       "name": "Soul eater",
-      "description": "Wouldn\u0027t it be great to actually make use of the intelligence or abilities a certain creature has? For example: enderman teleportation or brain capacity of a zombie for simple logic? (He doesn\u0027t use it anyway...) With this machine, you are able to bind a captured soul to an item, which can then be used in machines to improve their functionality.",
+      "description": "Wouldn\u0027t it be great to actually make use of the intelligence or abilities a certain creature has? For example: the ender-teleportation or brain capacity of a zombie for simple logic? (He doesn\u0027t use it anyway...) With this machine, you are able to bind a captured soul to an item, which can then be used in machines to improve their functionality.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -16272,7 +16278,7 @@
       "tasks": [
         {
           "partialMatch": true,
-          "ignoreNBT": true,
+          "ignoreNBT": false,
           "consume": false,
           "autoConsume": false,
           "requiredItems": [
@@ -16523,7 +16529,7 @@
     {
       "questID": 183,
       "name": "Getting your first circuits",
-      "description": "Making the circuits is quite different from what you\u0027re used to, so it\u0027s advised to check NEI for the new recipes. Get 8 of each circuit for now.",
+      "description": "Making the circuits is quite different from what you\u0027re used to, so it\u0027s advised to check NEI for the new recipes. Get 8 of each circuits for now.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -17185,7 +17191,7 @@
     {
       "questID": 190,
       "name": "Appropriate power",
-      "description": "Whether you used magic, steam, oil or biogas for power until now, you will run into problems as you advance to higher tiers. So you need to upgrade your power grid, at least for your blast furnaces. So let\u0027s start with something more powerful: A nuclear reactor!\n\nHint:\nThe multiplier is set to 10x in this pack. That means your nuclear reactor is 10 times more efficient.",
+      "description": "Whether you used magic, steam, oil or biogas for power until now, you will run into problems as you advance to higher tiers. So you need to upgrade your power grid, at least for your blast furnaces. So let\u0027s start with something more powerful: A nuclear reactor!\n\nHint:\nThe multiplier is set to 5 in this pack. That means your nuclear reactor is 10 times more efficient.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -17404,7 +17410,7 @@
     {
       "questID": 193,
       "name": "Tier 1 fuel: Thorium",
-      "description": "The weakest of all rods, but very easy to produce, very easy to keep cool and runs twice as long as uranium. A perfect \"fission and forget\" power source.",
+      "description": "The weakest of all rods, but very easy to produce, very easy to keep cool and runs twice as long as uranium. A perfect \"fire and forget\" power source.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -17625,7 +17631,7 @@
     {
       "questID": 196,
       "name": "Move the heat",
-      "description": "Reactors heat up, well the rods do, so you need to \"move the heat away\" to somewhere else. You should get one of each, and try to figure out what each individual heat exchanger does, in order to figure out a good setup.",
+      "description": "Reactors heat up, well the rods do, so you need to \"move the heat away\" to somewhere else. You should get one of each, and try to figure out what each individual heat exchangers does, in order to figure out a good setup.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -18029,7 +18035,7 @@
     {
       "questID": 200,
       "name": "Advanced mob-protection",
-      "description": "Like the chandelier, the magnum torch prevents monsters from spawning. However, its range is quite big, so a single one might be enough for your entire base.\nDon\u0027t forget, monsters can still follow you home!",
+      "description": "Like the chandelier, the magnum torch prevents monsters from spawning. However, its range is quite big, so a single one might be enough for your entire base.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -20721,7 +20727,7 @@
     {
       "questID": 233,
       "name": "Getting shards",
-      "description": "Now that you found all six primal types of infused stone, you need to break those up in order to get the shards. The easiest way to do that, is to throw these stones in your Forge Hammer. Later when you have a Sifter, you can sift purified ores for more shards. An autoclave can turn shard dust into a shard. Maybe there is a magical way to do the same thing?",
+      "description": "Now that you found all six primal types of infused stone, you need to break those up in order to get the shards. The easiest way to do that, is to throw these stones in your Forge Hammer.",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -22407,7 +22413,7 @@
     {
       "questID": 252,
       "name": "This is the end...",
-      "description": "...of your apprenticeship. You have mastered all 6 primal aspects, you mastered the weak and strong infusion of essentia and vis, and you\u0027ve already made your adept wand. But be warned, young one. The further you progress, the more darkness, and evil will tempt you to follow the forbidden ways of magic. I have seen things... weather changing, random teleportation, or even a Wither tearing its way into our universe right next to someone. Be careful, my friend...",
+      "description": "...of your apprenticeship. You have mastered all 6 primal aspects, you mastered the weak and strong infusion of essentia and vis, and you\u0027ve already made your adept wand. But be warned, young one. The further you progress, the more darkness, and evil will tempt you to follow the forbidden ways of magic. I have seen things... weather changing, random teleportation, or even a Wither spawning right next to someone. Be careful, my friend...",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -23990,7 +23996,7 @@
               "id": "gregtech:gt.metaitem.01",
               "Count": 4,
               "OreDict": "",
-              "Damage": 27083
+              "Damage": 27084
             }
           ],
           "taskID": "bq_standard:retrieval"
@@ -24033,13 +24039,13 @@
         }
       ],
       "preRequisites": [
-        274
+        261
       ]
     },
     {
       "questID": 274,
       "name": "Reactor material",
-      "description": "This stuff is interesting... Maybe I can use it as a wand conductor?",
+      "description": "This stuff is interesting... Maybe I can use it as wand conductor?",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -24251,12 +24257,6 @@
       "rewards": [
         {
           "rewards": [
-            {
-              "id": "Thaumcraft:ItemResource",
-              "Count": 4,
-              "OreDict": "",
-              "Damage": 2
-            },
             {
               "id": "Thaumcraft:ItemLootBag",
               "Count": 1,
@@ -26751,7 +26751,7 @@
     {
       "questID": 302,
       "name": "Useful plant life",
-      "description": "While regular plants are mostly used to make food, you are wondering if you could get some... \"more useful\" plant life going...",
+      "description": "While regular plants are mostly used to make food, you are wondering if you could get some... \"more special\" plant life going...",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -29241,7 +29241,7 @@
     },
     {
       "questID": 332,
-      "name": "Fire burn and...",
+      "name": "Brewers start",
       "description": "In order to get started with your basic witchery needs, you need a witches oven. It\u0027s used to get the most basic ingredients for your recipes: Fumes.",
       "isMain": false,
       "isSilent": false,
@@ -29401,7 +29401,7 @@
     },
     {
       "questID": 334,
-      "name": "...Cauldron bubble",
+      "name": "A cauldron?",
       "description": "The second thing you\u0027ll need is a cauldron. It is used to craft most of the basic items, like mutandis.",
       "isMain": false,
       "isSilent": false,
@@ -30309,7 +30309,7 @@
     {
       "questID": 345,
       "name": "Bloodlust: Seeping shoes",
-      "description": "Who needs an antidote? Now with free fertilizer!",
+      "description": "Who needs an antidote?",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -30583,7 +30583,7 @@
     },
     {
       "questID": 349,
-      "name": "Be a vampire; Dress like a fancy person",
+      "name": "Be a vampire; Like a sir",
       "description": "Sometimes it can be troublesome to get fancy clothing. However, if you prove yourself worthy, you get a set for free.",
       "isMain": false,
       "isSilent": false,
@@ -30945,7 +30945,7 @@
     {
       "questID": 353,
       "name": "A problem that matters",
-      "description": "I need to open a wormhole. But for that, I need an immense gravitational field. One like those created upon the death of a massive star. But I can\u0027t really \"kill\" a sun for this. I need to compress matter somehow... \nBut... How?",
+      "description": "I need to open a wormhole. But for that, I need an immense gravitational field. One like those created upon the death of a star. But I can\u0027t really \"kill\" a sun for this. I need to compress matter somehow... \nBut... How?",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -31413,7 +31413,7 @@
     {
       "questID": 360,
       "name": "A casing",
-      "description": "I need something for the outer shell. Again, a crystal-based material would be best, because I like it shiny. I tested all crystals we know and none of them meet the requirements. I heard you have access to outer space? Can you try to find a suitable material while you\u0027re out there?",
+      "description": "I need something for the outer shell. Again, a crystal-based material would be best, because I like it shiny. I tested all crystals we know and none of them meet the requirements. I heard you have access to the space? Can you try to find a suitable material while you\u0027re out there?",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -32073,7 +32073,7 @@
     {
       "questID": 371,
       "name": "We need to control it",
-      "description": "The problem is that the immense power of this dust is released all at once. We need something to control the vast amount of energies. I noticed that the dust starts to glow when it gets near an aura node. Maybe Thaumaturgy has the solution?",
+      "description": "The problem is, that the immense power of this dust is released all at once. We need something to control the vast amount of energies. I noticed that the dust starts to glow when it gets near an aura node. Maybe Thaumaturgy has the solution?",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -32274,7 +32274,7 @@
     {
       "questID": 375,
       "name": "An interesting material",
-      "description": "This metal has quite interesting properties. It seems that it has absorbed some of the energy that exists in the End. While ender pearls are quite fragile, this metal is a lot more durable. However, the absorbed energy is not enough to teleport things around. But you might find a solution for this.",
+      "description": "This metal has quite interesting properties. It seems, that it has absorbed some of the energy that exists in the End. While ender pearls are quite fragile, this metal is a lot more durable. However, the absorbed energy is not enough to teleport things around. But you might find a solution for this.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -32882,7 +32882,7 @@
     {
       "questID": 385,
       "name": "Draconic... Like... Dragon?",
-      "description": "Maybe you where looking for the right things in the wrong place. As this dust obviously comes from dragons, the best thing to do now is to find answers in the dimension of dragons: The End.",
+      "description": "Maybe you where looking for the right things in the wrong place. As this dust obviously origins from dragons, the best thing to do now is to find answers in the dimension of dragons: The End.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -33097,7 +33097,7 @@
     {
       "questID": 389,
       "name": "Draconic evolution",
-      "description": "I found a way to combine technology and magic into something fantastic. A shiny blue emblem that emits immense amount of energy. I\u0027ve decided to call it the draconic core. Make one for yourself!",
+      "description": "Don\u0027t you hate it to manually compress all those tiny piles? Let\u0027s automate this process! A combination of a typefilter, a chest buffer (super buffer in HV) and a packager frees you from that annoying task. The chestbuffer can hold up to 9 tiny piles and the super buffer can hold all your tiny dusts and you can set its mode with a screwdriver on the output side. Set it to 9 and let the packager handle the rest.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -35523,7 +35523,7 @@
     {
       "questID": 418,
       "name": "Spell foci",
-      "description": "There are nine basic elements and each has a focus, an item that represents them. You place this focus in your altar next to the spell table in order for your magic to flow through it and the paradigm.",
+      "description": "You have nine basic elements and each have a focus, an item that represents them. You place this focus in your altar next to the spell table in order for your magic to flow through it and the paradigm.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -37023,7 +37023,7 @@
     {
       "questID": 435,
       "name": "Bound tools: Shovel",
-      "description": "Ever wanted to clear out a large terrain with dirt, gravel and sand? Why not let demons do it? This shovel, imbued with the soul of a demon will unleash the power by your will. But be warned: The demon you\u0027re about to summon with this is thirsty, and it costs a lot of LP to make use of it, so make sure your LP pool is full!",
+      "description": "Ever wanted to clear out a large terrain with dirt, gravel and sand? Why not let demons do it? This shovel, imbued with the soul of a demon will unleash the power on your will. But be warned: The demon you\u0027re about to summon with this is thirsty, and it costs a lot of LP to make use of it, so make sure your LP pool is full!",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -37290,7 +37290,7 @@
     {
       "questID": 438,
       "name": "Complex spell system",
-      "description": "Unlike the simple spells with foci and paradigm, the complex spell system is incredibly...complex. There are way too much combinations to cover them here, so it\u0027s advised to look for the knowledge in other places. However, with the items from this quest, you are able to craft a simple mining spell.",
+      "description": "Unlike the simple spells with foci and paradigm, the complex spell system is incredible... complex. There are way too much combinations to cover them here, so it\u0027s advised to look for the knowledge in other places. However, with the items from this quest, you are able to craft a simple mining spell.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -37439,7 +37439,7 @@
     {
       "questID": 439,
       "name": "Steam \u003e Tier 2",
-      "description": "Three steam lootbags give a better one \u003d Tier 2.",
+      "description": "Three steam backpacks give a better one \u003d Tier 2.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -37498,8 +37498,8 @@
     },
     {
       "questID": 440,
-      "name": "Oak trees are not apple trees",
-      "description": "Oak trees which give apples?  Who the hell added this to minecraft? You found a way of combining an oak sapling and an apple to get an apple tree sapling. Try to plant one to get a permanent source of food.",
+      "name": "tier0.quest12.name",
+      "description": "tier0.quest12.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -37672,8 +37672,8 @@
     },
     {
       "questID": 442,
-      "name": "\"Backed\" potatoes",
-      "description": "Eating raw potatoes isn\u0027t that healthy, as you might have noticed. Some potatoes are green and poisonous already. After you get a furnace you can make delicious baked potatoes as another food alternative. Put a baked potato on a stick to make it even more delicious.",
+      "name": "tier0.quest19.name",
+      "description": "tier0.quest19.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -37805,7 +37805,7 @@
     {
       "questID": 443,
       "name": "Tier 2 \u003e Tier 3",
-      "description": "Three Tier 2 lootbags give a better one \u003d Tier 3.",
+      "description": "Three Tier 2 backpacks give a better one \u003d Tier 3.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -37864,8 +37864,8 @@
     },
     {
       "questID": 444,
-      "name": "Soft mallet adventure",
-      "description": "You now have some melon slices or pumpkins but what can you do with them? Well just eat them or... use a mallet to get some seeds... OK, let\u0027s craft one. Perhaps you can use this mallet for some other things too.",
+      "name": "tier0.quest24.name",
+      "description": "tier0.quest24.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -37975,7 +37975,7 @@
     {
       "questID": 445,
       "name": "Tier 3 \u003e Tier 4",
-      "description": "Three Tier 3 lootbags give a better one \u003d Tier 4",
+      "description": "Three Tier 3 backpacks give a better one \u003d Tier 4",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -38034,8 +38034,8 @@
     },
     {
       "questID": 446,
-      "name": "Shields UP",
-      "description": "With a sword in one hand, what can you do with the other? Right, you need a shield. Let\u0027s make one.",
+      "name": "tier0.quest23.name",
+      "description": "tier0.quest23.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -38137,7 +38137,7 @@
     {
       "questID": 447,
       "name": "Tier 4 \u003e Tier 5",
-      "description": "Three Tier 4 lootbags give a better one \u003d Tier 5.",
+      "description": "Three Tier 4 backpacks give a better one \u003d Tier 5.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -38196,8 +38196,8 @@
     },
     {
       "questID": 448,
-      "name": "Shield ppdate",
-      "description": "Your wooden shield is very weak. So you look for a better one. Looks like you need some leather, so go and find some cows.",
+      "name": "tier0.quest22.name",
+      "description": "tier0.quest22.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -38272,7 +38272,7 @@
     {
       "questID": 449,
       "name": "Tier 5 \u003e Tier 6",
-      "description": "Three Tier 5 lootbags give a better one \u003d Tier 6.",
+      "description": "Three Tier 5 backpacks give a better one \u003d Tier 6.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -38331,8 +38331,8 @@
     },
     {
       "questID": 450,
-      "name": "Your first long range weapon",
-      "description": "Since you can\u0027t make any vanilla bow before LV and Tinkers weapons are not in this Tier, you find a way to make a spear out of sticks, leather and a string. Get one because some infernal monsters are easier to kill with a long range weapon.",
+      "name": "tier0.quest16.name",
+      "description": "tier0.quest16.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -38631,7 +38631,7 @@
     },
     {
       "questID": 455,
-      "name": "Trigger Unknown Crystal",
+      "name": "Trigger Unknwon Crystal",
       "description": "Triggered by finding a \"Mysterious Crystal\".",
       "isMain": false,
       "isSilent": false,
@@ -39437,8 +39437,8 @@
     },
     {
       "questID": 468,
-      "name": "Trigger Thauminite Nugget",
-      "description": "Triggers if you get Thauminite Nuggets.",
+      "name": "Trigger Thuaminite Nugget",
+      "description": "Triggers if you get Thaumite Nuggets.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -39485,8 +39485,8 @@
     },
     {
       "questID": 469,
-      "name": "Collecting some berries",
-      "description": "Are you now waiting for the carrots to grow? Go and find some berry bushes and berries. The berries are a good source of food and you can put these bushes around your house to make a wall. It should provide a good protection against all those monsters that want to come into your house and kill you.",
+      "name": "tier0.quest10.name",
+      "description": "tier0.quest10.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -39589,8 +39589,8 @@
     },
     {
       "questID": 470,
-      "name": "Berry medley",
-      "description": "Hmmm... what can you do with all those berries? Just eating? You will see that they have a very low saturation Level. Let\u0027s plant the new berry bushes and mix the berries to make some better food.",
+      "name": "tier0.quest11.name",
+      "description": "tier0.quest11.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -39786,8 +39786,8 @@
     },
     {
       "questID": 471,
-      "name": "Food variants",
-      "description": "Maybe you noticed already that eating the same food too often is very boring and not healthy any more. Some food like tea leaf can be taken to the furnace and processed further. So take a break and drink a cup of tea. Maybe munch some tasty raisins as they are very nice.",
+      "name": "tier0.quest20.name",
+      "description": "tier0.quest20.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -39896,8 +39896,8 @@
     },
     {
       "questID": 472,
-      "name": "Your first tool",
-      "description": "When your tinkers tables are ready you can craft your first tool. If you did not find a village yet you can only craft flint tools. Let\u0027s start with a pickaxe, an axe and a shovel. At this point swords are unobtainable since they need metals like iron or bronze which you will get at a later stage. In the meantime use your gregtech swords. Your new tools are weak at first but the more you use them the better they will get. They will level up to level 99 if you play long enough. Tool parts can be replaced for a bit of level XP, however the tool must be fully repaired first.",
+      "name": "tier0.5.quest54.name",
+      "description": "tier0.5.quest54.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -40229,8 +40229,8 @@
     },
     {
       "questID": 473,
-      "name": "Making a better sword",
-      "description": "Now it\u0027s time to make your first tinkers sword. First you have to make blade, hand guard, and tool rod cast forms. Melt some bronze in the smeltery and cast your tool parts. Tadaa... there is your first tinkers sword.",
+      "name": "tier0.5.quest28.name",
+      "description": "tier0.5.quest28.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -40386,8 +40386,8 @@
     },
     {
       "questID": 474,
-      "name": "Upgrade 2.0",
-      "description": "Find iron, copper and tin ore. Very funny... How can you mine these with just a flint pickaxe? \nI have an idea; bring me all the stone you mined with your flint pickaxe and I will give you a better tool head in exchange.",
+      "name": "tier0.5.quest53.name",
+      "description": "tier0.5.quest53.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -40501,8 +40501,8 @@
     },
     {
       "questID": 475,
-      "name": "Upgrade #4: Upgrade tier 5",
-      "description": "To process more advanced materials like HSS-E, HSS-S, naquadah or draconium you need more than 4500K. Time to upgrade your EBF to 5400k.",
+      "name": "multiblock.goals.quest46.name",
+      "description": "multiblock.goals.quest46.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -40572,8 +40572,8 @@
     },
     {
       "questID": 476,
-      "name": "Upgrade #3: Upgrade tier 6",
-      "description": "To process more advanced materials like naquadah-alloy you need more than 5400K. Upgrade your EBF to 7200k to increase the heat.",
+      "name": "multiblock.goals.quest48.name",
+      "description": "multiblock.goals.quest48.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -40651,8 +40651,8 @@
     },
     {
       "questID": 477,
-      "name": "Upgrade #6: Upgrade tier 7",
-      "description": "To process the most advanced materials like neutronium, fluxed-electrum or awakened draconium you need more than 7200K. Upgrade your EBF to 9001k. (OVER 9000!!!)",
+      "name": "multiblock.goals.quest47.name",
+      "description": "multiblock.goals.quest47.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -40730,8 +40730,8 @@
     },
     {
       "questID": 478,
-      "name": "Flint and steel",
-      "description": "After you make steel you are able to craft flint and steel. I guess you want to travel to the Nether as soon as possible but be aware; the Nether is a very dangerous place.",
+      "name": "tier1.quest48.name",
+      "description": "tier1.quest48.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -40868,8 +40868,8 @@
     },
     {
       "questID": 479,
-      "name": "THE NETHER",
-      "description": "Now more dangerous with extra hardcore infernal mobs. Have fun and take care.",
+      "name": "tier1.quest49.name",
+      "description": "tier1.quest49.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -41039,8 +41039,8 @@
     },
     {
       "questID": 480,
-      "name": "Malachite",
-      "description": "Another copper source  is \"malachite\" which can be found between Y level 10 and 40. This vein contains more iron ore variants like \"brown limonite\", \"yellow limonite\" and \"banded iron ore\".\n\nHint:\nTo see where a special ore can be found click the raw ore in nei and it will show you more details. Works with small ores too.",
+      "name": "tier0.5.quest57.name",
+      "description": "tier0.5.quest57.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -41140,8 +41140,8 @@
     },
     {
       "questID": 481,
-      "name": "Creosote oil",
-      "description": "I guess you already processed a bit of wood into charcoal and wonder what you can do with all this creosote oil?\nWell you can burn it in the normal furnace to cook your food or you can make more torches with it. Later in the LV age you probably should run combustion generators with it.",
+      "name": "tier0.5.quest43.name",
+      "description": "tier0.5.quest43.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -41176,8 +41176,8 @@
     },
     {
       "questID": 482,
-      "name": "Animal farms",
-      "description": "Trying to get some leather or wool? You probably need to spend a lot of time hunting animals and traveling around, or you could simply make a farm to get a decent amount of leather, wool and meat. Make sure you don\u0027t put too many animals in the pen or they will overcrowd and kill each other.",
+      "name": "tier0.5.quest8.name",
+      "description": "tier0.5.quest8.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -41357,8 +41357,8 @@
     },
     {
       "questID": 483,
-      "name": "Gardener",
-      "description": "If you are wondering: Why do I never get seeds when destroying grass? You are right. Try to work with your new mattock on the grass blocks that do not have water anywhere nearby to find some seeds.",
+      "name": "tier0.5.quest16.name",
+      "description": "tier0.5.quest16.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -41531,8 +41531,8 @@
     },
     {
       "questID": 484,
-      "name": "Can you hear the carrots grow?",
-      "description": "Tired of waiting since your carrots grow sooooo slow?\nWell I got an idea, bone meal will help you grow food in seconds. Ok, chop down some trees and I will trade you some bone meal.",
+      "name": "tier0.quest15.name",
+      "description": "tier0.quest15.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -41643,8 +41643,8 @@
     },
     {
       "questID": 485,
-      "name": "You need MOOOOOOORE wood",
-      "description": "It\u0027s time to feed your new coke oven with some wood to get more charcoal. You are looking for the most efficient way to plant trees. Try to find some spruce saplings and some jungle saplings. Both can be planted in a 2x2 grid to get bigger trees.",
+      "name": "tier0.5.quest34.name",
+      "description": "tier0.5.quest34.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -41744,8 +41744,8 @@
     },
     {
       "questID": 486,
-      "name": "Tanned leather",
-      "description": "You have found a way to make leather more durable and more resistant by further processing it. Make some bound leather from four pieces of leather, some strings and a woven cotton. Now you only have to hang it on a drying rack and wait about 10 minutes to get some tanned leather. Stockpile some for later.",
+      "name": "tier0.5.quest11.name",
+      "description": "tier0.5.quest11.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -41884,8 +41884,8 @@
     },
     {
       "questID": 487,
-      "name": "Need more space?",
-      "description": "As you might know: tanned leather is more resistant and good enough for a backpack. Let\u0027s get a digger\u0027s backpack and a miner\u0027s backpack. Each pack holds different items. So use both for your first true back-packed mining experience.",
+      "name": "tier0.5.quest12.name",
+      "description": "tier0.5.quest12.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -42044,8 +42044,8 @@
     },
     {
       "questID": 488,
-      "name": "You need them all!",
-      "description": "There are many more backpacks: Hunter, builder, forester...",
+      "name": "tier0.5.quest13.name",
+      "description": "tier0.5.quest13.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -42180,8 +42180,8 @@
     },
     {
       "questID": 489,
-      "name": "Better lunch bag",
-      "description": "Your lunch bag is now so abused and rather old so it\u0027s time to get something better. Let\u0027s craft a lunch box which can hold way more food.",
+      "name": "tier0.5.quest24.name",
+      "description": "tier0.5.quest24.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -42282,7 +42282,7 @@
     {
       "questID": 490,
       "name": "Horseback riding",
-      "description": "Are you ready for a small trip? With your new lunch box, saddle, lead and of course a horse we can start a small journey. Be sure to make paths over water, horses don\u0027t like going over deep water.",
+      "description": "Are you ready for a small trip? With your new lunch box, saddle, lead and of course a horse we can start a small journey.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -42374,8 +42374,8 @@
     },
     {
       "questID": 491,
-      "name": "Sleeping outside",
-      "description": "Carrying the bed with you all the time the looks very funny. Why don\u0027t you craft a sleeping bag to stay outside without placing a bed and changing your spawn point. This way if you die, you\u0027ll be right at home! Be warned: If you play on a server then you\u0027d better sleep below Y level 128, as nights are very cold in the mountains...",
+      "name": "tier0.5.quest18.name",
+      "description": "tier0.5.quest18.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -42488,8 +42488,8 @@
     },
     {
       "questID": 492,
-      "name": "Sheep hairdresser",
-      "description": "Killing sheep to get the wool is so ineffective. Making some shears would make sense if you need more wool.",
+      "name": "tier0.5.quest9.name",
+      "description": "tier0.5.quest9.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -42666,8 +42666,8 @@
     },
     {
       "questID": 493,
-      "name": "Wire Cutter v.0.2alpha",
-      "description": "Small gears require a wire cutter to be made, so let\u0027s craft one.",
+      "name": "tier1.quest8.name",
+      "description": "tier1.quest8.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -42766,8 +42766,8 @@
     },
     {
       "questID": 494,
-      "name": "Redstone",
-      "description": "If you didnt\u0027t find any Redstone veins yet, it is quite important to look for one now. Try your luck at Y level 5-40.",
+      "name": "tier1.quest14.name",
+      "description": "tier1.quest14.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -42835,10 +42835,10 @@
               "Damage": 32221
             },
             {
-              "id": "TConstruct:oreBerries",
-              "Count": 10,
+              "id": "TConstruct:ore.berries.two",
+              "Count": 5,
               "OreDict": "",
-              "Damage": 5
+              "Damage": 9
             }
           ],
           "rewardID": "bq_standard:choice"
@@ -42861,8 +42861,8 @@
     },
     {
       "questID": 495,
-      "name": "Oh, shiny! (Not platinum!)",
-      "description": "To make your first macerator you need two diamonds, and to enter the Twilight Forest you need one. Finding a diamond vein would help you a lot. Go and look for one at Y level 5-20.",
+      "name": "tier1.quest19.name",
+      "description": "tier1.quest19.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -42979,8 +42979,8 @@
     },
     {
       "questID": 496,
-      "name": "How to make rubber",
-      "description": "Making rubber is now more complicated - you need raw rubber and sulfur. Finding a sulfur vein in the Nether seems like a good idea, doesn\u0027t it? Found on Y level 5-20. Later on you can get sulfur from chemicals like hydrogren sulfide or pyrite.",
+      "name": "tier1.quest50.name",
+      "description": "tier1.quest50.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -43080,8 +43080,8 @@
     },
     {
       "questID": 497,
-      "name": "More charcoal",
-      "description": "You have found an alternative way of making charcoal with a \"charcoal pile igniter\". \nGo and start getting massive amounts of charcoal.",
+      "name": "tier1.quest55.name",
+      "description": "tier1.quest55.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -43212,8 +43212,8 @@
     },
     {
       "questID": 498,
-      "name": "XP usage?!",
-      "description": "Exploring some dungeons or fighting mobs probably gave you a lot of XP. Better use it to get iron, copper, tin or other useful dusts before you die during the next fight.\nPlace your tank on the ground and a drain on top. Now you can fill it with XP.",
+      "name": "tier0.5.quest27.name",
+      "description": "tier0.5.quest27.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -43638,7 +43638,7 @@
     {
       "questID": 503,
       "name": "Analyze them all",
-      "description": "Every bee has multiple properties that define what the bee does, how it behaves in rain or at night, and a couple of other aspects. It is mandatory to keep track of those properties. This kit isn\u0027t very good, but waste not, want not.",
+      "description": "Every bee has multiple properties that define what the bee does, how it behaves in rain or at night, and a couple of other aspects. It is mandatory to keep track of those properties.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -43869,7 +43869,7 @@
     {
       "questID": 506,
       "name": "To play god",
-      "description": "In order to continue with bees, to mutate and breed them as you like, you need mutagen. This greenish, smelly liquid needs to be refined from bacterial sludge that seems to be available only on Mars. You will be able to continue, once you\u0027ve arrived there.\n\nIn the meantime you can start working with the Genetics mod, since we all know Gendustry is too easy... Check out the recipes and you will understand why you should look into the Genetics mod.",
+      "description": "In order to continue with bees, to mutate and breed them as you like, you need mutagen. This greenish, smelly liquid needs to be refined from bacterial sludge, that seems to be available only on Mars. You will be able to continue, once you\u0027ve arrived there.\n\nIn the meantime you can start working with the Genetics mod, since we all know Gendustry is too easy... Check out the recipes and you will understand why you should look into the Genetics mod.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -44323,7 +44323,7 @@
     {
       "questID": 510,
       "name": "Diamondware",
-      "description": "Also known as labware. Be prepared. In order to do serious bee-work, you need stacks of diamonds. I\u0027m not joking, stacks! Better start working on that diamond bee!",
+      "description": "Also known as labware. Be prepared. In order to do serious bee-work, you need stacks of diamonds. I\u0027m not joking, stacks!",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -45097,7 +45097,7 @@
     {
       "questID": 521,
       "name": "Only the Best: Fertility 4",
-      "description": "On your way to awesome bees, you have to collect only the best traits available. Bees bees everywhere!",
+      "description": "On your way to awesome bees, you have to collect only the best traits available.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -45340,7 +45340,7 @@
     {
       "questID": 524,
       "name": "Only the Best: Speed Fastest",
-      "description": "On your way to awesome bees, you have to collect only the best traits available. Buzz buzz buzz, working hard and really buzzing!",
+      "description": "On your way to awesome bees, you have to collect only the best traits available.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -45502,7 +45502,7 @@
     {
       "questID": 526,
       "name": "Only the Best: Rain",
-      "description": "On your way to awesome bees, you have to collect only the best traits available. Beekeeping in the rain!  Make sure to keep your GT machines covered!",
+      "description": "On your way to awesome bees, you have to collect only the best traits available.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -45583,7 +45583,7 @@
     {
       "questID": 527,
       "name": "Only the Best: Day and Night",
-      "description": "On your way to awesome bees, you have to collect only the best traits available. Bee working day and night, all night and all day long!",
+      "description": "On your way to awesome bees, you have to collect only the best traits available.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -45664,7 +45664,7 @@
     {
       "questID": 528,
       "name": "Only the Best: Cave",
-      "description": "On your way to awesome bees, you have to collect only the best traits available. Bees with Cave can work in housing that is covered - by more housing!",
+      "description": "On your way to awesome bees, you have to collect only the best traits available.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -45744,8 +45744,8 @@
     },
     {
       "questID": 529,
-      "name": "You\u0027re gonna hate this #5",
-      "description": "The fifth item you\u0027ll need a lot of. For the microwave, the scanner, the precision laser engraver, etc.",
+      "name": "tier2.quest53.name",
+      "description": "tier2.quest53.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -45819,8 +45819,8 @@
     },
     {
       "questID": 530,
-      "name": "You\u0027re gonna hate this #6",
-      "description": "The sixth item you\u0027ll need a lot of. For the scanner and the seismic prospector.",
+      "name": "tier2.quest61.name",
+      "description": "tier2.quest61.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -45894,8 +45894,8 @@
     },
     {
       "questID": 531,
-      "name": "Scanning bees, crops and moooooore!",
-      "description": "Automate your bee, sapling, or crop scanning. Later on, this machine gets very useful for scanning high tier machine parts for the assembly line research data or to fill data orbs with data for the UU matter production. Data sticks with raw prospecting data need a scanner too.",
+      "name": "tier2.quest60.name",
+      "description": "tier2.quest60.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -45968,8 +45968,8 @@
     },
     {
       "questID": 532,
-      "name": "Diesel, oil or maybe creosote?",
-      "description": "You probably collected a ton of creosote and maybe even have built your first \u0027electric\u0027 blast furnace. creosote will be a good fuel for the moment. So try to build a few of the combustion generators and use them besides steam as a secondary power source. Small generators will only use fuel if there is EU demand.",
+      "name": "tier2.quest51.name",
+      "description": "tier2.quest51.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -46051,8 +46051,8 @@
     },
     {
       "questID": 533,
-      "name": "Hydrogen, methane or some farts... (Natural gas) ",
-      "description": "Some centrifugal processes leave gases behind like hydrogen or methane. Centrifuge some brown and yellow limonite to get hydrogen or dump your unused food in a centrifuge to get methane gas. Wood will even give 60 mb per log. Maybe it\u0027s time to build a forestry tree farm.",
+      "name": "tier2.quest49.name",
+      "description": "tier2.quest49.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -46134,8 +46134,8 @@
     },
     {
       "questID": 534,
-      "name": "Pollution what....?",
-      "description": "If you are running your bricked blast furnace for a long time you will sometimes get headaches, nausea and other weird effects. Yes this is pollution... from making so much steel. If you can collect some rubber sheets, I will trade you a complete hazmat suit.",
+      "name": "tier1.quest63.name",
+      "description": "tier1.quest63.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -46213,8 +46213,8 @@
     },
     {
       "questID": 535,
-      "name": "Redstone, early game processing",
-      "description": "Are you wondering how to process redstone without a macerator? Well you can mine it with a gregtech hammer and get the crushed ore. Then use with the hammer in the crafting table to get some impure redstone dust. After this, fill a cauldron with water and drop the dust in it - CTRL-Q drops a whole stack. You will get pure redstone dust for your red alloy ingots.",
+      "name": "tier1.quest15.name",
+      "description": "tier1.quest15.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -46345,8 +46345,8 @@
     },
     {
       "questID": 536,
-      "name": "Low tier wires",
-      "description": "Low tier wires like red alloy and tin can be made in a crafting table. Copper wire requires an alloy smelter. So let\u0027s make a mold for the rubber plates.",
+      "name": "tier1.quest65.name",
+      "description": "tier1.quest65.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -46477,7 +46477,7 @@
     {
       "questID": 537,
       "name": "Time to kill (Witch)",
-      "description": "Witches bring stitches because they are always infernal and very dangerous. Be careful since they throw potions at you.",
+      "description": "Witches are always infernal and very dangerous. Be careful since they throw potions at you.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -46693,8 +46693,8 @@
     },
     {
       "questID": 538,
-      "name": "Basic ore washer",
-      "description": "Macerating ores usually doubles the output. If you want MOOOOOOORE, craft an ore washer and wash out some rare materials.",
+      "name": "tier2.quest40.name",
+      "description": "tier2.quest40.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -46764,8 +46764,8 @@
     },
     {
       "questID": 539,
-      "name": "Round and round and round...",
-      "description": "After purification of your ore dust, you can centrifuge it to get even more byproducts out of the dust.",
+      "name": "tier2.quest79.name",
+      "description": "tier2.quest79.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -46835,8 +46835,8 @@
     },
     {
       "questID": 540,
-      "name": "A truly sharp saw blade",
-      "description": "Combining cobalt brass and diamond dust makes a really sharp saw blade for your cutting machine.",
+      "name": "tier2.quest115.name",
+      "description": "tier2.quest115.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -46936,8 +46936,8 @@
     },
     {
       "questID": 541,
-      "name": "A new alloy - Cobalt Brass",
-      "description": "If you want to cut diamond blocks into plates, it\u0027s time to get a new alloy \u0027cobalt brass\u0027.\nFirst you need to make brass out of zinc (only found in small ores or as a centrifuge byproduct from tin or tetrahedrite) and copper. Mix it with aluminium and cobalt dust (can be centrifuged from various materials) to get the cobalt brass dust.\n\nNow that you have come this far, we think that you are able to look up the ores that you need by yourself with the help of NEI.",
+      "name": "tier2.quest20.name",
+      "description": "tier2.quest20.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -47082,8 +47082,8 @@
     },
     {
       "questID": 542,
-      "name": "Water and electricity, sounds fun and safe right?",
-      "description": "Using the power of water and electricity you can get even more out of your dusts.",
+      "name": "tier2.quest80.name",
+      "description": "tier2.quest80.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -47153,8 +47153,8 @@
     },
     {
       "questID": 543,
-      "name": "C9H8O4...NaCl...H2O...",
-      "description": "Want to make some cetane-boosted diesel, plastic or some chemical dyes? Then it\u0027s time to craft a chemical reactor.\n\nHint: You can use the battery slot and other extra slot in the GUI to store unused configuration circuits.",
+      "name": "tier2.quest102.name",
+      "description": "tier2.quest102.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -47224,8 +47224,8 @@
     },
     {
       "questID": 544,
-      "name": "Compact? Or is it?",
-      "description": "It is a compressor but that doesn\u0027t mean it is compact... \n\nHint:\nIt is highly recommended to get one of these electric compressors, as the efficiency in terms of coal/steam used to compress something is a lot better when using EU.",
+      "name": "tier2.quest30.name",
+      "description": "tier2.quest30.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -47295,8 +47295,8 @@
     },
     {
       "questID": 545,
-      "name": "Suction device... nice",
-      "description": "I hope you are not thinking about what I am thinking you are thinking about... \n\nHint:\nIt is highly recommended to get one of these, as the efficiency in terms of coal/steam used to extracting something is a lot better when using EU.",
+      "name": "tier2.quest29.name",
+      "description": "tier2.quest29.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -47367,8 +47367,8 @@
     },
     {
       "questID": 546,
-      "name": "Hello Baron, how is your black gold today?",
-      "description": "During your travels you may have seen some of these huge oil spouts. Now it\u0027s time to go make a pump and put this black gold into tanks. Oil can be burned in a combustion generator or be refined. \nMining pipes are needed for pumping the oil.\n\nBring a combustion generator with you to power the pump. (Thanks to the advancement of technology the pumping machine can auto output on top.)\nTaller spouts have more oil!",
+      "name": "tier2.quest27.name",
+      "description": "tier2.quest27.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -47459,8 +47459,8 @@
     },
     {
       "questID": 547,
-      "name": "Your oil is too Crude? Refine it!",
-      "description": "Burning oil in the combustion generator is a very inefficient way of producing power. Every bucket/cell of oil only gives you 20,000 EU. Time to try and refine it...",
+      "name": "tier2.quest68.name",
+      "description": "tier2.quest68.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -47536,8 +47536,8 @@
     },
     {
       "questID": 548,
-      "name": "Light Sulfuric Fuel",
-      "description": "The first step is to distill your oil into light sulfuric fuel, that has a burn value of 40,000 EU.",
+      "name": "tier2.quest100.name",
+      "description": "tier2.quest100.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -47613,8 +47613,8 @@
     },
     {
       "questID": 549,
-      "name": "Light fuel",
-      "description": "By adding hydrogen to sulfuric light fuel in a chemical reactor you can produce some light fuel with the very high burn value of 320,000 EU.\n\nThe remaining hydrogen sulfide cells can be used later to produce some sulfuric acid for your TNT/iTNT or acid batteries.\n\nIn MV age you can make diesel out of light and heavy fuel.",
+      "name": "tier2.quest101.name",
+      "description": "tier2.quest101.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -47698,8 +47698,8 @@
     },
     {
       "questID": 550,
-      "name": "H like Hydrogen... rest of the alphabet is too complicated...",
-      "description": "Centrifuge some brown or yellow limonite dust to get some hydrogen, or use an Electrolyser with some water to produce it in a fluid form.",
+      "name": "tier2.quest78.name",
+      "description": "tier2.quest78.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -47769,8 +47769,8 @@
     },
     {
       "questID": 551,
-      "name": "Heavy Sulfuric fuel",
-      "description": "The second step is to distill your oil into heavy sulfuric fuel, that has a burn value of 40,000 EU.",
+      "name": "tier2.quest85.name",
+      "description": "tier2.quest85.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -47852,8 +47852,8 @@
     },
     {
       "questID": 552,
-      "name": "Heavy fuel",
-      "description": "By adding hydrogen to sulfuric heavy fuel in a chemical reactor you can produce some heavy fuel with the burn value of 200,000 EU.\n\nThe remaining hydrogen sulfide cells can be used later to produce some sulfuric acid for your TNT/iTNT or acid batteries.\n\nIn MV age you can make diesel out of heavy and light fuel.",
+      "name": "tier2.quest86.name",
+      "description": "tier2.quest86.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -48022,8 +48022,8 @@
     },
     {
       "questID": 554,
-      "name": "Hey DJ, Mix it!",
-      "description": "The mixer is a very useful device. You can mix all kinds of fluids and items. Useful to prevent dust from falling to the ground when crafting - most mixer recipes give a slight boost over hand crafting!\n\nHint: You can use the battery slot and other extra slot in the GUI to store unused configuration circuits.",
+      "name": "tier2.quest11.name",
+      "description": "tier2.quest11.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -48093,8 +48093,8 @@
     },
     {
       "questID": 555,
-      "name": "N like nitrogen... Hide, alphabet strikes again!",
-      "description": "You can get some nitrogen by centrifuging... air. This process takes a long time, especially at the LV tier.",
+      "name": "tier2.quest73.name",
+      "description": "tier2.quest73.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -48170,8 +48170,8 @@
     },
     {
       "questID": 556,
-      "name": "Glyceryl trini...... what?",
-      "description": "Kids, today we will make some glyceryl trinitrate (aka Nitroglycerin) with some glycerol.\n    - Chemistry 101",
+      "name": "multiblock.goals.quest33.name",
+      "description": "multiblock.goals.quest33.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -48339,8 +48339,8 @@
     },
     {
       "questID": 558,
-      "name": "What can I put all these items in?",
-      "description": "After you make your first steel you\u0027re able to craft the small backpack. In this bag you can put a lot of the stuff you want to carry around. With 36 slots it\u0027s a bit bigger than a small chest. Later you can make it even larger. You can put one on your back and set it to automatically pick up stuff. The maximum you can have in your inventory at once is 4.",
+      "name": "tier1.quest61.name",
+      "description": "tier1.quest61.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -48542,8 +48542,8 @@
     },
     {
       "questID": 559,
-      "name": "Low pressure boiler tank",
-      "description": "The low pressure boiler tank is the easiest way to store steam. The firebox needs this tank on top to produce steam. The bigger the boiler the slower it heats up, but it will produce more steam when heated up.",
+      "name": "multiblock.goals.quest15.name",
+      "description": "multiblock.goals.quest15.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -48650,8 +48650,8 @@
     },
     {
       "questID": 560,
-      "name": "Railcraft steam power",
-      "description": "As an alternative way to make steam you can use the railcraft boilers. They require at least one firebox.\nMore than one size is possible: (1x1 mentioned above) 2x2 and 3x3. Each boiler needs 1, 2 or 3 layers of tanks on top, depending on the size.",
+      "name": "multiblock.goals.quest7.name",
+      "description": "multiblock.goals.quest7.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -48764,8 +48764,8 @@
     },
     {
       "questID": 561,
-      "name": "Liquid fuelled firebox",
-      "description": "Cresosote oil into steam! After you make your first steel you are able to craft a liquid fueled firebox.\nDiesel, ethanol, creosote and biodiesel all work well here.",
+      "name": "multiblock.goals.quest8.name",
+      "description": "multiblock.goals.quest8.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -48889,8 +48889,8 @@
     },
     {
       "questID": 562,
-      "name": "High pressure boiler tank",
-      "description": "After you make steel you are able to craft a high pressure boiler tank. The upgraded version increases the temperature and produces more steam than the low pressure version. It will take longer to warm up, so make sure to keep it well fed!",
+      "name": "multiblock.goals.quest16.name",
+      "description": "multiblock.goals.quest16.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -49002,8 +49002,8 @@
     },
     {
       "questID": 563,
-      "name": "Bookshelves...? Ah forestry... Multiblock farms!",
-      "description": "The bookshelf can only be made with wood planks, which are made in a compressor. Perhaps someone thinks this is a bit crazy...",
+      "name": "tier1.quest39.name",
+      "description": "tier1.quest39.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -50110,7 +50110,7 @@
     {
       "questID": 578,
       "name": "The carpenter",
-      "description": "The carpenter is similar to an automatic crafting table. It has an item input slot and a storage slot for the recipes. Some recipes need an additional fluid like water, creosote, honey or molten redstone. With the carpenter you can make farmblocks, woven backpacks, bee and tree analysers and many more.\n\nThe carpenter needs power to work. You can use a GT cable or a battery box to connect to the machine or make some forestry, railcraft or buildcraft RF engines.",
+      "description": "The Carpenter is similar to an automatic crafting table. It has an item input slot and a storage slot for the recipes. Some recipes need an additional fluid like water, creosote, honey or molten redstone. With the carpenter you can make farmblocks, woven backpacks, bee and tree analysers and many more.\n\nThe carpenter needs power to work. You can use a GT cable or a battery box to connect to the machine or make some forestry, railcraft or buildcraft RF engines.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -50247,8 +50247,8 @@
     },
     {
       "questID": 579,
-      "name": "Molten redstone?",
-      "description": "You heard that the carpenter needs some molten redstone for a few recipes. \nConverting redstone dust into a fluid requires a fluid extractor. Let\u0027s build one.",
+      "name": "tier2.quest50.name",
+      "description": "tier2.quest50.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -50354,7 +50354,7 @@
     {
       "questID": 580,
       "name": "Thermionic fabricator",
-      "description": "The thermionic fabricator is used to craft electron tubes and stained glass. It requires redstone flux (RF) energy to run. It is your first machine made in the carpenter. Once warmed up, it needs to maintain a certain heat level to operate. The amount of power supplied will determine how much heat will be generated. If you do not supply enough power to maintain the current temperature it will slowly drop. It will continuously draw power, so disconnect it if you don\u0027t need it.",
+      "description": "The thermionic fabricator is used to craft electron tubes and stained glass. It requires redstone flux (RF) energy to run. It is your first machine which is made in the carpenter. Once warmed up, it needs to maintain a certain heat level to operate. The amount of power supplied will determine how much heat will be generated. If you do not supply enough power to maintain the current temperature it will slowly drop.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -50488,8 +50488,8 @@
     },
     {
       "questID": 581,
-      "name": "A Series of Tubes",
-      "description": "Before you can craft your first farm block you need apatite tubes. Make some apatite rods first with a lathe, then use a forge hammer to join them into long apatite rods. You need golden bolts and a red alloy plate.\nPut some glass or sand into your thermionic fabricator and make your first tubes.",
+      "name": "Tubes",
+      "description": "Before you can craft your first farm block you need apatite tubes. Make some apatite long rods first (Using a lathe or extruder). You need golden bolts and a red alloy plate.\nPut some glass or sand into your thermionic fabricator and make your first tubes.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -50618,7 +50618,7 @@
     {
       "questID": 582,
       "name": "Your first multiblock farm",
-      "description": "The smallest farm you can build requires 36 farm blocks (3x4x3 - the largest is 5x4x5 or 100 farm blocks). For water input you need a valve, items go through the hatches, and to supply the farm with energy you need a gearbox. With the farm control block you can control which fields of your farm work by applying a redstone signal. Remember to put creosote in the carpenter when crafting the different farm blocks. If you need the farm to work faster, just add more gearboxes.\nYou can use Orchard mode to collect Pam foods and Natura products. You can even mix and match modes on the same farm - logging and collecting fruit from trees, for example.",
+      "description": "The smallest farm you can build requires 36 farm blocks. For water input you need a valve, items go through the hatches and to supply the farm with energy you need a gearbox. With the farm control block you can control which fields of your farm work by applying a redstone signal. Remember to put creosote in the carpenter when crafting the different farm blocks.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -50747,7 +50747,7 @@
     {
       "questID": 583,
       "name": "Farm logic",
-      "description": "This chip is optional and more advanced. Farms can work without it. But if you want to configure your farm you will need one of them.",
+      "description": "This chip is optional and more advanced. The farms are working without them too. But if you want to configure your farm you will need one of them.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -51015,7 +51015,7 @@
     {
       "questID": 585,
       "name": "Heating coils",
-      "description": "Your thermionic fabricator needs heating coils to function. So combine some magnetized (requires polariser) steel rods with some copper wire and make some.",
+      "description": "Your thermionic fabricator needs heating coils to function. So combine some magnetized (requires polarizer) steel rods with some copper wire and make some.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -51191,8 +51191,8 @@
     },
     {
       "questID": 587,
-      "name": "Magnetize your rods",
-      "description": "Magnetic steel rods need a polariser to craft. Make a few for your coils.",
+      "name": "tier2.quest4.name",
+      "description": "tier2.quest4.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -51296,7 +51296,7 @@
     {
       "questID": 588,
       "name": "Finding Apatite",
-      "description": "It\u0027s now time to search for some ores. Apatite is the most important material in Forestry. You can make fertilizer, farm blocks and many other things. The vein is found between Y level 40-60.",
+      "description": "It\u0027s now time to search for some ores. Apatite is the most basic material in Forestry. You can make fertilizer, farm blocks and many other things. The vein is found between Y level 40-60.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -51397,7 +51397,7 @@
     {
       "questID": 589,
       "name": "Multiblock farm: Hatch",
-      "description": "Farm hatch (Item pipe connectivity)\n\nYou can supply and extract items from the farm by using farm hatches that are connected to pipe systems. \n\nSupplying items\nThe farm hatch is clever enough to know which item goes where. If an item isn\u0027t appropriate for the farm\u0027s configuration, the hatch will simply reject it.\n\nExtracting items\nAny item that is harvested by the Multifarm is automatically ejected by the farm hatches into inventories or pipes. Pipes can be used to extract from other sides.",
+      "description": "Farm hatch (Pipe connectivity)\n\nYou can supply and extract items from the farm by using farm hatches that are connected to pipe systems. \n\nSupplying items\nThe farm hatch is clever enough to know which item goes where. If an item isn\u0027t appropriate for the farm\u0027s configuration, the hatch will simply reject it.\n\nExtracting items\nAny item that is harvested by the Multifarm is automatically ejected by the farm hatches into inventories or pipes. Pipes can be used to extract from other sides.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -51605,12 +51605,6 @@
               "Count": 4,
               "OreDict": "",
               "Damage": 11
-            },
-            {
-              "id": "gregtech:gt.metaitem.02",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 31305
             }
           ],
           "taskID": "bq_standard:retrieval"
@@ -51753,7 +51747,7 @@
               "id": "Forestry:thermionicTubes",
               "Count": 4,
               "OreDict": "",
-              "Damage": 4
+              "Damage": 9
             }
           ],
           "taskID": "bq_standard:retrieval"
@@ -51956,8 +51950,8 @@
     },
     {
       "questID": 593,
-      "name": "Enhanced farm logic",
-      "description": "This chip is optional and more advanced than the basic one. The farms can work without them. However, if you want to configure your farm you will need one of them.",
+      "name": "Farm logic enhanced",
+      "description": "This chip is optional and more advanced than the basic one. The farms can work without them too. If you want to configure your farm you will need one of them.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -52097,8 +52091,8 @@
     },
     {
       "questID": 594,
-      "name": "Refined farm logic",
-      "description": "This chip is optional and more advanced than the enhanced one. The farms can work without them. If you want to configure your farm even more you will need one of them.",
+      "name": "Farm logic refined",
+      "description": "This chip is optional and more advanced than the enhanced one. The farms are working without them too. If you want to configure your farm even more you will need one of them.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -52238,8 +52232,8 @@
     },
     {
       "questID": 595,
-      "name": "Intricate farm logic",
-      "description": "This chip is optional and more advanced than the refined one. The farms will work without them, but if you want to configure your farm even more you will need one of them.",
+      "name": "Farm logic intricate",
+      "description": "This chip is optional and more advanced than the refined one. The farms are working without them too. If you want to configure your farm even more you will need one of them.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -52379,8 +52373,8 @@
     },
     {
       "questID": 596,
-      "name": "Upgrade of the upgrade of the...",
-      "description": "It\u0027s upgrade time. Unlock redstone and obsidian level for your different tools.",
+      "name": "tier1.quest34.name",
+      "description": "tier1.quest34.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -52492,8 +52486,8 @@
     },
     {
       "questID": 597,
-      "name": "Tetrahedrite, stibnite and copper",
-      "description": "Maybe you are wondering why you need tetrahedrite or stibnite. Well, antimony can be centrifuged out of it which is very useful for batteries in the LV Age.\nThe veins can be found between Y level 80-120.",
+      "name": "tier1.quest58.name",
+      "description": "tier1.quest58.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -52592,8 +52586,8 @@
     },
     {
       "questID": 598,
-      "name": "Antimony",
-      "description": "The most efficient way to get antimony for batteries is to centrifuge stibnite dust, the second most efficient way is to use tetrahedrite dust.",
+      "name": "tier2.quest88.name",
+      "description": "tier2.quest88.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -52664,8 +52658,8 @@
     },
     {
       "questID": 599,
-      "name": "Thermal centrifuge",
-      "description": "A optional machine to get different byproducts out of your crushed and purified ore dust. This machine becomes very useful when you have reactors and want to recycle your depleted fuel rods.",
+      "name": "tier2.quest19.name",
+      "description": "tier2.quest19.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -53206,7 +53200,7 @@
     {
       "questID": 603,
       "name": "Dimensional chest",
-      "description": "You\u0027ve heard rumors, that the endermen had built laboratories in the End. To invent new machines and weapons in order to attack the Overworld. One of their inventions is a chest, which is somehow linked to all instances of itself. Go and try to find one of those.",
+      "description": "You\u0027ve heard rumors, that the endermen had build laboratories in the End. To invent new machines and weapons in order to attack the Overworld. One of their inventions is a chest, which is somehow linked to all instances of itself. Go and try to find one of those.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -53579,136 +53573,8 @@
           "target": "DraconicEvolution.EnderDragon",
           "required": 1,
           "subtypes": true,
-          "ignoreNBT": false,
-          "targetNBT": {
-            "ForgeData:10": {},
-            "Initialized:1": 0,
-            "Attributes:9": [
-              {
-                "Base:6": 0.0,
-                "Name:8": "weapon.penetrateArmor"
-              },
-              {
-                "Base:6": 3.0,
-                "Name:8": "weapon.daze"
-              },
-              {
-                "Base:6": 0.0,
-                "Name:8": "weapon.attackSpeed"
-              },
-              {
-                "Base:6": 0.0,
-                "Name:8": "weapon.mountedBonus"
-              },
-              {
-                "Base:6": 200.0,
-                "Name:8": "generic.maxHealth"
-              },
-              {
-                "Base:6": 0.0,
-                "Name:8": "generic.knockbackResistance"
-              },
-              {
-                "Base:6": 0.10000000149011612,
-                "Name:8": "generic.movementSpeed"
-              },
-              {
-                "Base:6": 16.0,
-                "Name:8": "generic.followRange"
-              }
-            ],
-            "Invulnerable:1": 0,
-            "PortalCooldown:3": 0,
-            "AbsorptionAmount:5": 0.0,
-            "FallDistance:5": 0.0,
-            "DeathTime:2": 0,
-            "DropChances:9": [
-              0.08500000089406967,
-              0.08500000089406967,
-              0.08500000089406967,
-              0.08500000089406967,
-              0.08500000089406967
-            ],
-            "PersistenceRequired:1": 0,
-            "HealF:5": 200.0,
-            "id:8": "DraconicEvolution.EnderDragon",
-            "Motion:9": [
-              0.0,
-              0.0,
-              0.0
-            ],
-            "Leashed:1": 0,
-            "AttackDamage:5": 0.0,
-            "UUIDLeast:4": -3850102294886758996,
-            "Health:2": 200,
-            "IsUber:1": 0,
-            "Dimension:3": 0,
-            "OnGround:1": 0,
-            "Air:2": 0,
-            "Rotation:9": [
-              0.0,
-              0.0
-            ],
-            "CreatureInfusion:10": {
-              "PlayerInfusions:11": [
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0
-              ],
-              "tumorWarpTemp:3": 0,
-              "InfusionCosts:10": {
-                "Aspects:9": []
-              },
-              "Infusions:11": [
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0
-              ],
-              "toggleClimb:1": 0,
-              "toggleInvisible:1": 0,
-              "tumorWarp:3": 0,
-              "tumorWarpPermanent:3": 0,
-              "sitting:1": 0
-            },
-            "Equipment:9": [
-              {},
-              {},
-              {},
-              {},
-              {}
-            ],
-            "UUIDMost:4": 131653853705906,
-            "CustomName:8": "",
-            "Pos:9": [
-              0.0,
-              0.0,
-              0.0
-            ],
-            "Fire:2": 0,
-            "CanPickUpLoot:1": 0,
-            "HurtTime:2": 0,
-            "oiltweak.inOil:1": 0,
-            "AttackTime:2": 0,
-            "CustomNameVisible:1": 0
-          },
+          "ignoreNBT": true,
+          "targetNBT": {},
           "taskID": "bq_standard:hunt"
         }
       ],
@@ -53754,8 +53620,8 @@
     },
     {
       "questID": 608,
-      "name": "A lead about lead that leads to lead dust",
-      "description": "The next step of making batteries is to collect some lead. Lead and galena veins can be found in the Twilight Forest at y levels 5 - 45.",
+      "name": "tier2.quest94.name",
+      "description": "tier2.quest94.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -53826,8 +53692,8 @@
     },
     {
       "questID": 609,
-      "name": "Battery alloy",
-      "description": "Mixing antimony and lead in the alloy smelter will give you some battery alloy.\nCombine it with some tin cable and voila there is your small battery hull.",
+      "name": "tier2.quest95.name",
+      "description": "tier2.quest95.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -54038,8 +53904,8 @@
     },
     {
       "questID": 611,
-      "name": "Single use battery: Mercury",
-      "description": "Mercury and acid batteries are single-use batteries. They are crafted fully charged but cannot be re-charged. Once their stored energy is depleted, they can be placed in an extractor to be converted back into small battery hulls.\n\nThey can be placed in the battery slot of any standard LV gregtech machine, in that case they will be depleted before the machine\u0027s internal EU storage. They can also be used in LV battery buffers.",
+      "name": "tier2.quest119.name",
+      "description": "tier2.quest119.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -54140,8 +54006,8 @@
     },
     {
       "questID": 612,
-      "name": "Single use battery: Acid",
-      "description": "Mercury and acid Batteries are single-use batteries. They are crafted fully charged but cannot be re-charged. Once their stored energy is depleted, they can be placed in an extractor to be converted back into small battery hulls.\n\nThey can be placed in the battery slot in any standard LV gregtech machine, in that case they will be depleted before the machine\u0027s internal EU storage. They can also be used in LV battery buffers.",
+      "name": "tier2.quest110.name",
+      "description": "tier2.quest110.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -54242,8 +54108,8 @@
     },
     {
       "questID": 613,
-      "name": "Reusable battery: Sodium",
-      "description": "Sodium, cadmium, and lithium batteries are rechargeable batteries. They are crafted without stored energy, but can be charged in any gregtech machine. If unneeded, they can be placed in an extractor and converted back into small battery hulls, but their contents are lost.",
+      "name": "tier2.quest91.name",
+      "description": "tier2.quest91.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -54340,8 +54206,8 @@
     },
     {
       "questID": 614,
-      "name": "Reusable battery: Cadmium",
-      "description": "Sodium, cadmium, and lithium batteries are rechargeable batteries. They are crafted without stored energy, but can be charged in any gregtech machine. If unneeded, they can be placed in an extractor and converted back into small battery hulls, but their contents are lost.",
+      "name": "tier2.quest97.name",
+      "description": "tier2.quest97.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -54439,8 +54305,8 @@
     },
     {
       "questID": 615,
-      "name": "Reusable battery: Lithium",
-      "description": "Sodium, cadmium, and lithium batteries are rechargeable batteries. They are crafted without stored energy, but can be charged in any gregtech machine. If unneeded, they can be placed in an extractor and converted back into small battery hulls, but their contents are lost.",
+      "name": "tier2.quest84.name",
+      "description": "tier2.quest84.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -54537,8 +54403,8 @@
     },
     {
       "questID": 616,
-      "name": "Mercury",
-      "description": "Mercury can be centrifuged out of redstone. If you find some cinnabar ore in the redstone vein you can use that too.",
+      "name": "tier2.quest118.name",
+      "description": "tier2.quest118.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -54621,8 +54487,8 @@
     },
     {
       "questID": 617,
-      "name": "Fluid canner",
-      "description": "The fluid canner is a fundamental machine, since it is necessary to move fluids around, as well as for filling tin cells, glass bottles, buckets, and even batteries. Most cases you can use the small GT++ tanks instead.\n\nAnother interesting thing about the fluid canner is that it can be transformed into a raintank, by attaching a drain cover on its top (Any machine with a tank actually can be...).",
+      "name": "tier2.quest109.name",
+      "description": "tier2.quest109.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -54693,8 +54559,8 @@
     },
     {
       "questID": 618,
-      "name": "Sulfuric acid",
-      "description": "Combining sulfur trioxide and water in the chemical reactor will give you sulfuric acid for your single use acid batteries. If you have made some light or heavy fuel already maybe you have some spare hydrogen sulfide. If not, you can always make sulfuric acid with some sulfur and water in the chemical reactor.",
+      "name": "tier2.quest108.name",
+      "description": "tier2.quest108.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -54770,8 +54636,8 @@
     },
     {
       "questID": 619,
-      "name": "Battery buffer",
-      "description": "Batteries can be placed directly in machines. To recharge a battery you need a battery buffer. Buffers can also power an energy network. They come in different sizes: 1, 4, 9 and 16 slots. They can draw 2A and output 1A per battery inserted - watch your wire amperage!",
+      "name": "tier2.quest111.name",
+      "description": "tier2.quest111.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -54845,8 +54711,8 @@
     },
     {
       "questID": 620,
-      "name": "IC2 Battery",
-      "description": "Some recipes require IC2 batteries. Fill your small battery hull with some molten redstone and you will get your RE-Battery. Molten cells will hurt you, so be careful.",
+      "name": "tier2.quest81.name",
+      "description": "tier2.quest81.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -54925,8 +54791,8 @@
     },
     {
       "questID": 621,
-      "name": "How to get sodium",
-      "description": "A second source for sodium is glauconite ore or glauconite sand. This type of ore vein can be found at Y level 20-50.",
+      "name": "tier2.quest90.name",
+      "description": "tier2.quest90.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -55021,13 +54887,13 @@
         }
       ],
       "preRequisites": [
-        609
+        1168
       ]
     },
     {
       "questID": 622,
-      "name": "How to get sodium/lithium",
-      "description": "Salt ore mixes can be found in the Overworld between Y level 50-70. Salt isn\u0027t only used to get sodium, it\u0027s an important ingredient in many pam\u0027s harvestcraft food recipes.\n\nHint: Lepidolite and spodumene are good sources of lithium for your batteries.",
+      "name": "tier2.quest74.name",
+      "description": "tier2.quest74.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -55122,13 +54988,13 @@
         }
       ],
       "preRequisites": [
-        609
+        1167
       ]
     },
     {
       "questID": 623,
-      "name": "A big meteorite",
-      "description": "The best way to get rare earth is to find an applied energistics 2 meteorite and grind the blocks into dust. Maybe you completed the quest in the steam age and stored your crushed skystone somewhere? That dust can now be centrifuged into various byproducts like cadmium, neodymium, caesium, lanthanum, and yttrium.\n\nHint: Redstone has rare earth as byproduct. Chalcopyrite (at HV level) and sphalherite (at LV level) have cadmium as byproduct.",
+      "name": "tier2.quest96.name",
+      "description": "tier2.quest96.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -55255,8 +55121,8 @@
     },
     {
       "questID": 624,
-      "name": "Basic canner",
-      "description": "The canning machine is mainly used to fill tin cans with any kind of food, but it is useful for filling and emptying tin cells with other solid items than food, usually in the form of dust. It can also fill batteries with sulfur, mercury, cadmium, lithium or sodium.",
+      "name": "tier2.quest83.name",
+      "description": "tier2.quest83.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -55328,8 +55194,8 @@
     },
     {
       "questID": 625,
-      "name": "Packing your tanks chests and barrels",
-      "description": "Packing your chests and barrels without spilling all the things (buildcraft(tm))? \nNo problem! Make a dolly and you can carry your full chests, barrels or storage drawers anywhere you want. But be warned, you will get a slowness debuff so hopefully you don\u0027t have to travel very far. Not portable buildcraft and iron tanks can moved so too without loosing fluids.\n\nPS Later on you can fly or make a traveller\u0027s belt to get around the debuff.",
+      "name": "tier1.quest69.name",
+      "description": "tier1.quest69.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -55459,8 +55325,8 @@
     },
     {
       "questID": 626,
-      "name": "Portable mob spawners..? Cool!",
-      "description": "Do you want to move the spawners around and build some cool mob farms? That will be no problem if you get the diamond dolly.",
+      "name": "tier2.quest104.name",
+      "description": "tier2.quest104.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -56587,7 +56453,7 @@
     {
       "questID": 638,
       "name": "Tasty toast",
-      "description": "Smelt your bread again and you get some toast! Give\u0027s you more nutrition points, and unlocks more culinary potential!",
+      "description": "Smelt your bread again and you get some toast!? Give\u0027s you more nutrition points, and unlocks more culinary potential!",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -56676,8 +56542,8 @@
     },
     {
       "questID": 639,
-      "name": "Sulfuric naphtha",
-      "description": "Another distillate you can make out of oil is sulfuric naphtha with a burn value of 40,000 EU per cell in the gas turbine.",
+      "name": "tier2.quest69.name",
+      "description": "tier2.quest69.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -56715,7 +56581,7 @@
           "requiredItems": [
             {
               "id": "gregtech:gt.metaitem.01",
-              "Count": 9,
+              "Count": 7,
               "OreDict": "",
               "Damage": 30736
             }
@@ -56759,8 +56625,8 @@
     },
     {
       "questID": 640,
-      "name": "LPG",
-      "description": "Centrifuging some Butane or Propane gives you LPG with a burn value of 320,000 EU, the same as naphtha. Also it is a way to get methane and eventually epichlorohydrin.",
+      "name": "tier2.quest76.name",
+      "description": "tier2.quest76.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -56842,8 +56708,8 @@
     },
     {
       "questID": 641,
-      "name": "Naphtha",
-      "description": "You can process sulfuric naphtha to fluid naphtha which has a burn value of 320,000 EU in the gas turbine.\nNaphtha is also a base product for polyethylene and polycaprolactam - a great substitute for string.",
+      "name": "tier2.quest70.name",
+      "description": "tier2.quest70.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -56881,7 +56747,7 @@
           "requiredItems": [
             {
               "id": "gregtech:gt.metaitem.01",
-              "Count": 9,
+              "Count": 7,
               "OreDict": "",
               "Damage": 30739
             }
@@ -56925,8 +56791,8 @@
     },
     {
       "questID": 642,
-      "name": "Sulfuric gas",
-      "description": "Another distillate for your gas turbine you can make out of oil is sulfuric gas with a burn value of 25,000 EU per cell.",
+      "name": "tier2.quest62.name",
+      "description": "tier2.quest62.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -57008,8 +56874,8 @@
     },
     {
       "questID": 643,
-      "name": "Refinery gas",
-      "description": "Refine your gas in a chemical reactor with hydrogen gas to give it a better burn value of 160,000 EU, and maybe use it to make methane gas.",
+      "name": "tier2.quest71.name",
+      "description": "tier2.quest71.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -57092,8 +56958,8 @@
     },
     {
       "questID": 644,
-      "name": "Methane",
-      "description": "Distilling some \"refinery gases\" gives you some methane gas. There are many more ways to get methane.",
+      "name": "tier2.quest72.name",
+      "description": "tier2.quest72.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -57332,8 +57198,8 @@
     },
     {
       "questID": 646,
-      "name": "Electrotine battery",
-      "description": "The electrotine battery is exclusively used in project red machines and the jetpack.\nElectrotine is a mixture of redstone and electrum dust.",
+      "name": "tier2.quest107.name",
+      "description": "tier2.quest107.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -57821,7 +57687,7 @@
     {
       "questID": 650,
       "name": "Copter jetpack",
-      "description": "The copter jetpack is the first jetpack with a hover mode. It is using all kind of different fuel types in buckets. \nBuckets of creosote, lava, oil, cetane, diesel,ethanol, and fuel will work.\nEquip your jetpack and hit Shift and the adventure backpacks action-key. You can also switch between hover and normal mode.\n\nMax flying height is limited to Y level 200. \n\nVertical velocity decreases linearly with height after overcoming optimal height - 135 for jetpack and 100 for copter.",
+      "description": "The copter jetpack is the first jetpack with a hover mode. It is using all kind of different fuel types in buckets. \nBuckets of creosote, lava, oil and fuel will work.\nEquip your jetpack and hit Shift and the adventure backpacks action-key. You can also switch between hover and normal mode.\n\nMax flying height is limited to Y level 200. \n\nVertical velocity decreases linearly with height after overcoming optimal height - 135 for jetpack and 100 for copter.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -58754,8 +58620,8 @@
     },
     {
       "questID": 656,
-      "name": "Iron shields",
-      "description": "You have been using your hide shield long enough. After you make your first tools, grab a bit of iron ore and make a nice iron shield.",
+      "name": "tier0.5.quest25.name",
+      "description": "tier0.5.quest25.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -58868,8 +58734,8 @@
     },
     {
       "questID": 657,
-      "name": "Stone spear",
-      "description": "Upgrade your wooden spear with a stone arrowhead and iron screws to a stone spear.\nThis spear has better durability than the wooden one.",
+      "name": "tier0.5.quest26.name",
+      "description": "tier0.5.quest26.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -58983,8 +58849,8 @@
     },
     {
       "questID": 658,
-      "name": "Iron spear",
-      "description": "Upgrade your wooden spear with an iron arrowhead and two steel screws to an iron spear. \nThe iron spear has better durability than the stone variant.",
+      "name": "tier1.quest54.name",
+      "description": "tier1.quest54.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -59338,8 +59204,8 @@
     },
     {
       "questID": 661,
-      "name": "Bow, arrows and quiver",
-      "description": "Wow, your first handmade *ehm* machine made bow. You find out that you can put the bow in the mine and blade battlegears slots. Now it\u0027s time to make a quiver and maybe some arrows. You can put up to 4 stacks of arrows in your quiver.\n\nLet\u0027s go hunt a bit.",
+      "name": "tier2.quest52.name",
+      "description": "tier2.quest52.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -59484,8 +59350,8 @@
     },
     {
       "questID": 662,
-      "name": "Basic arc furnace",
-      "description": "The arc furnace is an alternative to smelting stuff back into components and making wrought iron. The recipes use oxygen and 3 amperes of power.",
+      "name": "tier2.quest113.name",
+      "description": "tier2.quest113.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -59555,8 +59421,8 @@
     },
     {
       "questID": 663,
-      "name": "Faster steel production",
-      "description": "A faster alternative to steel production is to use the arc furnace and smelt the iron ingots into wrought iron ingots. Then macerate them to dust and smelt them very fast in the EBF to steel. (Some might even dare arc furnacing the dust itself...)",
+      "name": "tier2.quest114.name",
+      "description": "tier2.quest114.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -59674,8 +59540,8 @@
     },
     {
       "questID": 664,
-      "name": "LV battery buffer 9 slots",
-      "description": "Upgrade your battery buffer to hold 9 batteries which allows max 9 ampere output.\nUseful for your EBF and the arc furnace.",
+      "name": "tier2.quest112.name",
+      "description": "tier2.quest112.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -60608,8 +60474,8 @@
     },
     {
       "questID": 673,
-      "name": "LV extruder",
-      "description": "The extruder is not very useful in the LV age. But it will extrude your next tier of boat, make rubber sheets more efficiently, or make some Tinkers Construct tool parts.",
+      "name": "tier2.quest41.name",
+      "description": "tier2.quest41.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -60882,7 +60748,7 @@
     {
       "questID": 676,
       "name": "Crowbar",
-      "description": "The crowbar comes in a Railcraft and a gregtech variant. It is used to manipulate machines from railcraft, remove plates and any other covers (pumps, conveyor belts, etc.) from gregtech pipes and machines as well as breaking certain objects faster, such as tracks. This tool is also used to access certain inventories from Railcraft.\nHold a crowbar and shift + right click to attach carts. Click the starting cart then continue to click to add more carts to the link. Carts will act slower the more connections are made.\n\nThe crowbar can be used as a weapon, though it costs twice as much durability on attack (just like any other non weapon tool...).",
+      "description": "The crowbar comes in a Railcraft and a gregtech variant. It is used to manipulate machines from railcraft, remove plates and any other covers (pumps, conveyor belts, etc.) from gregtech pipes and machines as well as breaking certain objects faster, such as tracks. This tool is also used to access certain inventories from Railcraft.\nHoldi a crowbar and shift + right click to attach carts. Click the starting cart then continue to click to add more carts to the link. Carts will act slower the more connections are made.\n\nThe crowbar can be used as a weapon, though it costs twice as much durability on attack (just like any other non weapon tool...).",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -62412,7 +62278,7 @@
     {
       "questID": 691,
       "name": "Armor 2.5",
-      "description": "The steel armor has more durability than the iron/bronze or chainmail armor.",
+      "description": "The steel armor has much more durability than the iron/bronze or chainmail armor.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -62533,7 +62399,7 @@
     {
       "questID": 692,
       "name": "Composite vest",
-      "description": "Combining the strength of advanced alloy plates with the steel chestplate makes your vest very hard. Now you have double the durability and increased armor points by 1.5.",
+      "description": "Combining the strength of advanced alloy plates with the steel chestplate makes your vest very hard. Now you have double the durability and increased armor points by 1,5.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -62647,8 +62513,8 @@
     },
     {
       "questID": 693,
-      "name": "Fallen from the sky",
-      "description": "There are big meteors everywhere and you are wondering why you need to mine them now?\nSkystone is a good source of rare earth metals in the LV age. \nInside the meteor you can find a skystone chest containing some processor press plates. Save them for later, as they are really important. Plus the chest is nice, and can be placed underneath blocks and still opened.",
+      "name": "tier0.5.quest19.name",
+      "description": "tier0.5.quest19.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -62745,8 +62611,8 @@
     },
     {
       "questID": 694,
-      "name": "One Anvil... Better make that two!",
-      "description": "With your brand-new Compressor you are able to make some metal blocks for your new anvil. Better craft two anvils, one will be required for the forge hammer.\n\nWith the anvil you can repair, rename and enchant armor and tools.\n",
+      "name": "tier1.quest37.name",
+      "description": "tier1.quest37.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -62853,8 +62719,8 @@
     },
     {
       "questID": 695,
-      "name": "Automation tier 1",
-      "description": "Do you want to automate your smeltery because you are planning to make stacks of glass blocks? \nNo problem, craft a large bronze pipe and place it under the faucet. Now the molten fluid will flow inside the pipe. Under or next to the pipe you have to place the casting basins or tables.\nA hopper and a chest underneath would auto-output products. NOTE: Faucets will output precisely 144L each activation if you toggle it off immediately. That\u0027s going to have some uses later on...",
+      "name": "multiblock.goals.quest1.name",
+      "description": "multiblock.goals.quest1.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -62982,8 +62848,8 @@
     },
     {
       "questID": 696,
-      "name": "Automation tier 2",
-      "description": "You want a better automation than using pipes? Sure, craft a comparator and link it with redstone dust placed on the ground. The redstone needs to be adjacent to the faucet to activate the crafting process.",
+      "name": "multiblock.goals.quest10.name",
+      "description": "multiblock.goals.quest10.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -63072,8 +62938,8 @@
     },
     {
       "questID": 697,
-      "name": "2x steel",
-      "description": "Steel production is so slow. If you got enough bricks and clay, build a second BBF. Build it attached to the first one, so they can share a wall and you will save some bricks, clay and concrete.",
+      "name": "multiblock.goals.quest21.name",
+      "description": "multiblock.goals.quest21.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -63202,8 +63068,8 @@
     },
     {
       "questID": 698,
-      "name": "4x steel",
-      "description": "Not even two BBFs are fast enough...Can you figure out how to save the most bricks making 4?",
+      "name": "multiblock.goals.quest22.name",
+      "description": "multiblock.goals.quest22.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -63332,8 +63198,8 @@
     },
     {
       "questID": 699,
-      "name": "Why one coke oven when you can have ten?",
-      "description": "Your bricked blast furnace uses coal like hell and your steam boiler too? Well it\u0027s time to make more coke ovens and automate them a bit. Wooden fluid pipes and tin item pipes will help you reach your goal.\n\nSearch NEI for a more efficient way to make coke oven bricks.",
+      "name": "multiblock.goals.quest5.name",
+      "description": "multiblock.goals.quest5.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -63918,8 +63784,8 @@
     },
     {
       "questID": 705,
-      "name": "Accelerated plant growth",
-      "description": "Plants grow very slowly, you might\u0027ve discovered that by now. So why you don\u0027t counter that? A watering can will come in handy very soon.",
+      "name": "tier1.quest59.name",
+      "description": "tier1.quest59.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -64939,8 +64805,8 @@
     },
     {
       "questID": 716,
-      "name": "Find some Certus Quartz",
-      "description": "The Nether is full of different kinds of quartz. For the emitter and the sensor you will need to find some certus quartz.",
+      "name": "tier2.quest25.name",
+      "description": "tier2.quest25.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -65039,8 +64905,8 @@
     },
     {
       "questID": 717,
-      "name": "Good Circuits",
-      "description": "Good circuits are an improvement on basic circuits. They are a component of all MV gregtech machines. Be sure you build the electric blast furnace first, so you can process some aluminium dust into ingots.",
+      "name": "tier2.quest65.name",
+      "description": "tier2.quest65.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -65304,7 +65170,7 @@
     {
       "questID": 719,
       "name": "First Breeding",
-      "description": "New plants have grown on your crop sticks. You can harvest the crop by right clicking it or by left clicking with a seed bag eventually - this will destroy the plant though. Collect 8 seeds of any kind.",
+      "description": "New plants have grown on your crop sticks. You can harvest the crop by right clicking it or by left clicking with a seed bag eventually, This will destroy the plant though. Collect 8 seeds of any kind.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -65396,7 +65262,7 @@
     {
       "questID": 720,
       "name": "Weed II",
-      "description": "Weeds, weeds, and more weeds. You get so many of them while cross breeding. \nNeed some  biogas cells for your power production in exchange? Or maybe some glowstone to light up your fields?",
+      "description": "Weeds, weeds, and more weeds. You get so many of them while cross breeding. \nNeed some  biogas cells for your power production in exchange? or maybe some glowstone to light up your fields.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -65677,8 +65543,8 @@
     },
     {
       "questID": 723,
-      "name": "Potatos, Carrots, Pumpkins and Melons",
-      "description": "Your seeds have three different values: Growth, gain, and resistance (GGR).\n\nThe only way to change a crop\u0027s GGR without 3rd party tools is through cross breeding. When two plants cross-breed, the resulting plant will have a GGR score that is between both \"parent\" plants\u0027 GGR. Sometimes it will also be a little bit higher or lower. Thus, to obtain high GGR scores you must go through numerous generations of crossbreeding.\n\nThe highest score for GGR is 31.",
+      "name": "Potatos, Carrots, Pumkins and Melons",
+      "description": "Your seeds have three different values. growth, gain, and resistance (GGR).\n\nThe only way to change a crop\u0027s GGR without 3rd party tools is through cross breeding. When two plants cross-breed, the resulting plant will have a GGR score that is between both \"parent\" plants\u0027 GGR. Sometimes it will also be a little bit higher or lower. Thus, to obtain high GGR scores you must go through numerous generations of crossbreeding.\n\nThe highest score for GGR is 31.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -66018,8 +65884,8 @@
     },
     {
       "questID": 726,
-      "name": "Chemical rubber production",
-      "description": "A much more efficient way to make insulated cables is by making molten rubber in a chemical reactor which can be applied to a cable in the assembling machine. When you put both machines next to each other you can output the molten rubber directly to the assembling machine by clicking the fluid auto-output button on the chemical reactor. Make sure to set the correct side of the reactor as output side by wrenching it.",
+      "name": "tier2.quest92.name",
+      "description": "tier2.quest92.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -66128,8 +65994,8 @@
     },
     {
       "questID": 727,
-      "name": "Better than barrels",
-      "description": "While barrels offer a slot for a single item, drawers can have up to 4 slots each (holding 16 stacks per slot). Once you reach HV you can combine them with some ProjectRed pipes to set up a \"ghetto ME storage system\" (Tec2k17)",
+      "name": "tier0.5.quest36.name",
+      "description": "tier0.5.quest36.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -66209,8 +66075,8 @@
     },
     {
       "questID": 728,
-      "name": "Compact Drawers",
-      "description": "They are very compact and add some fanciness to your glorious dirt base. ",
+      "name": "tier0.5.quest35.name",
+      "description": "tier0.5.quest35.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -66284,8 +66150,8 @@
     },
     {
       "questID": 729,
-      "name": "Framing Drawers",
-      "description": "Now you can really make some swaggy and even FANCIER drawers using this table, all you have to do is place some decorative blocks (works with almost ALL decorative blocks) and it will take their texture, the TOP left is the outer Square bottom left is for the front face and top right is for the borders.",
+      "name": "tier0.5.quest44.name",
+      "description": "tier0.5.quest44.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -66367,7 +66233,7 @@
     {
       "questID": 730,
       "name": "Bio Fuels",
-      "description": "You are using steam, creosote, and possibly oil plus their by-products to generate Power. It\u0027s time to start with bio diesel. You can use wheat, sugarcane, apples, saplings or fish.\n\nBe sure you have a managed Forestry farm, Steve\u0027s Cart Farm, IC2 Crop Sticks with a harvester, or a lot of fish catchers because you need plenty of biomaterials for constant biodiesel production.\n\nHint: Hazelnut is the ultimative source for biodiesel.",
+      "description": "You are using steam, creosote, and possibly oil plus their by-products to generate Power. It\u0027s time to start with bio diesel. You can use wheat, sugarcane, apples or saplings.\n\nBe sure you have a managed Forestry farm, Steve\u0027s Cart Farm or IC2 Crop Sticks with a harvester because you need plenty of biomaterials for constant biogas production.\n\nHint: Hazelnut is the ultimative source for biodiesel.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -66724,7 +66590,7 @@
     {
       "questID": 734,
       "name": "Way One: IC 2 Fluid Canner",
-      "description": "The first way you get biomass out of bio chaff is to use the IC2 Fluid Canner. One bucket of water and one bio chaff gives one bucket of biomass. In HV Tier you can use the pyrolyze oven to do it in a more efficient way.",
+      "description": "The first way you get biomass out of bio chaff is to use the IC2 Fluid Canner. One bucket of water and one bio chaff give one bucket of biomass. In HV Tier you can use the pyrolyze oven to do it in a more efficient way.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -66902,7 +66768,7 @@
     {
       "questID": 736,
       "name": "Fermented Biomass",
-      "description": "With the MV fermenter you can produce fermented biomass. This is the base product to make methane, ethanol and methanol.\nWhen you reach HV tier there\u0027s a more efficient way to process it - the distillation tower multiblock.",
+      "description": "With the MV fermenter you can produce fermented biomass. This is the base product to make methane, ethanol and methanol.\nWhen you reach HV tier there\u0027s a more efficient way to process it; the distillation tower multiblock.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -67012,7 +66878,7 @@
     {
       "questID": 737,
       "name": "Can u eat those? ",
-      "description": "No you can\u0027t eat them but you can add them to your routed pipes. Without chips routed pipes can\u0027t do anything on their own, chips also have a GUI to configure them wich can be opened by right clicking. \nThere are 8 types of chips:\n\n-Item extractor chip can be used to send items from its inventory to responder, dynamic responder, terminator and overflow responder chips in a pipe network. \n\n-Item responder chip will request items from the extractor chips in your network wich match the filter configured to the inventory connected to the responder chip. Chips with higher priority value will receive items first until the inventory is full then will be sent to other inventories with valid filters and remaining space.\n\n-Dynamic item responder chip will request items from the extractor chips in your network that match items inside the dynamic item responder connected inventory. This chip has to be in the same interface pipe as the item responder chip in order to work. Priority rules apply here as well. \n\n-Item overflow responder works exactly the same as the item responder chip, however it only accepts items that cannot go to an item responder chip, dynamic item responder chip, or item terminator chip. \n\n-Item terminator chip works as a backup for responder chips.\n\n-Item broadcaster chip will show you the inventory connected to the routed request pipe on the pipe network and can be used to retrieve items from it. They can also extract from the side you configure. \n\n-Item stock keeper chip will constantly check the network for items and pull them to its pipe. If the chip is set to pull when empty, it will only pull if the inventory next to it is empty, otherwise it will pull when there are less items in the inventory than configured in the chip.\n\n-Item crafting chips craft things. \n\n-Item crafting extension chips are placed inside the item crafting chips. Make sure you randomize the id.",
+      "description": "No you can\u0027t eat them but you can add them to your routed pipes. Without chips routed pipes can\u0027t do anything on their own, chips also have a GUI to configure them wich can be opened by right clicking. \nThere are 8 types of chips:\n\n-Item extractor chip can be used to send items from its inventory to responder, dynamic responder, terminator and overflow responder chips in a pipe network. \n\n-Item responder chip will request items from the extractor chips in your network wich match the filter configured to the inventory connected to the responder chip. Chips with higher priority value will receive items first until the inventory is full then will be sent to other inventories with valid filters and remaining space.\n\n-Dynamic item responder chip will request items from the extractor chips in your network that match items inside the dynamic item responder connected inventory. This chip has to be in the same interface pipe as the item responder chip in order to work. Priority rules apply here as well. \n\n-Item overflow responder works exactly the same as the item responder chip, however it only accepts items that cannot go to an item responder chip, dynamic item responder chip, or item terminator chip. \n\n-Item terminator chip works as a backup for responder chips.\n\n-Item broadcaster chip will show you the inventory connected to the routed request pipe on the pipe network and can be used to retrieve items from it. They can also extract for wich side you configure them. \n\n-Item stock keeper chip will constantly check the network for items and pull them to its pipe. If the chip is set to pull when empty, it will only pull if the inventory next to it is empty, otherwise it will pull when there are less items in the inventory than configured in the chip.\n\n-Item crafting chips craft things. \n\n-Item crafting extension chips are placed inside the item crafting chips. Make sure you randomize the id.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -67152,7 +67018,7 @@
     {
       "questID": 738,
       "name": "Routed Pipes",
-      "description": "There are six types of routed pipes: \n\n-Junction pipe is used to form an intersection that will allow other routed pipes to communicate. \n\n-Interface pipe will connect to an inventory allowing you to extract or insert items, chips can be used to control the logic. \n\n-Request pipe will allow requesting only specific items to be send through pipes.\n\n-Firewall pipe can control which items can pass through them.",
+      "description": "There are six types of routed pipes: \n\n-Junction pipe is used to form an intersection that will allow other routed pipes to communicate. \n\n-Interface pipe will connect to an inventory allowing you to extract or insert items, chips can be used to control the logic. \n\n-Request pipe will allow requesting only specific items to be send through pipes.\n\n-Firewall pipe can control wich items can pass through them.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -67258,8 +67124,8 @@
     },
     {
       "questID": 739,
-      "name": "Ghetto ME System",
-      "description": "Now that you are familiar with the mod it\u0027s time to organize items in your base a bit. These are the things you need in order to get a basic extract/insert system.\n\nFirst of all you will need a drawer controller. You can pick it from here or craft it yourself and place it down. Next to it add as much drawers as you want, and make sure they are touching each other or the controller.\n\nThe next step is to connect a routed interface pipe to your drawer controller. Take the item responder chip and configure it to filter mode: blacklist (this will allow you to get any items from your system) and add the chip to the routed interface pipe by right clicking on it. Don\u0027t forget the dynamic item responder.\n\nIn order to allow your system to be able to see items you need to add the item broadcast chip TO THE SAME ROUTED INTERFACE PIPE WHICH IS CONNECTED TO THE DRAWER CONTROLLER.\n\nThe last step is to connect a routed request pipe IN THE SAME NETWORK AS THE ROUTED INTERFACE PIPE and right click it to access the GUI. You can only extract items from it. In order to insert items simply right click them on the drawer controller. \n\nYou can find more complex tutorials on youtube for autocrafting.",
+      "name": "Ghetto Me System",
+      "description": "Now that you are familiar with the mod it\u0027s time to organize items in your base a bit. These are the things you need in order to get a basic extract/insert system.\n\nFirst of all you will need a drawer controller. You can pick it from here or craft it yourself and place it down. Next to it add as much drawers as you want, and make sure they are touching each other or the controller.\n\nThe next step is to connect a routed interface pipe to your drawer controller. Take the item responder chip and configure it to filter mode: blacklist (this will allow you to get any items from your system) and add the chip to the routed interface pipe by right clicking on it. Don\u0027t forget the dynamic item responder.\n\nIn order to allow your system to be able to see items you need to add the item broadcast chip TO THE SAME ROUTED INTERFACE PIPE WICH IS CONNECTED TO THE DRAWER CONTROLLER.\n\nThe last step is to connect a routed request pipe IN THE SAME NETWORK AS THE ROUTED INTERFACE PIPE and right click it to acess the GUI. You can only extract items from it. In order to insert items simply right click them on the drawer controller. \n\nYou can find more complex tutorials on youtube for autocrafting.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -67557,8 +67423,8 @@
     },
     {
       "questID": 741,
-      "name": "Tool Forge",
-      "description": "Finally you get your first alumite. Now it\u0027s time to craft a tool forge for making bigger Tinkers tools. ",
+      "name": "tier1.quest44.name",
+      "description": "tier1.quest44.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -67667,8 +67533,8 @@
     },
     {
       "questID": 742,
-      "name": "One Block mining is so Old School",
-      "description": "By making a steel hammer you are now able to mine a shaft of 3x3 blocks. Be careful in the Nether or you could be boiled in lava very quickly.",
+      "name": "tier1.quest53.name",
+      "description": "tier1.quest53.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -67801,7 +67667,7 @@
                   "Modifiers:4": 0
                 },
                 "display:10": {
-                  "Name:8": "Steel Hammer"
+                  "Name:8": "ï¿½fSteel Hammer"
                 }
               }
             }
@@ -67845,8 +67711,8 @@
     },
     {
       "questID": 743,
-      "name": "Cutting a Tree log by log is so Old School",
-      "description": "By making a steel lumber axe you are now able to cut down the entire tree in one hit. Don\u0027t forget your backpack when you are cutting a sacred oak tree down.",
+      "name": "tier1.quest52.name",
+      "description": "tier1.quest52.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -67976,7 +67842,7 @@
                   "Modifiers:4": 0
                 },
                 "display:10": {
-                  "Name:8": "Steel Lumber Axe"
+                  "Name:8": "ï¿½fSteel Lumber Axe"
                 }
               }
             }
@@ -68020,8 +67886,8 @@
     },
     {
       "questID": 744,
-      "name": "Mining Dirt Block by Block is so Old School",
-      "description": "By making a steel excavator you are now able to mine dirt in a 3x3 area. Don\u0027t destroy your whole garden.",
+      "name": "tier1.quest43.name",
+      "description": "tier1.quest43.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -68151,7 +68017,7 @@
                   "Modifiers:4": 0
                 },
                 "display:10": {
-                  "Name:8": "Steel Excavator"
+                  "Name:8": "ï¿½fSteel Excavator"
                 }
               }
             }
@@ -68195,8 +68061,8 @@
     },
     {
       "questID": 745,
-      "name": "Glue",
-      "description": "If you centrifuge sticky resin, you get some glue. Glue is very useful in the creation of good circuit boards.",
+      "name": "tier2.quest63.name",
+      "description": "tier2.quest63.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -68300,7 +68166,7 @@
     {
       "questID": 746,
       "name": "Silicon",
-      "description": "Due to the chip production, silicon becomes a more important material. You can centrifuge it out of fullers earth, asbestos or redstone dust. The electric blast furnace is needed to make ingots. One ingot requires a temperature of 1687 K for 84 seconds at 120 EU/t.",
+      "description": "Due to the chip production silicon becomes a more important material. You can centrifuge it out of fullers earth, asbestos or redstone dust. The electric blast furnace is needed to make ingots. One ingot requires a temperature of 1687 K for 84 seconds at 120 EU/t.",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -68404,8 +68270,8 @@
     },
     {
       "questID": 747,
-      "name": "Diode",
-      "description": "Good circuits need diodes. There are two ways to craft them. Using a silicon wafer together with some fine tin wire or gallium arsenide. Molten glass is also needed.",
+      "name": "tier2.quest66.name",
+      "description": "tier2.quest66.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -68517,8 +68383,8 @@
     },
     {
       "questID": 748,
-      "name": "Empty Circuit Board",
-      "description": "Good circuit boards require wooden pulp and refined glue to make phenolic circuit boards. By adding gold wire you can craft a good circuit board.",
+      "name": "tier2.quest64.name",
+      "description": "tier2.quest64.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -68763,7 +68629,7 @@
     {
       "questID": 750,
       "name": "Molten Plastic",
-      "description": "Molten polyethylene can be made in a chemical reactor using ethylene, compressed air cells or oxygen - using oxygen gives a 50% boost. Use a mold for making plates in a fluid solidifier to make plastic sheets.",
+      "description": "Molten polyethylene can be made in a chemical reactor using ethylen, compressed air cells or oxygen. Use a mold for making plates in a fluid solidifier to make plastic sheets.",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -69216,8 +69082,8 @@
     },
     {
       "questID": 755,
-      "name": "Better than Duct Tape",
-      "description": "A soldering iron tool to remove the \"burned out circuits\" message is better than duct tape. \nThe soldering iron requires one soldering material item and 10,000 EU. Valid soldering materials are fine wires, rods, and ingots made from either tin, lead, or soldering alloy. The soldering iron will consume the first such material it finds in the player\u0027s inventory.\n\nFor the other problems other tools are necessary.\n\nPossible problems                  Tool to fix\n\"Pipe is loose.\"                        Wrench\n\"Screws are missing.\"             Screwdriver \n\"Something is stuck.\"               Soft mallet \n\"Platings are dented.\"              Hammer \n\"Circuitry burned out.\"          Soldering Iron \n\"That doesn\u0027t belong there.\"     Crowbar",
+      "name": "multiblock.goals.quest19.name",
+      "description": "multiblock.goals.quest19.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -69307,8 +69173,8 @@
     },
     {
       "questID": 756,
-      "name": "Less Power loss",
-      "description": "When you reach MV tier you can make your own duct tape in case you have to move your multiblock machines around. Duct tape will fix all maintenance problems in any multiblock machine.",
+      "name": "multiblock.goals.quest27.name",
+      "description": "multiblock.goals.quest27.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -69440,7 +69306,7 @@
     {
       "questID": 757,
       "name": "Ruby Electrolyzing",
-      "description": "Ruby is a good source for electrolyzing to get chrome and aluminium.  Your new MV electrolyzer gives you access to a lot of new recipes. Once you get low on Ruby, you can centrifuge Redstone to get more.",
+      "description": "Ruby is a good source for electrolyzing to get chrome and aluminium.  Your new MV electrolyzer gives you access to a lot of new recipes.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -69614,7 +69480,7 @@
     {
       "questID": 759,
       "name": "Molten Polyethylene",
-      "description": "Polyethylene is made out of ethylene in a chemical reactor.\nTip: Right-clicking an empty cell on a fluid tank will fill the cell with fluid from that tank. \nTip: If you want to extract multiples of 144 into a portable tank, you can use a smeltery faucet. Whack it on and back off, and it will send exactly 144.",
+      "description": "Polyethylene is made out of ethylene in a chemical reactor.\nTip: Right-clicking an empty cell on a fluid tank will fill the cell with fluid from that tank. ",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -69834,8 +69700,8 @@
     },
     {
       "questID": 761,
-      "name": "Powderbarrels",
-      "description": "Powderbarrels are twice as good as dynamite in the implosion compressor. Craft one stack.",
+      "name": "multiblock.goals.quest34.name",
+      "description": "multiblock.goals.quest34.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -69944,8 +69810,8 @@
     },
     {
       "questID": 762,
-      "name": "TNT",
-      "description": "TNT is much more powerful than the powderbarrel but much harder to craft. There are LV and HV ways to craft. At LV you need heavy or light fuel to make some toluene which can be solidified to gelled toluene. Alternatively you can use sugar and plastic dust in a chemical reactor to make toluene more efficiently. Mix it with sulfuric acid to make TNT.\n\nThe HV way requires an oil cracking unit to make all kinds of cracked fuel or cracked naphta and a distillation tower to extract toluene from that.",
+      "name": "multiblock.goals.quest35.name",
+      "description": "multiblock.goals.quest35.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -70072,8 +69938,8 @@
     },
     {
       "questID": 763,
-      "name": "iTNT",
-      "description": "Industrial TNT is the HV variant of TNT. It explodes with more power, yet does not destroy blocks when it explodes.",
+      "name": "multiblock.goals.quest41.name",
+      "description": "multiblock.goals.quest41.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -70206,8 +70072,8 @@
     },
     {
       "questID": 764,
-      "name": "Dynamite",
-      "description": "Dynamite is the most basic explosive you can use in the implosion compressor.\nMix some paper, string and glyceryl trinitrate in a chemical reactor to get dynamite.",
+      "name": "multiblock.goals.quest40.name",
+      "description": "multiblock.goals.quest40.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -70325,8 +70191,8 @@
     },
     {
       "questID": 765,
-      "name": "Time to drill!",
-      "description": "Pumps are nice but you\u0027re going to reach a point where you will want MOOOOOOOOOOOOORE oil. This multiblock will help with that but you will need to search for oil using a seismic prospector. You can find raw, light and heavy oil. There\u0027s also a chance to find natural gas.\n\nHigher tiers of power will drill faster. You need to upgrade the energy hatch corresponding to the power tier. ",
+      "name": "multiblock.goals.quest25.name",
+      "description": "multiblock.goals.quest25.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -70469,8 +70335,8 @@
     },
     {
       "questID": 766,
-      "name": "Let\u0027s get it crackin!",
-      "description": "Cracking oil will result in better by-products in the distillation tower. It is a smart idea to get this multiblock since you are going to need TONS of industrial TNT for advanced tier rockets. \n\nIf you add steam the amout of EU/t will be reduced by 50% and if you add hydrogen the output will be increased by 30%.\n\nHint: Only GT/Railcraft steam can used no ic2 steam.",
+      "name": "multiblock.goals.quest36.name",
+      "description": "multiblock.goals.quest36.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -70576,16 +70442,10 @@
               "Damage": 30001
             },
             {
-              "id": "IC2:itemFluidCell",
+              "id": "IC2:itemCellEmpty",
               "Count": 64,
               "OreDict": "",
-              "Damage": 0,
-              "tag": {
-                "Fluid:10": {
-                  "FluidName:8": "steam",
-                  "Amount:4": 1000
-                }
-              }
+              "Damage": 14
             }
           ],
           "rewardID": "bq_standard:choice"
@@ -70609,8 +70469,8 @@
     },
     {
       "questID": 767,
-      "name": "Analyzing the soil",
-      "description": "To determine which kind of oil or gas there is in the chunk you need to scan the soil by right clicking a Seismic Prospector with 8 dynamite, 4 TNT, 2 industrial TNT or 1 glyceryl. Then use a data stick to extract the data by right clicking on it after the animation has finished.\nNow you need to add the analyzed data stick to a scanner. Then place it in the bottom right slot of the printer and add 3 paper in the top left slot and make sure you have atleast 144 mb squid ink in it. (Only gregtech machines will work)\n\nAfter the process is done take the printed page and combine it with a piece of leather in an assembling machine filled with at least 20 mb of refined glue. Don\u0027t assemble more than one book at time.\n\nTADA now you have a book with info about the chunk you scanned.",
+      "name": "multiblock.goals.quest6.name",
+      "description": "multiblock.goals.quest6.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -70686,8 +70546,8 @@
     },
     {
       "questID": 768,
-      "name": "You smell like a distillery!",
-      "description": "This bad boy will tremendously boost the by-products of your cracked fuel or pyrolyse oven. This way you can make industrial TNT, polyethylene, polytetrafluoroethylene and other plastics more efficiently. \n\nYou will also need this for your automated setups.",
+      "name": "multiblock.goals.quest30.name",
+      "description": "multiblock.goals.quest30.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -70823,7 +70683,7 @@
     {
       "questID": 769,
       "name": "Playing with dust",
-      "description": "This machine will help you turn dust into crystals which you will need for high tier recipes. ",
+      "description": "This machine will help you turn dust into crystals wich you will need for high tier recipes. ",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -70982,8 +70842,8 @@
     },
     {
       "questID": 771,
-      "name": "Dust to crystals",
-      "description": "Use the autoclave to crystallize your dust. You can make raw carbon mesh out of carbon dust.",
+      "name": "tier2.quest38.name",
+      "description": "tier2.quest38.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -71131,7 +70991,7 @@
     {
       "questID": 773,
       "name": "Way one: Raw carbon mesh",
-      "description": "This way of making carbon requires autoclaving 4 carbon dust. You can use polyethylene which gives you only 1 raw carbon fibre at LV tier, polytetrafluoroethylene gives you 2 at MV Tier or go for the best way: molten epoxid which yields 4 at HV Tier.  ",
+      "description": "This way of making carbon requires autoclaveing 4 carbon dust. You can use polyethylene wich gives you only 1 raw carbon fibre at LV tier, polytetrafluoroethylene gives you 2 at MV Tier or go for the best way: molten epoxid which yields 4 at HV Tier.  ",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -71236,7 +71096,7 @@
     {
       "questID": 774,
       "name": "Way two: Bio Organic Mesh",
-      "description": "If want to save the ecosystem you can autoclave 16 plantballs to get raw bio fiber with the following liquids:\n\n-Biomass 33% chance\n-Methanol 50% chance\n-Fuel 90% chance\n-Nitro-diesel 100% chance\n\nHowever, making carbon plates this way will require an electric blast furnace.",
+      "description": "If you like to save the ecosystem you can autoclave 16 plantballs to get raw bio fiber with the following liquids:\n\n-Biomass 33% chance\n-Methanol 50% chance\n-Fuel 90% chance\n-Nitro-diesel 100% chance\n\nHowever, making carbon plates this way will require an electric blast furnace.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -71341,7 +71201,7 @@
     {
       "questID": 775,
       "name": "Carbon parts",
-      "description": "These are the first parts you will need for your beloved nano armor.",
+      "description": "Those are the first parts you will need for your beloved nano armor.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -71458,7 +71318,7 @@
     {
       "questID": 776,
       "name": "Seeing things brighter",
-      "description": "The nano helmet is a bit special. It will provide you with night vision as long as you have energy!  Don\u0027t turn it on in bright areas or you\u0027ll be blinded!",
+      "description": "The nano helmet is a bit special. It will provide you with night vision as long as you have energy! ",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -71912,8 +71772,8 @@
     },
     {
       "questID": 781,
-      "name": "Still not enough charcoal?",
-      "description": "This oven is the best way to get charcoal and creosote (x50 faster than Railcraft\u0027s coke oven) and other byproducts. You will need tons of bronze, iron and steel to build it, but it\u0027s worth it. Finally, it will be possible to dismantle the charcoal pit.\nWith Cupronickel coils the oven is a bit slower. Each coil tier speeds up the charcoal production.",
+      "name": "multiblock.goals.quest32.name",
+      "description": "multiblock.goals.quest32.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -72124,8 +71984,8 @@
     },
     {
       "questID": 783,
-      "name": "We need big toys",
-      "description": "All your little turbines take up too much space? Are you running out of water? It is time to solve these problems. This large turbine can help you produce a tremendous amount of energy. It will also distill water for you, so you can use the same water again inside your large boiler.  Don\u0027t forget to make a rotor for the turbine. At the initial stage the most suitable materials for the rotor are: vanadium steel (it has a very high durability, but slowly produces energy), cobalt (good combination of durability and performance) and ultimet (has higher efficiency, durability and performance). Make sure you provide the optimal flow of steam using a fluid regulator. Don\u0027t exceed your dynamo hatch\u0027s EU rating, or it will explode!",
+      "name": "multiblock.goals.quest18.name",
+      "description": "multiblock.goals.quest18.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -72248,8 +72108,8 @@
     },
     {
       "questID": 784,
-      "name": "It\u0027s time to get more steam",
-      "description": "As soon as you have the ability to store energy in large quantities, it would be necessary to have a way to generate energy in large quantities. You need a large bronze boiler. But in order to make this boiler, you will need a mountain of bronze. This boiler produces 800 liters of steam per tick. This is enough to run 10 basic steam turbines.\n\nThe large boiler can use either water or distilled water. Water is consumed at a rate of 1L of water per 150L of steam.\n\nTo make a large boiler you must make a 3x3x5 structure with Bronze Pipe Casings in the center of the middle 3 levels. The lowest level must contain at least 1 or 2 input hatches, 1 or 2 input buses, 3 or 4 fireboxes, 1 muffler, and one maintenance hatch. The lowest level can not contain any plated bricks. All hatches, buses, and mufflers must have their back side touching a firebox. The output hatch can be placed on any of the upper 4 levels.",
+      "name": "multiblock.goals.quest9.name",
+      "description": "multiblock.goals.quest9.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -72463,7 +72323,7 @@
           "requiredItems": [
             {
               "id": "gregtech:gt.metaitem.01",
-              "Count": 12,
+              "Count": 16,
               "OreDict": "",
               "Damage": 32717
             }
@@ -72514,8 +72374,8 @@
     },
     {
       "questID": 786,
-      "name": "Steam is never enough",
-      "description": "Now you can make advanced circuits, which means it\u0027s time to build a large steel boiler. This boiler is one and a half times more efficient than a bronze one, and that means we need 5 more steam turbines. Don\u0027t forget to monitor the water level!",
+      "name": "multiblock.goals.quest17.name",
+      "description": "multiblock.goals.quest17.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -72636,8 +72496,8 @@
     },
     {
       "questID": 787,
-      "name": "Moooooore steam",
-      "description": "Stock up on titanium, it will be fun. A large titanium boiler produces 1600 litres of steam per tick. For this amount you need to choose the right rotors for your turbines. For example, 2 normal cobalt rotors will be just right. Optimal flow for such rotor is 800 liters per tick. Make a fluid regulator in the assembler to control the flow rate. If you have more than one boiler, you will need to make calculations in order to select the appropriate rotors. Make sure your dynamo hatch is capable of accepting all the EU, or it will explode!",
+      "name": "multiblock.goals.quest26.name",
+      "description": "multiblock.goals.quest26.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -72731,8 +72591,8 @@
     },
     {
       "questID": 788,
-      "name": "Even more steam? Are you sure?",
-      "description": "This boiler is the most efficient source of steam. It allows you to produce as much as 2000 litres of steam per tick. If you need more, then build a dual or even quad boiler.",
+      "name": "multiblock.goals.quest31.name",
+      "description": "multiblock.goals.quest31.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -73581,7 +73441,7 @@
     {
       "questID": 796,
       "name": "Sensor lens",
-      "description": "The night vision goggles need special sensor lenses to work.",
+      "description": "The nightvision goggles need special sensor lenses to work.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -73704,7 +73564,7 @@
     {
       "questID": 797,
       "name": "Advanced Heat Exchanger",
-      "description": "The night vision goggles need advanced heat exchangers to work.",
+      "description": "The nightvision goggles need advanced heat exchangers to work.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -74779,13 +74639,13 @@
       ],
       "preRequisites": [
         789,
-        1406
+        176
       ]
     },
     {
       "questID": 806,
       "name": "Lapotron Crystal",
-      "description": "With your new HV mixer you can make lapotron dust. Place it in an autoclave to make some raw lapotron crystals. With an EV assembler and advanced circuits you can make lapotron crystals which store up to 10 million EU.\n\nHint: Nei shows only ic2 advanced circuits in recipe but all advanced circuits works.",
+      "description": "With your new HV mixer you can make lapotron dust. Place it in an autoclave to make some raw lapotron crystals. With an HV assembler and advanced circuits you can make some lapotron crystals wich store up to 10 million EU.\n\nHint: Nei shows only ic2 advanced circuits in recipe but all advanced circuits works.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -74835,7 +74695,7 @@
           "requiredItems": [
             {
               "id": "IC2:itemPartCircuitAdv",
-              "Count": 8,
+              "Count": 2,
               "OreDict": "circuitAdvanced",
               "Damage": 0
             },
@@ -74914,7 +74774,7 @@
     {
       "questID": 807,
       "name": "Quantum Crystal",
-      "description": "For your quantum armor you need some quantum crystals. Place a lapotron crystal in your precision laser to get a quantum crystal ",
+      "description": "For you quantum armor you need some quantum crystals. Place a lapotron crystal in your precision laser to get a quantum crystal ",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -75006,7 +74866,7 @@
         }
       ],
       "preRequisites": [
-        1407
+        806
       ]
     },
     {
@@ -75829,7 +75689,7 @@
     },
     {
       "questID": 814,
-      "name": "Rocket Fins",
+      "name": "Rocket Fines",
       "description": "Every rocket needs a few rocket fins.",
       "isMain": true,
       "isSilent": false,
@@ -76068,7 +75928,7 @@
     {
       "questID": 816,
       "name": "Moon Lander",
-      "description": "The Moon lander is requiered for a soft landing.\nYou will need an additional frequency module for hearing things on planets and a second seat for a Moon buggy you may build later.",
+      "description": "The Moon lander is requiered for a soft landing.\nYou will need an additional frequency module for hearing some things on planets and a second seat for a Moon buggy you may build later.",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -76314,7 +76174,7 @@
     {
       "questID": 818,
       "name": "Frequency Module",
-      "description": "The frequency Module will help you hear sounds properly while in space (it\u0027s also used with the telemetry unit so that your buddies can keep track of you from your base, if you are playing with friends). You need it in your inventory and in the Moon lander.",
+      "description": "The frequency Module will help you hear sounds properly while in space (it\u0027s also used with the telemetry unit so that your buddies can keep track of you from your base, if you are playing with friends). You need it in you inventory and in the Moon lander.",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -76450,8 +76310,8 @@
     },
     {
       "questID": 819,
-      "name": "Small Fuel Canister",
-      "description": "Every rocket needs fuel storage canisters. For the tier 1 rocket you need to craft two of them.",
+      "name": "Small Fuel Cannister",
+      "description": "Every rocket needs fuel storage cannisters. For the tier 1 rocket you need to craft two of them.",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -76969,7 +76829,7 @@
     {
       "questID": 823,
       "name": "Oxygen Mask",
-      "description": "The oxygen mask is part of the system used to breathe on planets without oxygen, the others being oxygen gear and oxygen tanks.",
+      "description": "The oxygen mask is part of the oxygen system used to breathe on planets without oxygen, the others being oxygen gear and oxygen tanks.",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -77074,7 +76934,7 @@
     {
       "questID": 824,
       "name": "Oxygen Tanks",
-      "description": "The Light oxygen tank is an oxygen storage tank that can hold up to 90 units of air. It is used to provide a portable source of oxygen while in areas that do not have an oxygen source of their own.\n\nUsage:\nUp to two oxygen tanks can be worn at a time. To wear any type of oxygen tank, open your inventory and click on the Galacticraft tab at the top of the menu. Here you will see the available spots for your various types of equipment. Simply place your tank(s) in one of the slots with a grey picture of an oxygen tank. Other types of oxygen tanks are the medium oxygen tank, which holds twice the amount of oxygen as a light tank, and the heavy oxygen tank, which holds three times the amount of a light tank. I recommend making the medium tanks and using the light tanks as spares to return to base.",
+      "description": "The Light oxygen tank is an oxygen storage tank that can hold up to 90 units of air. It is used to provide a portable source of oxygen while in areas that do not have an oxygen source of their own.\n\nUsage:\nUp to two oxygen tanks can be worn at a time. To wear any type of oxygen tank, open your inventory and click on the Galacticraft tab at the top of the menu. Here you will see the available spots for your various types of equipment. Simply place your tank(s) in one of the slots with a grey picture of an oxygen tank. Other types of oxygen tanks are the medium oxygen tank, which holds twice the amount of oxygen as a light tank, and the heavy oxygen tank, which holds three times the amount of a light tank.",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -77190,8 +77050,8 @@
     },
     {
       "questID": 825,
-      "name": "Copper Ore",
-      "description": "Can be found between y levels 5 and 60 either as \"Copper Ore\" or \"Chalcopyrite\". Most of the time you\u0027ll find it together with  \"Iron\" and \"Pyrite\".\n\nHint:\nTo see where a special ore can be found click the raw ore in NEI and it will show you more details. Works with small ores too.",
+      "name": "tier0.5.quest56.name",
+      "description": "tier0.5.quest56.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -77241,10 +77101,10 @@
         {
           "choices": [
             {
-              "id": "TConstruct:oreBerries",
-              "Count": 10,
+              "id": "TConstruct:ore.berries.one",
+              "Count": 5,
               "OreDict": "",
-              "Damage": 2
+              "Damage": 10
             },
             {
               "id": "harvestcraft:footlongItem",
@@ -77279,8 +77139,8 @@
     },
     {
       "questID": 826,
-      "name": "Iron Ore",
-      "description": "With iron tools, you are able to mine most of the Overworld ores. I think you already found iron or magnetite. So bring me some ores and make some iron ingots out of them.\n\nHint:\nTo see where a special ore can be found click the raw ore in nei and it will show you more details. Works with small ores too.",
+      "name": "tier0.5.quest58.name",
+      "description": "tier0.5.quest58.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -77348,10 +77208,10 @@
         {
           "choices": [
             {
-              "id": "TConstruct:oreBerries",
-              "Count": 10,
+              "id": "TConstruct:ore.berries.one",
+              "Count": 5,
               "OreDict": "",
-              "Damage": 0
+              "Damage": 8
             },
             {
               "id": "minecraft:lava_bucket",
@@ -77387,7 +77247,7 @@
     {
       "questID": 827,
       "name": "Rocket Fuel",
-      "description": "For every flight the rocket needs some fuel. So refine some fuel and fill some fuel canisters. ",
+      "description": "For every flight the rocket needs some fuel. So refine some fuel and fill some fuel cannisters. ",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -77908,7 +77768,7 @@
     {
       "questID": 831,
       "name": "Advanced Wafers",
-      "description": "The advanced wafer is used for more advanced machines such as the advanced solar panel or the Avaritia dire crafting table. It is also used in the creation of a space station.",
+      "description": "The advanced wafer is used for more advanced machines such as the advanced solar panel or the avaritia dire crafting table. It is also used in the creation of a space station.",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -78317,8 +78177,8 @@
     },
     {
       "questID": 834,
-      "name": "Circuit Boards",
-      "description": "For every circuit you need a basic circuit board. Craft a coated circuit board and use copper wire to finish it.",
+      "name": "tier1.quest76.name",
+      "description": "tier1.quest76.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -78458,8 +78318,8 @@
     },
     {
       "questID": 835,
-      "name": "Resistor",
-      "description": "Every basic circuit needs two resistors to work",
+      "name": "tier1.quest78.name",
+      "description": "tier1.quest78.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -78560,8 +78420,8 @@
     },
     {
       "questID": 836,
-      "name": "Gallium Arsenide",
-      "description": "The diode requires gallium arsenide and you may be wondering how to get gallium or arsenic this early in the game.\nYou can get gallium out of crushed zinc ore by using a thermal centrifuge. You can find the small zinc ores in the Overworld or the in the Nether at Y Level 80 - 210. To get crushed ore, you may need a Tinker\u0027s Construct tool with the Luck (Fortune) enchant on it. Sphalerite is another source of gallium. Finally you can breed zinc bees, which have a small chance at gallium combs.\nYou can get arsenic from realgar small ores in the Nether at Y level 5 - 85. Centrifuge the dusts in a centrifuge. Another source is tinkers construct cobalt ore in the nether.\nYou need to level up your obsidian level tool or use a alumite tool.\n\nAnother nice way to get gallium and arsenic is with XP buckets in a crafting grid.\n\nMix those two dusts in a mixer to get gallium arsenic dust.\n\nIn the nether it is maybe easier to use a GT miner to get all the ores you need.",
+      "name": "tier2.quest67.name",
+      "description": "tier2.quest67.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -78671,7 +78531,7 @@
     {
       "questID": 837,
       "name": "ILC and RAM",
-      "description": "Advanced circuits need integrated logic circuits and random access memory chips.\nYou can get those by cutting the ILC and RAM wafers.",
+      "description": "Advanced circuits need itegrated logic circuits and random access memory chips.\nYou can get those by cutting the ILC and RAM wafers.",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -78781,7 +78641,7 @@
     {
       "questID": 838,
       "name": "Advanced Circuits",
-      "description": "For the next tier we need advanced circuits. To make an advanced circuit, you need good integrated circuits, RAM, an integrated logic circuit, and transistors.",
+      "description": "For the next tier we need advanced circuits. To make an advanced circuit, you need good integrated circuits, RAM, an ILC and transistors.",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -78915,7 +78775,7 @@
     {
       "questID": 839,
       "name": "Handle tiny piles like a K1ng",
-      "description": "Don\u0027t you hate having to manually compress all those tiny piles ? Well, let me show you how to automate that. A combination of typefilter, chest buffer (or super buffer in HV) and packager frees you from that annoying task. The chestbuffer can hold up to 9 stacks of tiny piles and the super buffer can hold 256 stacks of tiny dusts, which is more than enough. You can set its mode with a screwdriver on the output side. Set it to 9 to export 9 tiny piles at a time and let the packager compress these into regular dusts.",
+      "description": "Don\u0027t you hate to manually compress all those tiny piles ? Well, let me show you how to automate that. A combination of typefilter, chest buffer (or super buffer in HV) and packager frees you from that annoying task. The chestbuffer can hold up to 9 stacks of tiny piles and the super buffer can hold 256 stacks of tiny dusts, which is more than enough. You can set its mode with a screwdriver on the output side. Set it to 9 to export 9 tiny piles at a time and let the packager compress these into regular dusts.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -79039,8 +78899,8 @@
     },
     {
       "questID": 840,
-      "name": "Butane and Propane",
-      "description": "You can distill a lot of different gases out of your \"refinery gases\".\nMethane, butane, propane, helium and ethane.\n\nHint:\nRefinery gas is not the best source for Propane and Butane. Better refine those out of naphtha.",
+      "name": "tier2.quest77.name",
+      "description": "tier2.quest77.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -79511,7 +79371,7 @@
     {
       "questID": 845,
       "name": "Bio Diesel Fuel",
-      "description": "With ethanol or methanol and seed oil or fish oil you can make bio diesel. Burn value is 256,000 EU per cell. Diesel and bio diesel are needed for cetane-boosted diesel.\n\nYou get some glycerol as by-product. Save it so you can make glyceryl trinitrate for your dynamite or for your future epoxid production.",
+      "description": "With ethanol or methanol and seedoil or fish oil you can make bio diesel. Burn value is 256,000 EU per cell. Diesel and bio diesel are needed for cetane-boosted diesel.\n\nYou get some glycerol as by-product. Save it so you can make glyceryl trinitrate for your dynamite or for your future epoxid production.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -79603,7 +79463,7 @@
     {
       "questID": 846,
       "name": "O like Oxygen",
-      "description": "Oxygen can be made in different ways. Centrifuge some brown and yellow lemonite dust, or electrolyze it out of water or various other oxygen-rich elements.",
+      "description": "Oxygen can be made in different ways. Centrifuge some brown an yellow lemonite dust, or electrolyze it out of water or various other oxygen-rich elements.",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -79784,7 +79644,7 @@
     {
       "questID": 848,
       "name": "Seed Oil",
-      "description": "To make some bio diesel you need seed oil or fish oil and mix that with ethanol or methanol. Seeds give seed oil and fish produce fish oil when placed in a fluid extractor.",
+      "description": "To make some bio diesel you need seed oil or fish oil and mix that with ethanol or methanol. Seeds give seed oil when placed in a fluid extractor.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -81079,7 +80939,7 @@
     {
       "questID": 860,
       "name": "Titanium finaly",
-      "description": "Rutile, chlorine and carbon dust makes Titaniumtetrachloride. Combining this with Magnesium in an HV EBF will give you hot Titanium ingots. Freeze those and you will get your first titanium.\nOn the Moon if you are lucky you can find pure Titanium ore.",
+      "description": "Rutile, chlorine and carbon dust makes Titaniumtetrachloride. Combining this with Magnesium in an HV EBF will give you hot Titanium ingots. Freeze those and you will get your first titanium.\nOn Mars you can find pure Titanium ore.",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -81235,8 +81095,7 @@
       ],
       "preRequisites": [
         78,
-        1012,
-        1424
+        1012
       ]
     },
     {
@@ -81256,7 +81115,7 @@
         "complete": "random.levelup",
         "update": "random.levelup"
       },
-      "logic": "OR",
+      "logic": "AND",
       "taskLogic": "AND",
       "icon": {
         "id": "gregtech:gt.metaitem.01",
@@ -81319,14 +81178,14 @@
         }
       ],
       "preRequisites": [
-        1244,
-        1415
+        79,
+        1244
       ]
     },
     {
       "questID": 862,
-      "name": "Your first bow",
-      "description": "Since vanilla bows are only craftable in the assembling machine and mobs do not drop them very often you have to make a Tinkers bow. Wood would be the best material for now.  So craft the bow limbs out of wood and the bow string out of strings. The arrow that has the most durability is bone, so craft the stick out of bone. It is much lighter but less durable than a regular arrow. Use a flint tip to make it repairable with flint.\n\nYou can repair your bow the same way as all the other Tinkers tools. Arrows can be regained by repairing them or picking them up from the floor.",
+      "name": "tier0.5.quest51.name",
+      "description": "tier0.5.quest51.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -81629,8 +81488,8 @@
     },
     {
       "questID": 863,
-      "name": "Bronze javelin",
-      "description": "The bronze javelin is a bit expensive and has only 7 throws, yet it is a good mid-range weapon. With one bronze ingot you can replenish your stack of javelins.",
+      "name": "tier0.5.quest37.name",
+      "description": "tier0.5.quest37.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -81817,8 +81676,8 @@
     },
     {
       "questID": 864,
-      "name": "Your first flint throwing knife",
-      "description": "Is the bone bow too expensive for your taste? Then make a flint throwing knife instead. You need flint and a stick to get 12 knives. The durability and the attack damage are very low but it still helps with killing mobs from a safe distance.",
+      "name": "tier0.5.quest55.name",
+      "description": "tier0.5.quest55.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -82011,8 +81870,8 @@
     },
     {
       "questID": 865,
-      "name": "Monster trap",
-      "description": "If you\u0027re lucky you spawned in a sand or rainforest biome and find some quicksand. Collect a stack of the stuff, dig a small ditch and fill it with the quicksand to protect your \"dirt base\" home. Just don\u0027t fall in!",
+      "name": "tier0.quest13.name",
+      "description": "tier0.quest13.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -82182,8 +82041,8 @@
     },
     {
       "questID": 867,
-      "name": "Lapis, Lazurite, Sodalite, Calcite",
-      "description": "In order to make your bricked blast furnace you need to find a lapis vine containing calcite.\nYou can find the vein in the overworld or the Twilight Forest at Y 20-50.",
+      "name": "tier1.quest21.name",
+      "description": "tier1.quest21.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -82294,8 +82153,8 @@
     },
     {
       "questID": 868,
-      "name": "Gypsum",
-      "description": "To make bricks for the blast furnace you need concrete and gypsum. Gypsum can be found in a vein together with basaltic and granitic mineral sand, and fullers earth. Y 50-60 and only in the overworld.",
+      "name": "tier1.quest22.name",
+      "description": "tier1.quest22.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -82412,8 +82271,8 @@
     },
     {
       "questID": 869,
-      "name": "Sifting Machine",
-      "description": "You need flawless or exquisite diamonds, emeralds, rubies or other gems? Well then it\u0027s time for you to make a Sifting Machine.",
+      "name": "tier2.quest23.name",
+      "description": "tier2.quest23.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -82495,8 +82354,8 @@
     },
     {
       "questID": 870,
-      "name": "Smelt all the things...",
-      "description": "Smelting up to nine items at once? With a bit of steel you can make a railcraft Steam Oven. 2x2x2\n\nHint: All furnace recipes work just fine, but you cannot use it to make charcoal from wood.",
+      "name": "multiblock.goals.quest14.name",
+      "description": "multiblock.goals.quest14.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -82593,8 +82452,8 @@
     },
     {
       "questID": 871,
-      "name": "Molds, molds, molds",
-      "description": "After you can make steel and have a tinkers smelter you have to make molds. Molds can be used in the alloy smelter and the fluid solidifier. You need them to make vacuum tubes, ingots, gears and more.",
+      "name": "tier1.quest62.name",
+      "description": "tier1.quest62.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -82922,8 +82781,8 @@
     },
     {
       "questID": 875,
-      "name": "Slime Island Journey",
-      "description": "Rubber trees are not the only source for raw rubber. Go and find a slimy island high in the sky. Slime balls and slime leaves give raw rubber too.\nMake some slime tree farms beside your rubber farm.",
+      "name": "tier1.quest51.name",
+      "description": "tier1.quest51.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -83040,8 +82899,8 @@
     },
     {
       "questID": 876,
-      "name": "LCR Large Chemical Reactor",
-      "description": "Chemical recipes without using cells? Build a LCR a large chemical reactor and use only fluids for your chemical recipes.\nYou need also:\nMaintenance Hatch 1;\n(EV) Energy Hatch 1;\nInput Bus  1;\nOutput Bus  1;\nInput Hatch  5;\nOutput Hatch  5.",
+      "name": "Iron berry bush",
+      "description": "Farming your iron (berries) instead of finding iron ores.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -83058,49 +82917,22 @@
       "logic": "AND",
       "taskLogic": "AND",
       "icon": {
-        "id": "gregtech:gt.blockmachines",
+        "id": "TConstruct:ore.berries.one",
         "Count": 1,
         "OreDict": "",
-        "Damage": 1169
+        "Damage": 8
       },
       "visibility": "UNLOCKED",
       "tasks": [
         {
           "partialMatch": true,
           "ignoreNBT": false,
-          "consume": false,
+          "consume": true,
           "autoConsume": false,
           "requiredItems": [
             {
-              "id": "gregtech:gt.blockmachines",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 1169
-            },
-            {
-              "id": "gregtech:gt.blockcasings8",
-              "Count": 8,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        },
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.blockcasings8",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 1
-            },
-            {
-              "id": "gregtech:gt.blockcasings5",
-              "Count": 1,
+              "id": "dreamcraft:item.CoinFarmer",
+              "Count": 10,
               "OreDict": "",
               "Damage": 0
             }
@@ -83110,56 +82942,25 @@
       ],
       "rewards": [
         {
-          "choices": [
-            {
-              "id": "gregtech:gt.blockmachines",
-              "Count": 16,
-              "OreDict": "",
-              "Damage": 5683
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 16,
-              "OreDict": "",
-              "Damage": 32408
-            },
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 6,
-              "tag": {
-                "ench:9": [
-                  {
-                    "lvl:4": 3,
-                    "id:4": 35
-                  }
-                ]
-              }
-            }
-          ],
-          "rewardID": "bq_standard:choice"
-        },
-        {
           "rewards": [
             {
-              "id": "dreamcraft:item.CoinTechnicianII",
-              "Count": 1,
+              "id": "TConstruct:ore.berries.one",
+              "Count": 5,
               "OreDict": "",
-              "Damage": 0
+              "Damage": 8
             }
           ],
           "rewardID": "bq_standard:item"
         }
       ],
       "preRequisites": [
-        160
+        76
       ]
     },
     {
       "questID": 877,
-      "name": "Scepter with 75 vis capacity",
-      "description": "A scepter is crafted from a wand core, a primal charm, three wand caps, a twilight forest monster mob drop, and some screws. Any sort of core or cap may be used, but the caps must match each other. A scepter cannot hold a focus, but holds 150% as much vis as a wand with the same core, and gives an additional 5% discount for costs, beyond any discounts from its caps or the user\u0027s worn equipment. ",
+      "name": "Gold berry bush",
+      "description": "Farming your gold (berries) instead of finding gold ore.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -83176,73 +82977,24 @@
       "logic": "AND",
       "taskLogic": "AND",
       "icon": {
-        "id": "Thaumcraft:WandCasting",
+        "id": "TConstruct:ore.berries.one",
         "Count": 1,
         "OreDict": "",
-        "Damage": 4,
-        "tag": {
-          "cap:8": "iron",
-          "rod:8": "greatwood",
-          "sceptre:4": 1
-        }
+        "Damage": 9
       },
       "visibility": "UNLOCKED",
       "tasks": [
         {
           "partialMatch": true,
           "ignoreNBT": false,
-          "consume": false,
+          "consume": true,
           "autoConsume": false,
           "requiredItems": [
             {
-              "id": "Thaumcraft:ItemResource",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 15
-            },
-            {
-              "id": "Thaumcraft:WandRod",
-              "Count": 1,
+              "id": "dreamcraft:item.CoinFarmer",
+              "Count": 15,
               "OreDict": "",
               "Damage": 0
-            },
-            {
-              "id": "dreamcraft:item.LichBone",
-              "Count": 2,
-              "OreDict": "",
-              "Damage": 0
-            },
-            {
-              "id": "dreamcraft:item.IronWandCap",
-              "Count": 3,
-              "OreDict": "",
-              "Damage": 0
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 2,
-              "OreDict": "",
-              "Damage": 27306
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        },
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "Thaumcraft:WandCasting",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 4,
-              "tag": {
-                "cap:8": "iron",
-                "rod:8": "greatwood",
-                "sceptre:4": 1
-              }
             }
           ],
           "taskID": "bq_standard:retrieval"
@@ -83252,40 +83004,23 @@
         {
           "rewards": [
             {
-              "id": "Thaumcraft:ItemResource",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 15
-            },
-            {
-              "id": "Thaumcraft:ItemLootBag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 1
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinDarkWizardI",
+              "id": "TConstruct:ore.berries.one",
               "Count": 5,
               "OreDict": "",
-              "Damage": 0
+              "Damage": 9
             }
           ],
           "rewardID": "bq_standard:item"
         }
       ],
       "preRequisites": [
-        879
+        88
       ]
     },
     {
       "questID": 878,
-      "name": "Magic Staff Core",
-      "description": "A staff requires an extra step for crafting: Two (matching) wand cores must be combined with a primal charm, and crystal clusters to produce a staff core. (While the recipes are all similar, each type of staff core requires a separate research topic to be learned.) ",
+      "name": "Copper berry bush",
+      "description": "Farming your copper (berries) instead of finding copper ore.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -83302,81 +83037,24 @@
       "logic": "AND",
       "taskLogic": "AND",
       "icon": {
-        "id": "Thaumcraft:WandRod",
+        "id": "TConstruct:ore.berries.one",
         "Count": 1,
         "OreDict": "",
-        "Damage": 50
+        "Damage": 10
       },
       "visibility": "UNLOCKED",
       "tasks": [
         {
           "partialMatch": true,
           "ignoreNBT": false,
-          "consume": false,
+          "consume": true,
           "autoConsume": false,
           "requiredItems": [
             {
-              "id": "Thaumcraft:ItemResource",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 15
-            },
-            {
-              "id": "Thaumcraft:blockCrystal",
-              "Count": 1,
+              "id": "dreamcraft:item.CoinFarmer",
+              "Count": 10,
               "OreDict": "",
               "Damage": 0
-            },
-            {
-              "id": "Thaumcraft:blockCrystal",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 1
-            },
-            {
-              "id": "Thaumcraft:blockCrystal",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 2
-            },
-            {
-              "id": "Thaumcraft:blockCrystal",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 3
-            },
-            {
-              "id": "Thaumcraft:blockCrystal",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 4
-            },
-            {
-              "id": "Thaumcraft:blockCrystal",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 5
-            },
-            {
-              "id": "Thaumcraft:WandRod",
-              "Count": 2,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        },
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "Thaumcraft:WandRod",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 50
             }
           ],
           "taskID": "bq_standard:retrieval"
@@ -83386,40 +83064,23 @@
         {
           "rewards": [
             {
-              "id": "Thaumcraft:WandRod",
-              "Count": 2,
-              "OreDict": "",
-              "Damage": 0
-            },
-            {
-              "id": "Thaumcraft:ItemLootBag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 1
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinDarkWizardI",
+              "id": "TConstruct:ore.berries.one",
               "Count": 5,
               "OreDict": "",
-              "Damage": 0
+              "Damage": 10
             }
           ],
           "rewardID": "bq_standard:item"
         }
       ],
       "preRequisites": [
-        263
+        76
       ]
     },
     {
       "questID": 879,
-      "name": "Primal Charm",
-      "description": "With your new 50 vis wand you are able to make a Scepter which holds up to 75 vis.\nFirst you need some primal charms which cost 50 vis to craft.",
+      "name": "Aluminum berry bush",
+      "description": "Farming your Aluminum (berries) instead of looking for aluminum gravel.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -83436,81 +83097,24 @@
       "logic": "AND",
       "taskLogic": "AND",
       "icon": {
-        "id": "Thaumcraft:ItemResource",
+        "id": "TConstruct:ore.berries.two",
         "Count": 1,
         "OreDict": "",
-        "Damage": 15
+        "Damage": 8
       },
       "visibility": "UNLOCKED",
       "tasks": [
         {
           "partialMatch": true,
           "ignoreNBT": false,
-          "consume": false,
+          "consume": true,
           "autoConsume": false,
           "requiredItems": [
             {
-              "id": "Thaumcraft:blockCrystal",
-              "Count": 1,
+              "id": "dreamcraft:item.CoinFarmer",
+              "Count": 20,
               "OreDict": "",
               "Damage": 0
-            },
-            {
-              "id": "Thaumcraft:blockCrystal",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 1
-            },
-            {
-              "id": "Thaumcraft:blockCrystal",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 2
-            },
-            {
-              "id": "Thaumcraft:blockCrystal",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 3
-            },
-            {
-              "id": "Thaumcraft:blockCrystal",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 4
-            },
-            {
-              "id": "Thaumcraft:blockCrystal",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 5
-            },
-            {
-              "id": "Thaumcraft:blockCrystal",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 6
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 2,
-              "OreDict": "",
-              "Damage": 28351
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        },
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "Thaumcraft:ItemResource",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 15
             }
           ],
           "taskID": "bq_standard:retrieval"
@@ -83520,34 +83124,17 @@
         {
           "rewards": [
             {
-              "id": "Thaumcraft:blockCrystal",
-              "Count": 4,
-              "OreDict": "",
-              "Damage": 6
-            },
-            {
-              "id": "Thaumcraft:ItemLootBag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 1
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinDarkWizardI",
+              "id": "TConstruct:ore.berries.two",
               "Count": 5,
               "OreDict": "",
-              "Damage": 0
+              "Damage": 8
             }
           ],
           "rewardID": "bq_standard:item"
         }
       ],
       "preRequisites": [
-        265
+        89
       ]
     },
     {
@@ -83972,8 +83559,8 @@
     },
     {
       "questID": 887,
-      "name": "A Wizard\u0027s Staff has a Knob on the End",
-      "description": "Join the core with two wand caps, a twilight forest mob drop, and screws just as for making a wand. A staff cannot be used for crafting, but holds 250% as much vis as a corresponding wand. It can even serve as a backup weapon for melee. While it cannot receive weapon enchantments, its damage is decent, and it does not take damage with use (no durability bar).",
+      "name": "Tin berry bush",
+      "description": "Farming your tin (berries) instead of finding tin ore.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -83990,91 +83577,24 @@
       "logic": "AND",
       "taskLogic": "AND",
       "icon": {
-        "id": "Thaumcraft:WandCasting",
+        "id": "TConstruct:ore.berries.one",
         "Count": 1,
         "OreDict": "",
-        "Damage": 8,
-        "tag": {
-          "cap:8": "iron",
-          "rod:8": "greatwood_staff",
-          "AttributeModifiers:9": [
-            {
-              "UUIDMost:4": -3801225194067177672,
-              "UUIDLeast:4": -6586624321849018929,
-              "Amount:6": 6.0,
-              "AttributeName:8": "generic.attackDamage",
-              "Operation:4": 0,
-              "Name:8": "Weapon modifier"
-            }
-          ]
-        }
+        "Damage": 11
       },
       "visibility": "UNLOCKED",
       "tasks": [
         {
           "partialMatch": true,
           "ignoreNBT": false,
-          "consume": false,
+          "consume": true,
           "autoConsume": false,
           "requiredItems": [
             {
-              "id": "Thaumcraft:WandRod",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 50
-            },
-            {
-              "id": "dreamcraft:item.IronWandCap",
-              "Count": 2,
+              "id": "dreamcraft:item.CoinFarmer",
+              "Count": 10,
               "OreDict": "",
               "Damage": 0
-            },
-            {
-              "id": "TwilightForest:item.fieryBlood",
-              "Count": 2,
-              "OreDict": "",
-              "Damage": 0
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 4,
-              "OreDict": "",
-              "Damage": 27028
-            },
-            {
-              "id": "Thaumcraft:ItemResource",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 15
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        },
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "Thaumcraft:WandCasting",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 8,
-              "tag": {
-                "cap:8": "iron",
-                "rod:8": "greatwood_staff",
-                "AttributeModifiers:9": [
-                  {
-                    "UUIDMost:4": -3801225194067177672,
-                    "UUIDLeast:4": -6586624321849018929,
-                    "Amount:6": 6.0,
-                    "AttributeName:8": "generic.attackDamage",
-                    "Operation:4": 0,
-                    "Name:8": "Weapon modifier"
-                  }
-                ]
-              }
             }
           ],
           "taskID": "bq_standard:retrieval"
@@ -84084,34 +83604,17 @@
         {
           "rewards": [
             {
-              "id": "Thaumcraft:WandRod",
-              "Count": 2,
+              "id": "TConstruct:ore.berries.one",
+              "Count": 5,
               "OreDict": "",
-              "Damage": 2
-            },
-            {
-              "id": "Thaumcraft:ItemLootBag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 2
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinDarkWizardII",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
+              "Damage": 11
             }
           ],
           "rewardID": "bq_standard:item"
         }
       ],
       "preRequisites": [
-        878
+        76
       ]
     },
     {
@@ -84236,8 +83739,8 @@
     },
     {
       "questID": 890,
-      "name": "Better Tank... ULV Tank",
-      "description": "Next step is to store 32 buckets in a tank. The ULV Tank from Gt++ needs steel plates, iron plates, tin plates, a clay pipe, and a water bucket.",
+      "name": "tier1.quest79.name",
+      "description": "tier1.quest79.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -84311,8 +83814,8 @@
     },
     {
       "questID": 891,
-      "name": "Better Tank... LV Tank",
-      "description": "Next step is to store 64 buckets in a tank. The LV Tank from Gt++ needs steel plates, iron plates, bronze plates, a huge clay pipe, and an LV pump.",
+      "name": "tier2.quest37.name",
+      "description": "tier2.quest37.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -84389,8 +83892,8 @@
     },
     {
       "questID": 892,
-      "name": "Better Tank... MV Tank",
-      "description": "Next step is to store 128 buckets in a tank. The MV Tank from Gt++ needs steel plates, darksteel plates, bronze plates, a bronze pipe and an LV pump.",
+      "name": "tier2.quest46.name",
+      "description": "tier2.quest46.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -84545,7 +84048,7 @@
     {
       "questID": 894,
       "name": "Better Tank... HV Tank",
-      "description": "Next step is to store 256 buckets in a tank. The HV Tank from Gt++ needs aluminium plates, darksteel plates, vacuum tubes, a steel pipe, and an MV pump.",
+      "description": "Next step is to store 256 buckets in a tank. The HV Tank from Gt++ needs aluminium plates, darksteel plates, vacuum tubes a  steel pipe and an MV pump.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -84853,8 +84356,8 @@
     },
     {
       "questID": 898,
-      "name": "Simple Ore Washer",
-      "description": "Too lazy to make an ore washer, yet bored with your non-automatable cauldron? Then the simple washer is the machine for you! It work reasonably fast and uses 8eu max - make sure you don\u0027t provide too much voltage! Ok, so you do not get any byproducts, but who cares!",
+      "name": "tier2.quest39.name",
+      "description": "tier2.quest39.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -85898,7 +85401,7 @@
     {
       "questID": 911,
       "name": "Time to kill (Spiders)",
-      "description": "Eeeek! Wall climbing monsters, gross! Slay them. Quickly! Watch out for the witch spiders, they can give as good as they get.",
+      "description": "Eeeek! Wall climbing monsters, gross! Slay them. Quickly!",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -86312,7 +85815,7 @@
     {
       "questID": 916,
       "name": "Time to kill (Wither)",
-      "description": "After collecting a couple of those wither skeleton heads, you feel like you could use some more action. So why not kill a wither? You\u0027ll need a ton of nether stars anyway...\n\nKill it twice for something nice.",
+      "description": "After collecting a couple of those wither skeleton heads, you feel like you could need some more action. So why not kill a wither? You\u0027ll need a ton of nether stars anyway...",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -86406,7 +85909,7 @@
     {
       "questID": 917,
       "name": "Secret: The trade for life",
-      "description": "You have been busy my friend. I have something for you. Give me your hearts, and I will magically enhance them so you can actually use them.",
+      "description": "You have been busy my friend. I have something for you. Give me your hearts, and I will magically enhance them so you can actually use those.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -86477,7 +85980,7 @@
     {
       "questID": 918,
       "name": "Skeleton: Evolved",
-      "description": "In order to advance to a higher tier and reach Mars, Deimos and Phobos, you need to make yourself a better rocket. There are rumors that an Evolved Skeleton hiding out on the Moon has schematics of such a device.",
+      "description": "In order to advance to a higher tier and reach Mars, Deimos and Phobos, you need to make yourself a better rocket. There are rumors, that an evolved skeleton has schematics of such a device.",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -88049,7 +87552,7 @@
     {
       "questID": 926,
       "name": "Blood Altar Tier 3",
-      "description": "To make your altar more powerful you need to upgrade it. You need to build pillars two block high out of blood-soaked thaumium block and on top one block of glowstone blocks on each pillar.",
+      "description": "To make your altar more powerfull you need to upgrade it. You need to build pillars two block high out of blood-soaked thaumium block and on top one block of glowstone blocks on each pillar.",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -88142,7 +87645,7 @@
     {
       "questID": 927,
       "name": "Blood Altar Tier 4",
-      "description": "If you want to make tier 4 slates you need a Tier 4 altar. This can be made like the tier 3 altar with pillars out of void-blood-soaked stones four blocks high and a blood brick on top of the pillars.",
+      "description": "If you want to make tier 4 slates you need a Tier 4 altar. This can be made like the tier 3 altar with pillars out of void-blood-soaked stones four blocks high and a blood brick on top the pillars.",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -88318,7 +87821,7 @@
     {
       "questID": 929,
       "name": "Blood Altar Tier 6",
-      "description": "The highest tier of the blood altar is tier 6. You need pillars of blood-soaked ichorium 7 blocks high and on top the crystal cluster blocks made out of demon soul shards.",
+      "description": "The highest tier of the blood altar is tier 6. You need pillars of blood-soaked ichorium 7 blocks high and on top the crystal cluster blocks out of demon souls shards.",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -88437,8 +87940,8 @@
     },
     {
       "questID": 930,
-      "name": "Auto Mining",
-      "description": "A miner in LV age? Wow! This nifty machine will find ores for you. Place up to two stacks of mining pipes in the right slots. This machine needs 8 EU/t to work. The miner searches for ores in a 16 block radius. Don\u0027t forget to cover it up!",
+      "name": "tier2.quest54.name",
+      "description": "tier2.quest54.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -88515,7 +88018,7 @@
     {
       "questID": 931,
       "name": "Auto Mining MV",
-      "description": "The MV miner will find ores for you faster than the LV miner. Place up to two stacks of mining pipes in the right slots. This miner need 128 eu to work. The Miner searches ores in a 24 block radius and works two times faster than the LV variant.",
+      "description": "The MV miner will find ores for you better than the LV miner. Place up to two stacks of mining pipes in the right slots. This miner need 128 eu to work. The Miner searches ores in a 24 block radius and works two times faster than the LV variant.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -88592,7 +88095,7 @@
     {
       "questID": 932,
       "name": "Auto Mining HV",
-      "description": "The HV miner will find ores for you faster than the MV miner. Place up to two stacks of mining pipes in the right slots. This miner needs 512 eu to work. The Miner searches ores in a 32 block radius (two chunks) and works two times faster than the MV variant.",
+      "description": "The HV miner will find ores fore you better than the MV miner. Place up to two stacks of mining pipes in the right slots. This miner needs 512 eu to work. The Miner searches ores in a 32 block radius (two chuncks) and works two times faster than the MV variant.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -88670,7 +88173,7 @@
     {
       "questID": 933,
       "name": "Power of the Sun",
-      "description": "Now its time to invest in some renewable energy. Let\u0027s start with solar panels. The basic one only gives 1 EU/t. Most gt machine can use them as covers. Be sure to put a glass layer above them in case it rains while you swap panels.",
+      "description": "Now its time to investigate in some regenerative engery. Let\u0027s start with solarpanels. The basic one only gives 1 EU/t. Most gt machine can use them as covers.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -88798,7 +88301,7 @@
     {
       "questID": 934,
       "name": "Power of the Sun 8V",
-      "description": "The next solar panel you can make is the ULV one. It generates 8 EU/t. Most gt machines can use them as covers.",
+      "description": "The next solarpanel you can make is the ULV one. It generates 8 EU/t. Most gt machine can use them as covers.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -89030,7 +88533,7 @@
     {
       "questID": 936,
       "name": "Power of the Sun at LV Level",
-      "description": "The next solar panel you can make is the LV one. It generates 32 EU/t max. Most gt machines can use them as covers. First you need to produce a sunnarium item by using 10 million eu power.",
+      "description": "The next solarpanel you can make is the LV one. It generates 32 EU/t max. Most gt machine can use them as covers. First you need to produce a sunnarium item by using 10 million eu power.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -89278,7 +88781,7 @@
     {
       "questID": 938,
       "name": "Automated Sticky Resin Farmer",
-      "description": "If you are tired of crafting tons of tree taps, how about a machine that uses power but never breaks? Let\u0027s craft an electric tree tap!",
+      "description": "If you are tired of crafting tons of tree taps, how about a machine that uses power but never breaks? Let\u0027s craft an electric tree tap.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -89406,7 +88909,7 @@
     {
       "questID": 939,
       "name": "Automated Farmer",
-      "description": "Your hoe must be getting worn out by now. Why not craft an electric one which never breaks?",
+      "description": "Your hoe must be getting worn out by now. Why not craft an electric one which never breaks.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -89530,8 +89033,8 @@
     },
     {
       "questID": 940,
-      "name": "Cleanroom",
-      "description": "If you want to make more advanced circuits you\u0027ll need a cleanroom. The cleanroom is a multiblock between 3x4x3 and 15x15x15 (WxHxD) blocks. Besides plascrete blocks for all edges you\u0027ll need a controller in the top center, filter machine casings for the rest of the top except edges, an energy and maintenance hatch , a reinforced door and three machine hulls. For now you can use MV tier.\n\nLet\u0027s build a 5x5x5 room. Expanding it vertically is easy to do, or you can make it wider and longer, as long as both X and Z match and are odd.",
+      "name": "multiblock.goals.quest42.name",
+      "description": "multiblock.goals.quest42.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -89661,8 +89164,8 @@
     },
     {
       "questID": 941,
-      "name": "A very useful Scanner",
-      "description": "The portable scanner is a tool capable of showing advanced information about almost every block in the game. \nIn order to function, the tool needs to be charged first. It can hold up to 400k EU and accept 128 EU/t or less. This is MV tier.\n\nIt can scan crops, which shows more information than the cropnalyzer does. The crop, which was scanned in the world, will drop a scanned seed bag.\nIt can scan machines from GregTech, giving information about current progress, the stored energy, efficiency, problems and CPU-load - be sure to check the full chat window for additional details.\nFor any block in the game it scans, it gives information about its ID, Metadata, position in the world and hardness value.\nIt also gives information about pollution level in the chunk the scanned block belongs to.\nIn addition it shows when the cleanroom has reached its 100% efficieny level.",
+      "name": "multiblock.goals.quest43.name",
+      "description": "multiblock.goals.quest43.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -89738,8 +89241,8 @@
     },
     {
       "questID": 942,
-      "name": "The Plunger",
-      "description": "The Plunger is used to clear liquids from pipes. It can also be used on a machine to remove up to 1000mb of fluid from its internal buffer. You don\u0027t have to wrench your machine and replace it. It can be crafted from a rod of the desired material and rubber sheets. \n\nHint: Plunger deals 2.75 - 7.75 damage depending on the materials used.",
+      "name": "tier1.quest66.name",
+      "description": "tier1.quest66.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -89917,7 +89420,7 @@
     {
       "questID": 944,
       "name": "Super Tank I",
-      "description": "Next step is to store 4000 buckets in a tank. The super tank I needs a hermetic casing made with aluminium plates and PTFE pipe. The tank need 4 circuits, a pulsating iron plate and an MV pump. Now you can store the same amount of fluids a steel 5x5 Railcraft tank contains in a single block.",
+      "description": "Next step is to store 40000 buckets in a tank. The super tank needs a hermetic casing made with aluminium plates and PTFE pipe. The tank need 4 circuits, a pulsatingiron  plates and an MV pump. Now you can store the exact amount of fluids a steel 5x5 steel tank contains.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -90009,8 +89512,8 @@
     },
     {
       "questID": 945,
-      "name": "Chad - A better way to make Paper",
-      "description": "Making paper out of wood pulp and water can be tedious and difficult. Why not macerate some sugar cane down to chads and press it with two stone plates to paper? Later on you can use the chemical bath for a even better ratio.",
+      "name": "tier0.5.quest5.name",
+      "description": "tier0.5.quest5.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -90137,8 +89640,8 @@
     },
     {
       "questID": 946,
-      "name": "Bamboo fence",
-      "description": "Maybe you are lucky and start off in a bamboo forest.\nBamboo is a very useful tree since it grows really fast and when you place bamboo sticks they will grow and protect your base behind a 3 block tall wall.\nAlternatively, you can also use Berry Bushes.",
+      "name": "tier0.quest7.name",
+      "description": "tier0.quest7.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -90214,8 +89717,8 @@
     },
     {
       "questID": 947,
-      "name": "Punji Sticks",
-      "description": "A early game protection moat can be made out of punji sticks. It hurts all mobs/players and additionally gives a slowness II potion effect. Make a trench around your base and put the punji sticks inside.",
+      "name": "tier0.5.quest39.name",
+      "description": "tier0.5.quest39.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -90310,8 +89813,8 @@
     },
     {
       "questID": 948,
-      "name": "Better than iron",
-      "description": "Wrought Iron will become more important very soon when you have a bit of steel and are able to build high pressure steam machines. The material is much harder than iron and you can make better tools with it too.\nTo make wrought iron you need a furnace to smelt iron ingots down to wrought iron nuggets. With the compressor you can compress the nuggets to ingots.\n\nHint:\nCrushed or purified oredust can be smelt to iron nuggets directly. Later on you can use an arc furnace to make wrought iron ingots directly",
+      "name": "tier1.quest38.name",
+      "description": "tier1.quest38.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -90445,7 +89948,7 @@
     {
       "questID": 949,
       "name": "Garden Bags",
-      "description": "Finding some special \"Pam\u0027s HarvestCraft\" gardens can be very difficult. With your farmer coins you can buy some garden bags.",
+      "description": "Finding some special \"pams harvest craft\" gardens can be very difficult. With your farmer coins you can buy some gardenbags.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -90559,7 +90062,7 @@
         }
       ],
       "preRequisites": [
-        89
+        1191
       ]
     },
     {
@@ -90669,7 +90172,7 @@
     {
       "questID": 952,
       "name": "Base too big? I\u0027ve got a fix for you!",
-      "description": "Keeping a base spread apart for pollution or explosion prevention can really wear you out. Try harvesting some Marble and centrifuging it into Calcite, and mix up some concrete in your Mixer. Next output it into a Fluid Solidifier with a block mold to make concrete blocks. You\u0027ll move faster on top of these blocks. They can even be turned into bricks to prevent unwanted spawns! Hint: 10 buckets of wet mix converts to exactly 160 blocks. Note: Don\u0027t stack blocks more than 1 high or else you might move faster than you\u0027d like. Or do it if you need to really get from point A to point B in a hurry. Also keep your animals off them. These blocks can also be Chiseled into different varieties.",
+      "description": "Keeping a base spread apart for pollution or explosion prevention can really wear you out. Try harvesting some Marble and centrifuging it into Calcite, and mix up some concrete in your Mixer. Next output it into a Fluid Solidifier to make concrete blocks. You\u0027ll move faster on top of these blocks. They can even be turned into bricks to prevent unwanted spawns! Hint: 10 buckets of wet mix converts to exactly 160 blocks. Note: Don\u0027t stack blocks more than 1 high or else you might move faster than you\u0027d like. Or do it if you need to really get from point A to point B in a hurry. Also keep your animals off them.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -90919,8 +90422,8 @@
     },
     {
       "questID": 954,
-      "name": "The \"Water Problems\" are solved",
-      "description": "Entering the HV age you found a way of making a water reservoir which solves the finite water problem. Craft it with some fused quartz glass, HV pumps, and cauldrons.",
+      "name": "multiblock.goals.quest12.name",
+      "description": "multiblock.goals.quest12.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -91895,7 +91398,7 @@
     {
       "questID": 969,
       "name": "Transistors",
-      "description": "Want some transistors? Buy some!",
+      "description": "Want some transistor? Buy some!",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -92800,8 +92303,8 @@
     },
     {
       "questID": 983,
-      "name": "Cetane-Boosted Fuel",
-      "description": "Want some cetane-boosted fuel? Buy some!",
+      "name": "Cetan-Boosted Fuel",
+      "description": "Want some cetan-boosted fuel? Buy some!",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -92933,7 +92436,7 @@
     {
       "questID": 985,
       "name": "Time to kill (Ghast)",
-      "description": "They shoot you with explosive fireballs but they are weak when you hit them or knock the fireballs back with a weapon. Better upgrade your armor with fire and blast protection.",
+      "description": "They shoot you with explosive fireballs but they are weak when you hit them or throw the fireballs back. Better upgrade your armor with fire and blast protection.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -93015,7 +92518,7 @@
     {
       "questID": 986,
       "name": "Is this the End? No the END Dimension",
-      "description": "Your investigation into the pearls has shown you that the source of the disturbance seems to be coming out of the shimmering portals inside strongholds. You feel strangely drawn into its mysterious depths.\n\nHint: throwing Ender Eyes in the air in the Overworld will guide you to the nearest stronghold . From time to time Ender Eyes are destroyed in this process, so make extras.",
+      "description": "Your investigation into the pearls has shown you that the source of the disturbance seems to be coming out of the shimmering portals inside strongholds. You feel strangely drawn into its mysterious depths.\n\nHint: throwing Ender Eyes in the air in the Overworld will guide you to the nearest stronghold . From time to time Ender Eyes are destroyed in this progress.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -93865,7 +93368,7 @@
     {
       "questID": 992,
       "name": "Go find some tropical bees",
-      "description": "Next you will need to find some tropical bees. The hives can be found in Jungle biomes. Be careful as these bees are very aggressive and can poison you. Collect the silky combs and extract some silk wisp from those in order to make some Apiarist\u0027s clothes.\nLooking for pristine Bees.",
+      "description": "Next you will need to find some tropical bees. The hives can be found in Jungle biomes. Be careful as these bees are very agressive and can poison you. Collect the silky combs and extract some silk wisp from those in order to make some Apiarist\u0027s clothes.\nLooking for pristine Bees.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -94037,7 +93540,7 @@
     {
       "questID": 993,
       "name": "Silky combs and Propolis",
-      "description": "Collect silky combs and extract some silk wisp out of it in order to make some Apiarist\u0027s clothes.\nThis can take quite a bit of time.\nUse a GregTech or Forestry Centrifuge to get Silky Propolis.",
+      "description": "Collect silky combs and extract some silk wisp out of it in order to make some Apiarist\u0027s clothes.\nThis can take quite a bit of time.\nUse a Gretech or Forestry Centrifuge to get Silky Propolis.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -96088,7 +95591,7 @@
     {
       "questID": 1003,
       "name": "Power of the Sun at MV Level",
-      "description": "The next solar panel you can make is the MV one. It gives 128 EU/t max. Most GT machines can use them as covers. First you need to produce sunnarium out of 9 smaller sunnarium pieces.",
+      "description": "The next solarpanel you can make is the MV one. It gives 128 EU/t max. Most gt machines can use them as covers. First you need to produce sunnarium out of 9 smaller sunnarium pieces.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -96341,7 +95844,7 @@
     {
       "questID": 1005,
       "name": "Indium",
-      "description": "At EV Level you are able to make Indium for HV Solar Panels. Indium cannot be found in Ore form. It can only be made with an EV chemical reactor.\nFirst you need to make indium out of purified galena and sphalerite ore. Mix in some aluminium to get indium.",
+      "description": "At EV Level you are able to make Indium for HV Solar Panels. Indium can not be found in Ore form. It can only be made with an EV chemical reactor.\nFirst you need to make indium out of purified galena and sphalerite ore. Mix in some aluminium to get indium.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -96400,7 +95903,7 @@
           "requiredItems": [
             {
               "id": "gregtech:gt.metaitem.01",
-              "Count": 36,
+              "Count": 4,
               "OreDict": "",
               "Damage": 2019
             }
@@ -96460,13 +95963,13 @@
         }
       ],
       "preRequisites": [
-        176
+        1242
       ]
     },
     {
       "questID": 1006,
       "name": "Power of the Sun at HV Level",
-      "description": "The next solar panel you can make is the HV one. It generates 512 EU/t max. Most GregTech machines can use them as covers. First you need to produce enriched sunnarium by mixing irradiated uranium and sunnarium. The Avaritia 9x9 dire crafting table is required to make this panel.",
+      "description": "The next solarpanel you can make is the HV one. It generates 512 EU/t max. Most GregTech machines can use them as covers. First you need to produce enriched sunnarium by mixing irridiant uranium and sunnarium. The Avaritia 9x9 crafting table is required to make this panel.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -96623,7 +96126,7 @@
     {
       "questID": 1007,
       "name": "Power of the Sun 1x1 HV",
-      "description": "Put those 512 eu panels on a block to make them placeable in the world. Use an EV assembler to combine the panel with an HV hull.",
+      "description": "Put those 512 eu panels on a block to make them placeable in the world. Use an MV assembler to combine the panel with an HV hull.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -96726,8 +96229,8 @@
     },
     {
       "questID": 1008,
-      "name": "Books",
-      "description": "Books can be found easily enough in villages or in the roguelike dungeons surface brick house.\nI\u0027m sure they have a recipe too.",
+      "name": "tier1.quest40.name",
+      "description": "tier1.quest40.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -96931,7 +96434,7 @@
     {
       "questID": 1010,
       "name": "Fresh Water and Milk",
-      "description": "Many cooking recipes need milk and water. Crafting it in the crafting table can be very tedious.\nIt is much easier using a Forestry worktable. Drag-click all your buckets into the worktable, and craft them all at once.",
+      "description": "Many cooking recipes need milk and water. Crafting it in the crafting table can be very tedious.\nIt is much easier by using a Forestry worktable. Drag-click all your buckets into the worktable, and craft them all at once.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -97044,7 +96547,7 @@
     {
       "questID": 1011,
       "name": "Find Bauxite",
-      "description": "The main goal when you reach the Moon is to find some bauxite ore to make titanium for the EV machine tier. Some meteoric iron is required for your tier 2 rocket for reaching Mars so be sure to collect a stack from fallen meteors and small ores beneath the surface.\n\nIf you are lucky you will find Titanium veins to make the process much easier.",
+      "description": "The main goal when you reach the Moon is to find some bauxite ore to make titanium for the EV machine tier. Some meteoric iron will help to build your tier 2 rocket for reaching Mars.\n\nIf you are lucky you will find Titanium veins to make the process much easier.",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -97252,7 +96755,7 @@
     {
       "questID": 1013,
       "name": "SMD Circuit components",
-      "description": "Surface-mount devices are more advanced circuits parts. They are needed for high tier circuits and are cheaper to craft than basic capacitors, transitors, diodes and resistors. You need an Advanced Assembler and some molten polyethylene.",
+      "description": "Surface-mount devices are more advanced circuits parts. They are needed for high tier circuits and are cheaper to craft than basic capacitors, transitors, diodes and resistors. You need an Advanced Assembler and some molten polyethylen.",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -97630,7 +97133,7 @@
     {
       "questID": 1016,
       "name": "Integrated Processor",
-      "description": "There are three variants of good circuits. The good electronic circuit, the good integrated circuit and the integrated processor which needs an MV circuit assembling machine. The integrated processor requires a CPU, capacitors, transistors and resistors.\nA cleanroom is needed.",
+      "description": "There are three variants of good circuits. The good electronic circuit, the good integrated circuit and the integrated processor which needs an MV circuit assembling machine to be made. The integrated processor needs a cpu, capacitors, transistors and resistors.\nA cleanroom is needed.",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -97766,7 +97269,7 @@
     {
       "questID": 1017,
       "name": "Processor Assembly",
-      "description": "Another variant of the advanced circuit from IC2 is the processor assembly.\nTwo Integrated Processors are needed in the MV circuit assembler recipe.\nThe recipe is a cleanroom recipe.",
+      "description": "Another variant of the advanced circuit from IC2 is the processing assembly.\nTwo Integrated Processors are needed in the MV circuit assembler recipe.\nThe recipe is a cleanroom recipe.",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -97900,7 +97403,7 @@
     },
     {
       "questID": 1018,
-      "name": "Central Processing Unit",
+      "name": "Central Processing Unit CPU",
       "description": "Integrated Processors need central processing units. You can get these by cutting a ram wafer.\nA cleanroom is needed.",
       "isMain": true,
       "isSilent": false,
@@ -99482,7 +98985,7 @@
     {
       "questID": 1040,
       "name": "Transistors SMD",
-      "description": "Want some SMD transistors? Buy some!",
+      "description": "Want some SMD transistor? Buy some!",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -99542,7 +99045,7 @@
     {
       "questID": 1041,
       "name": "Capacitor SMD",
-      "description": "Want some SMD capacitors? Buy some!",
+      "description": "Want some SMD capacitor? Buy some!",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -99602,7 +99105,7 @@
     {
       "questID": 1042,
       "name": "Plastic Sheet",
-      "description": "Want some Plastic Sheets? Buy some!",
+      "description": "Want some Plastic Sheet? Buy some!",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -100112,7 +99615,7 @@
     {
       "questID": 1050,
       "name": "Bees House",
-      "description": "Want some bee houses? Buy some!",
+      "description": "Want some bee house? Buy some!",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -101250,7 +100753,7 @@
     {
       "questID": 1068,
       "name": "Are you prepared?",
-      "description": "Are you prepared for the Moon?\nA few things will help you to live longer and prevent you from dying on the Moon.\nIf you die on the moon you will be returned to earth without your stuff. Graves are placed at the location where you died.",
+      "description": "Are you prepared for the Moon?\nA few things will help you to live longer and prevent you from dying on the Moon.\nIf you die on the moon you will be retured to earth without your stuff. Graves are placed at the location where you died.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -101389,7 +100892,7 @@
     },
     {
       "questID": 1069,
-      "name": "Oak, Spruce, Birch, Jungle Sapling",
+      "name": "Oak, Spruce, Brich, Jungle Sapling",
       "description": "You spawned in a desert and need Oak or Birch saplings? No problem! For five Forestry Coins you can select which one you want to buy.",
       "isMain": false,
       "isSilent": false,
@@ -102508,7 +102011,7 @@
     {
       "questID": 1081,
       "name": "MV Bending",
-      "description": "This Plate Bending Machine allows you to directly make double, triple or more compressed plates, which might be useful for your first rocket in HV Tier.",
+      "description": "To make dense plates you need an MV Bender.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -102552,10 +102055,10 @@
         {
           "rewards": [
             {
-              "id": "IC2:itemDensePlates",
-              "Count": 8,
+              "id": "gregtech:gt.metaitem.01",
+              "Count": 16,
               "OreDict": "",
-              "Damage": 5
+              "Damage": 11019
             },
             {
               "id": "enhancedlootbags:lootbag",
@@ -102756,8 +102259,8 @@
     },
     {
       "questID": 1084,
-      "name": "Lubricant",
-      "description": "Using lubricant instead of water or distilled water in your cutting machines will increase the output or speed of the machines.\nYou can make lubricant out of oil, seed oil, fish oil or creosote. If you are able to craft a brewery you can use talc and soapstone to get much more lubricant each cycle.",
+      "name": "tier2.quest99.name",
+      "description": "tier2.quest99.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -102834,8 +102337,8 @@
     },
     {
       "questID": 1085,
-      "name": "More Compact Storage",
-      "description": "Now that you are starting to find more and more iron you feel your wood chests are too small to hold all the stuff you found and collected. Now it\u0027s time to upgrade your chests to iron chests. You can just build a new chest or upgrade the wood chest with a wood to iron chest upgrade item.",
+      "name": "tier0.5.quest4.name",
+      "description": "tier0.5.quest4.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -103112,7 +102615,7 @@
             },
             {
               "id": "harvestcraft:onionItem",
-              "Count": 4,
+              "Count": 1,
               "OreDict": "cropOnion",
               "Damage": 0
             },
@@ -103307,8 +102810,8 @@
     },
     {
       "questID": 1089,
-      "name": "Hearty Breakfast",
-      "description": "Let\u0027s now combine all the things together and make a healthy and very good breakfast.\nSome cooked meat, potato cakes, toast, fried egg and a tasty juice provide you with a very nourishing meal.\nYou can use any cooked meat and any fruit juice here.",
+      "name": "Hearty Breakfas",
+      "description": "Let\u0027s now combine all things together and make a healthy and very good breakfast.\nSome cooked meat, potato cakes, toast, fried egg and a tasty juice provide you with a very nourishing meal.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -103364,7 +102867,7 @@
             },
             {
               "id": "harvestcraft:applejuiceItem",
-              "Count": 1,
+              "Count": 64,
               "OreDict": "listAlljuice",
               "Damage": 0
             }
@@ -103436,8 +102939,8 @@
     },
     {
       "questID": 1090,
-      "name": "Try to dry out the Nether",
-      "description": "Pumps can do more than pump oil and water. You can go to the nether and pump lava from the huge lava lakes too.\nDon\u0027t forget to bring some tanks or fluid cells with you. Lava can be centrifuged for gold, silver, tin, copper, and a little tungstate.",
+      "name": "tier2.quest35.name",
+      "description": "tier2.quest35.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -103546,8 +103049,8 @@
     },
     {
       "questID": 1091,
-      "name": "Diamond Tanks... Oh shiny",
-      "description": "After you build a cutting machine you can make some diamond plates for your new 64 buckets single block tank.",
+      "name": "tier2.quest117.name",
+      "description": "tier2.quest117.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -103656,8 +103159,8 @@
     },
     {
       "questID": 1092,
-      "name": "New source of Glowstone",
-      "description": "Find some glowflowers in the Nether and plant them in the Overworld. You will never need to go to the Nether and harvest glowstone again.",
+      "name": "tier2.quest36.name",
+      "description": "tier2.quest36.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -103858,8 +103361,8 @@
     },
     {
       "questID": 1094,
-      "name": "Diamond Chests... Oh shiny",
-      "description": "After you build a cutting machine you can make some diamond plates for your new big diamond chests.",
+      "name": "tier2.quest105.name",
+      "description": "tier2.quest105.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -103962,8 +103465,8 @@
     },
     {
       "questID": 1095,
-      "name": "Even More Compact Storage",
-      "description": "If you found enough gold you can upgrade your chest to make it an even bigger inventory of 9x9. You can just build a new chest or upgrade the iron chest with a wood to gold chest upgrade item. You can use an assembler to make them a little easier.",
+      "name": "tier0.5.quest1.name",
+      "description": "tier0.5.quest1.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -104207,7 +103710,7 @@
     {
       "questID": 1097,
       "name": "Bathing the warp effects away.",
-      "description": "Litmus paper tell you how high you warp level is, but how can you get rid of the nasty warp effects? Bath salt will help you by prohibiting warp effects for a short period. Just throw the salt into a 1x1 water hole and jump inside. You will feel relieved a bit after bathing.",
+      "description": "Litmus paper tell you how high you warp level is, but how can you get rid of the nasty warp effects? Bath salt will help you by prohibiting warp effects for a short period. Just throw the salt intorelieved a 1x1 water hole and jump inside. You will feel relieved a bit after bathing.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -104411,7 +103914,7 @@
     {
       "questID": 1099,
       "name": "Temp warp remover Soap",
-      "description": "This soap is very special. It will remove temporary warp and has a small chance to also remove some normal warp, if you are lucky. Taking a bath first increases your chances.\n\nHint: You need to chisel your tallow block for the recipe to work.",
+      "description": "This soap is very special. It will remove temporary warp and has a small chance to also remove some normal warp, if you are lucky. \n\nHint: You need to chisel your tallow block for the recipe to work.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -104488,7 +103991,7 @@
     {
       "questID": 1100,
       "name": "Enchanting Table 1.0",
-      "description": "Finally with your new wand and 50 stored vis you are able to build your own enchantment table. The recipe can be found on the GTNH Thaumcraft Page",
+      "description": "Finaly with your new wand and 50 stored vis you are able to build your own enchantment table. The recipe can be found on the GTNH Thaumcraft Page",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -104565,7 +104068,7 @@
     {
       "questID": 1101,
       "name": "Division Sigil",
-      "description": "Maybe you found a division sigil in a chest already. You have heard about some ritual to activate it.\n\nYou need an enchantment table, 8 redstone dust, a good sword and an animal you want to sacrifice at night. Catching and holding it with a lasso would be the easiest way.\nPlace your enchantment table on a grass field and surround it with redstone dust.\nPrecisely at midnight place the animal on or near the table and kill it.\nOf course you also need to have your sigil on you.\nBe aware! Your actions will have consequences.",
+      "description": "Maybe you found a division sigil in a chest already. You have heard about some ritual to activate it.\n\nYou need an enchantment table, 8 redstone dust, a good sword and an animal you want to sacrifice at night. Catching and holding it with a lasso would be the easiest way.\nPlace your enchantment table on a grass field and sourround it with redstone dust.\nPrecisely at midnight place the animal on or near the table and kill it.\nOf course you also need to have your sigil on you.\nBe aware! Your actions will have consequences.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -105460,7 +104963,7 @@
     {
       "questID": 1106,
       "name": "Blub blub blub.....",
-      "description": "The brewing stand is really important for brewing the various potions like night vision, healing, haste and jump. Toxic potions or splash potions can be created too. \nWith your basic wand you can create one.\n\nThe recipes can be found on the GTNH page in the Thaumonomicon.",
+      "description": "The brewing stand is really important for brewing the various potion like night vision, healing, haste and jump. Toxic potions or splash potions can be created too. \nWith your basic wand you can create one.\n\nThe recipes can be found on the GTNH page in the Thaumonomicon.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -105560,8 +105063,8 @@
     },
     {
       "questID": 1107,
-      "name": "The Iron Guy",
-      "description": "Do you feel lonely? Need some extra protection in your base? Want to keep the pigmen off your back in the Nether?\nCraft some Iron Golems and the monster problem inside your base will be gone.",
+      "name": "tier1.quest28.name",
+      "description": "tier1.quest28.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -105660,8 +105163,8 @@
     },
     {
       "questID": 1108,
-      "name": "The Cool Guy",
-      "description": "Feeling lonely? Located far away from a smow biome?\nCraft a Snow Golem, and perhaps challenge him to a snow ball fight.",
+      "name": "tier1.quest29.name",
+      "description": "tier1.quest29.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -105761,7 +105264,7 @@
     {
       "questID": 1109,
       "name": "Oh crunchy",
-      "description": "After hours of doing Thaumcraft research you found a way to craft pure tears. Ichorium purifies the nether star which sucks all the warp away. Be careful, as this may have a deadly end.",
+      "description": "After hours of doing Thaumcraft research you found a way to craft pure tears. Ichorium purifies the nether star wich sucks all the warp away. Be careful, as this may have a deadly end.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -106303,7 +105806,7 @@
     {
       "questID": 1115,
       "name": "Go find some tropical bees",
-      "description": "Next you will need to find some tropical bees. The hives can be found in Jungle biomes. Be careful as these bees are very aggressive and can poison you. Collect the silky combs and extract some silk wisp from those in order to make some Apiarist\u0027s clothes.",
+      "description": "Next you will need to find some tropical bees. The hives can be found in Jungle biomes. Be careful as these bees are very agressive and can poison you. Collect the silky combs and extract some silk wisp from those in order to make some Apiarist\u0027s clothes.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -106929,7 +106432,7 @@
     {
       "questID": 1117,
       "name": "Breed some common bees",
-      "description": "To cross breed bees you need two different species of bees. One drone and one princess from different hives (Meadows and Forestry as an example)\nIn an Apiary you can cross breed them to a new species.\n\nCommon Bees produce Honey Combs every 2.2 minutes. Note that production times are an approximation based on the bee\u0027s base production speed and the product\u0027s rarity. They do not reflect actual production time.\n\nLook for pristine bees.\n",
+      "description": "To cross breed bees you need two different species of bees. One drone and one princess from different hives (Meadows and Forestry as an expamle)\nIn an Apiary you can cross breed them to a new species.\n\nCommon Bees produce Honey Combs every 2.2 minutes. Note that production times are an approximation based on the bee\u0027s base production speed and the product\u0027s rarity. They do not reflect actual production time.\n\nLook for pristine bees.\n",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -108273,166 +107776,6 @@
               "Damage": 26
             },
             {
-              "id": "Forestry:beePrincessGE",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0,
-              "tag": {
-                "MaxH:4": 20,
-                "Health:4": 20,
-                "IsAnalyzed:4": 1,
-                "Genome:10": {
-                  "Chromosomes:9": [
-                    {
-                      "UID1:8": "extrabees.species.ocean",
-                      "UID0:8": "extrabees.species.ocean",
-                      "Slot:4": 0
-                    },
-                    {
-                      "UID1:8": "forestry.speedSlowest",
-                      "UID0:8": "forestry.speedSlowest",
-                      "Slot:4": 1
-                    },
-                    {
-                      "UID1:8": "forestry.lifespanShorter",
-                      "UID0:8": "forestry.lifespanShorter",
-                      "Slot:4": 2
-                    },
-                    {
-                      "UID1:8": "forestry.fertilityNormal",
-                      "UID0:8": "forestry.fertilityNormal",
-                      "Slot:4": 3
-                    },
-                    {
-                      "UID1:8": "forestry.toleranceNone",
-                      "UID0:8": "forestry.toleranceNone",
-                      "Slot:4": 4
-                    },
-                    {
-                      "UID1:8": "forestry.boolFalse",
-                      "UID0:8": "forestry.boolFalse",
-                      "Slot:4": 5
-                    },
-                    {
-                      "UID1:8": "forestry.toleranceBoth1",
-                      "UID0:8": "forestry.toleranceBoth1",
-                      "Slot:4": 7
-                    },
-                    {
-                      "UID1:8": "forestry.boolTrue",
-                      "UID0:8": "forestry.boolTrue",
-                      "Slot:4": 8
-                    },
-                    {
-                      "UID1:8": "forestry.boolFalse",
-                      "UID0:8": "forestry.boolFalse",
-                      "Slot:4": 9
-                    },
-                    {
-                      "UID1:8": "extrabees.flower.water",
-                      "UID0:8": "extrabees.flower.water",
-                      "Slot:4": 10
-                    },
-                    {
-                      "UID1:8": "forestry.floweringSlowest",
-                      "UID0:8": "forestry.floweringSlowest",
-                      "Slot:4": 11
-                    },
-                    {
-                      "UID1:8": "forestry.territoryAverage",
-                      "UID0:8": "forestry.territoryAverage",
-                      "Slot:4": 12
-                    },
-                    {
-                      "UID1:8": "extrabees.effect.water",
-                      "UID0:8": "extrabees.effect.water",
-                      "Slot:4": 13
-                    }
-                  ]
-                }
-              }
-            },
-            {
-              "id": "Forestry:beeDroneGE",
-              "Count": 4,
-              "OreDict": "",
-              "Damage": 0,
-              "tag": {
-                "MaxH:4": 20,
-                "Health:4": 20,
-                "IsAnalyzed:4": 1,
-                "Genome:10": {
-                  "Chromosomes:9": [
-                    {
-                      "UID1:8": "extrabees.species.ocean",
-                      "UID0:8": "extrabees.species.ocean",
-                      "Slot:4": 0
-                    },
-                    {
-                      "UID1:8": "forestry.speedSlowest",
-                      "UID0:8": "forestry.speedSlowest",
-                      "Slot:4": 1
-                    },
-                    {
-                      "UID1:8": "forestry.lifespanShorter",
-                      "UID0:8": "forestry.lifespanShorter",
-                      "Slot:4": 2
-                    },
-                    {
-                      "UID1:8": "forestry.fertilityNormal",
-                      "UID0:8": "forestry.fertilityNormal",
-                      "Slot:4": 3
-                    },
-                    {
-                      "UID1:8": "forestry.toleranceNone",
-                      "UID0:8": "forestry.toleranceNone",
-                      "Slot:4": 4
-                    },
-                    {
-                      "UID1:8": "forestry.boolFalse",
-                      "UID0:8": "forestry.boolFalse",
-                      "Slot:4": 5
-                    },
-                    {
-                      "UID1:8": "forestry.toleranceBoth1",
-                      "UID0:8": "forestry.toleranceBoth1",
-                      "Slot:4": 7
-                    },
-                    {
-                      "UID1:8": "forestry.boolTrue",
-                      "UID0:8": "forestry.boolTrue",
-                      "Slot:4": 8
-                    },
-                    {
-                      "UID1:8": "forestry.boolFalse",
-                      "UID0:8": "forestry.boolFalse",
-                      "Slot:4": 9
-                    },
-                    {
-                      "UID1:8": "extrabees.flower.water",
-                      "UID0:8": "extrabees.flower.water",
-                      "Slot:4": 10
-                    },
-                    {
-                      "UID1:8": "forestry.floweringSlowest",
-                      "UID0:8": "forestry.floweringSlowest",
-                      "Slot:4": 11
-                    },
-                    {
-                      "UID1:8": "forestry.territoryAverage",
-                      "UID0:8": "forestry.territoryAverage",
-                      "Slot:4": 12
-                    },
-                    {
-                      "UID1:8": "extrabees.effect.water",
-                      "UID0:8": "extrabees.effect.water",
-                      "Slot:4": 13
-                    }
-                  ]
-                }
-              }
-            },
-            {
               "id": "Forestry:beeCombs",
               "Count": 32,
               "OreDict": "",
@@ -108466,7 +107809,7 @@
     {
       "questID": 1122,
       "name": "Royal Jelly",
-      "description": "Royal jelly is a honey bee secretion that is used in the nutrition of larvae, as well as adult queens. It is only produced by the imperial bee. It\u0027s production can be increased with proven frames or any other kind of frames except for the soul frame. Royal jelly is also useful because it can craft ambrosia, which fills 8 hunger points (4 full food icons) and gives Regeneration I for 40 seconds. Royal jelly is used to craft scented paneling which are required in the creation of alveary blocks.",
+      "description": "Royal jelly is a honey bee secretion that is used in the nutrition of larvae, as well as adult queens. It is only produced by the imperial bee. It\u0027s production can be increased with proven frames or any other kind of frames except for the soul frame. The royal jelly is very useful because it can craft ambrosia, which fills 8 hunger points (4 full food icons) and give Regeneration I for 40 seconds. Royal jelly is also used to craft scented paneling which are required in the creation of alveary blocks.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -108757,8 +108100,8 @@
     },
     {
       "questID": 1124,
-      "name": "Barrel Upgrades",
-      "description": "Are your cobblestone or dirt barrels filled to the brim? \nNo problem, upgrade them!",
+      "name": "tier1.quest46.name",
+      "description": "tier1.quest46.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -108905,8 +108248,8 @@
     },
     {
       "questID": 1125,
-      "name": "Barrel Upgrades Tier 2",
-      "description": "Are your upgraded cobblestone or dirt barrels full again? \nNo problem, upgrade them some more!",
+      "name": "tier1.quest45.name",
+      "description": "tier1.quest45.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -109053,8 +108396,8 @@
     },
     {
       "questID": 1126,
-      "name": "Alumite",
-      "description": "It\u0027s upgrade time again. You can make alumite by mixing obsidian, steel and alumin(i)um in the smeltery. Alumite pickaxes are able to mine ardite and cobalt in the Nether.",
+      "name": "tier1.quest33.name",
+      "description": "tier1.quest33.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -109154,8 +108497,8 @@
     },
     {
       "questID": 1127,
-      "name": "Reinforced X? Unbreakable",
-      "description": "With your steel tool you are able to mine obsidian. Large obsidian plates give a reinforced modifier which increases the durability of your tool. \nReinforced level X makes a tool unbreakable.",
+      "name": "tier1.quest25.name",
+      "description": "tier1.quest25.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -109264,8 +108607,8 @@
     },
     {
       "questID": 1128,
-      "name": "Lapis? Lucky!",
-      "description": "Maybe you were lucky and received the luck modifier on your pickaxe. If not, you may still have an unused modifier on your pick so you can add some lapis lazuli. Or you can perhaps add another modifier by adding a diamond and a gold block to your pick and then add some lapis. You can put the lapis lazuli in more than one slot in the tool station, or use blocks to raise the luck level faster.",
+      "name": "tier1.quest30.name",
+      "description": "tier1.quest30.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -109347,8 +108690,8 @@
     },
     {
       "questID": 1129,
-      "name": "Redstone? Haste!",
-      "description": "Mining and digging can be soooo slow. Get some redstone on your pick, shovel or axe to make it faster.",
+      "name": "tier1.quest26.name",
+      "description": "tier1.quest26.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -109424,8 +108767,8 @@
     },
     {
       "questID": 1130,
-      "name": "Extra Modifier",
-      "description": "If you don\u0027t have an extra modifier on your tool you can easily add one.\nA gold block and a diamond are all you need.\nYou can add two more modifiers, but you need to figure out how yourself.",
+      "name": "tier1.quest18.name",
+      "description": "tier1.quest18.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -109514,8 +108857,8 @@
     },
     {
       "questID": 1131,
-      "name": "Ardite and Cobalt",
-      "description": "If you are done with all quests you can look for cobalt and ardite in the Nether. Remember, you need an electric blast furnace to process these materials before you can make tools with them.",
+      "name": "tier1.quest56.name",
+      "description": "tier1.quest56.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -109603,8 +108946,8 @@
     },
     {
       "questID": 1132,
-      "name": "Netherquartz? Sharpness",
-      "description": "Your sword is too dull? Get some nether quartz to sharpen it again.",
+      "name": "tier1.quest57.name",
+      "description": "tier1.quest57.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -109686,8 +109029,8 @@
     },
     {
       "questID": 1133,
-      "name": "Submission Station",
-      "description": "Although many of the questing tasks can be submitted directly through your inventory (including liquids) sometimes you need a more automated solution. This is where the Object Submission Station (OSS) comes in handy. \nTasks supporting the OSS can be selected through the built in interface to enable its use. Once setup, liquids and items can be either piped in or dropped into the interface\u0027s input slot. It will not void items or liquids if no task is selected or if it has already been completed, however, making it relatively safe from accidental item/fluid deletion. Multiple OSS are also capable of taking on separate sub-tasks under the same quest simultaneously!",
+      "name": "tier1.quest35.name",
+      "description": "tier1.quest35.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -109802,8 +109145,8 @@
     },
     {
       "questID": 1134,
-      "name": "LV Advanced Steam Boiler",
-      "description": "The LV Gt++ Steam Boiler is the next machine you can build to produce steam more efficiently than with the High Pressure Boiler.",
+      "name": "tier2.quest106.name",
+      "description": "tier2.quest106.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -109891,8 +109234,8 @@
     },
     {
       "questID": 1135,
-      "name": "ULV Transformer",
-      "description": "To get your simple ore washer working you need a ULV Transformer. The Washer can only work with 8 EU. If you put more energy into it you get a big hole in your base.",
+      "name": "tier2.quest47.name",
+      "description": "tier2.quest47.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -109969,8 +109312,8 @@
     },
     {
       "questID": 1136,
-      "name": "Lossless LV Cables",
-      "description": "How about losless 32 EU LV Cables ? Redstone alloy is a superconductor wire and will transfer your energy without any loss.\nRedalloy is a new alloy which requires an EBF. Mix redstone, silicon and coal by hand, or in the mixer for a better result.",
+      "name": "tier2.quest32.name",
+      "description": "tier2.quest32.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -110519,7 +109862,7 @@
     {
       "questID": 1140,
       "name": "Rotor",
-      "description": "The Kinetic Wind and Water Generators need Rotors to function.  They can be added and removed with standard automation. Higher tier rotors will last longer.",
+      "description": "The Kinetic Generator will transform mechanical energy to electricity. The EU output depends on the KU input. It is most commonly used together with a Kinetic Wind Generator, Kinetic Water Generator  or a Kinetic Steam Generator.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -110680,7 +110023,7 @@
       "tasks": [
         {
           "partialMatch": true,
-          "ignoreNBT": true,
+          "ignoreNBT": false,
           "consume": false,
           "autoConsume": false,
           "requiredItems": [
@@ -110726,7 +110069,7 @@
         },
         {
           "partialMatch": true,
-          "ignoreNBT": true,
+          "ignoreNBT": false,
           "consume": false,
           "autoConsume": false,
           "requiredItems": [
@@ -110786,7 +110129,7 @@
     {
       "questID": 1142,
       "name": "HV Battery Buffers",
-      "description": "HV machines need battery buffers too. They come in different sizes like 1x, 4x, 9x and 16x.\nBuild a 1x and a 4x buffer for HV.",
+      "description": "MV machines need battery buffers too. They come in different sizes like 1x, 4x, 9x and 16x.\nBuild a 1x and a 4x buffer for HV.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -111123,8 +110466,8 @@
     },
     {
       "questID": 1146,
-      "name": "GT 6 styled Pipes",
-      "description": "Maybe you are wondering why the new pipes don\u0027t auto-connect anymore? This was changed to make the pipe smarter. You can now use a wrench to connect only the pipes you want. You don\u0027t need a plate or a foil to prevent pipes from connecting anymore (You\u0027ll still want to cover hot pipes to prevent getting hurt!). Shift clicking on the end of a pipe will disable the fluid input on that side. This is super handy, for example, to prevent coal boilers from feeding back steam into water pipes. \n\nHint: If you click one pipe onto the other they will auto-connect.",
+      "name": "tier0.5.quest2.name",
+      "description": "tier0.5.quest2.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -111219,8 +110562,8 @@
     },
     {
       "questID": 1147,
-      "name": "GT 6 styled Wires and Cables",
-      "description": "Maybe you are wondering why the new wires and cables don\u0027t auto-connect anymore? This was changed to make the wires and cables smarter. You have to use a wirecutter or soldering iron to connect the wires and cables on the side you want. No more burnt cables or wrongly connected wires and cables from now on.\n\nHint: If you click one wire or cable on the other it will auto-connect. Cables and pipes can be painted to make sure you do not cross your MV line with your EV line, or dump hot lava into your plastic water pipes. No boom today.",
+      "name": "tier1.quest73.name",
+      "description": "tier1.quest73.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -111321,7 +110664,7 @@
     {
       "questID": 1148,
       "name": "MV Machine hull",
-      "description": "The next tier of machine hull needs aluminium - a lot of aluminium. Keep your EBF running and make some aluminium.",
+      "description": "The next tier of machine hull needs aluminium, a lot of aluminium. Keep your EBF running and make some aluminium.",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -111405,8 +110748,8 @@
     },
     {
       "questID": 1149,
-      "name": "A new alloy - Magnalium",
-      "description": "You wonder why you need magnalium now? It\u0027s not for GT machines right now but for a material update for your crossbow.\nIt\u0027s a very good material in LV Tier. Go to the Twilight Forest and find an Olivine/Glauconite vein located at Y 10-40 or in the Overworld a Glauconite Soapstone mix located at Y 20-50 and a Granitic Mineral Vein in the Overworld Located at Y 50-60 (The Gypsum vein you will need for the Bricked Blast Furnace).\nWith your Ore Washer you can get Magnesium and Aluminium out of the Ores (Magnesite for Magnesium and Fullers Earth for Aluminium) and mix it in the Alloy smelter to Magnalium.\nMagnesite gives 10 tiny piles of Magnesium each dust but fullers earth gives only a tiny pile of Aluminium.",
+      "name": "tier2.quest48.name",
+      "description": "tier2.quest48.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -111536,8 +110879,8 @@
     },
     {
       "questID": 1150,
-      "name": "Magnalium Crossbow",
-      "description": "Now its time to craft your Crossbow Limb and the Crossbow Body to upgrade your old Wooden Crossbow.",
+      "name": "tier2.quest57.name",
+      "description": "tier2.quest57.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -111702,8 +111045,8 @@
     },
     {
       "questID": 1151,
-      "name": "Wooden Crosbow",
-      "description": "Now you are able to make a better long range weapon - a crossbow. Use wood for the the crossbow limb and the body and use obsidian (Reinforced III) for the tough binding. Normal strings for the bowstrings would be enough for now.",
+      "name": "tier1.quest32.name",
+      "description": "tier1.quest32.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -111867,7 +111210,7 @@
                   "Modifiers:4": 0
                 },
                 "display:10": {
-                  "Name:8": "§fWooden Crossbow"
+                  "Name:8": "ï¿½fWooden Crossbow"
                 }
               }
             }
@@ -111911,8 +111254,8 @@
     },
     {
       "questID": 1152,
-      "name": "Fiery Bowstring",
-      "description": "Why not upgrade your bowstring too?. If you cannnot find any fiery strings in the Nether you got some from the last quest. Craft some fiery bowstring with it.",
+      "name": "tier2.quest56.name",
+      "description": "tier2.quest56.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -112024,8 +111367,8 @@
     },
     {
       "questID": 1153,
-      "name": "Ardite Crossbow Body",
-      "description": "To make your crossbow even better craft an ardite crossbow body. You received a few ardite ingots as reward before.\nWith redstone you can make your bow faster. This requires a free modifier slot on your crossbow.",
+      "name": "tier2.quest55.name",
+      "description": "tier2.quest55.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -112137,8 +111480,8 @@
     },
     {
       "questID": 1154,
-      "name": "Magnalium Crossbow Bolts",
-      "description": "Magnalium bolts are much better than your old wooden bolts.\nYou can use nether quartz on the bolts to make them even better. \nThis requires a free modifier slot.\nNOTE: Unlike other tinker tools and weapons, bolts cannot be upgraded.  You will need to make a fresh one. Experiment with NEI to find other good bolt materials. ",
+      "name": "tier2.quest58.name",
+      "description": "tier2.quest58.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -112308,7 +111651,7 @@
                   "Modifiers:4": 0
                 },
                 "display:10": {
-                  "Name:8": "§fIron Bolts"
+                  "Name:8": "ï¿½fIron Bolts"
                 }
               }
             }
@@ -112359,8 +111702,8 @@
     },
     {
       "questID": 1155,
-      "name": "Basic Fluid Solidifier",
-      "description": "To get your molten fluids back to a solid state you need a fluid solidifier. It is used for crossbow bolts as well.",
+      "name": "tier2.quest59.name",
+      "description": "tier2.quest59.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -112465,8 +111808,8 @@
     },
     {
       "questID": 1156,
-      "name": "Iron Tipped Bolts",
-      "description": "Your crossbow need some ammo to shoot with. Let\u0027s craft some wooden bolts with an iron tip. You\u0027ll need to pump smeltery iron into a fluid solidifier.",
+      "name": "tier1.quest31.name",
+      "description": "tier1.quest31.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -112607,6 +111950,7 @@
                   "BaseDurability:4": 188,
                   "BaseAttack:4": 3,
                   "ToolEXP:4": 0,
+                  "Built:4": 1,
                   "HarvestLevel:4": 3,
                   "RenderHead:4": 2,
                   "ModDurability:6": 0.0,
@@ -112674,8 +112018,8 @@
     },
     {
       "questID": 1157,
-      "name": "Rubber Soft Mallet",
-      "description": "Your wooden soft mallet breaks after a few uses. Now you can make a rubber mallet which is much more durable.",
+      "name": "tier1.quest74.name",
+      "description": "tier1.quest74.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -112869,7 +112213,7 @@
               "id": "gregtech:gt.metaitem.01",
               "Count": 9,
               "OreDict": "",
-              "Damage": 86
+              "Damage": 2086
             }
           ],
           "taskID": "bq_standard:retrieval"
@@ -113030,8 +112374,8 @@
     },
     {
       "questID": 1160,
-      "name": "Empty Cells",
-      "description": "With your plate bender you are able to make empty cells. The circuit needs to be configured to 12 otherwise you will make foil. Once you have an MV Extruder, you can make cells directly from ingots.",
+      "name": "tier2.quest93.name",
+      "description": "tier2.quest93.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -113237,7 +112581,7 @@
     {
       "questID": 1163,
       "name": "Copper Wire",
-      "description": "Want some copper wires? Buy some!",
+      "description": "Want some coper wires? Buy some!",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -113434,8 +112778,8 @@
     },
     {
       "questID": 1166,
-      "name": "Quartz and Quartzite Veins",
-      "description": "The Nether is full of different kinds of quartz. Go and find a quartzite and certus quartz vein. They are located between Y levels 40-80.",
+      "name": "tier2.quest26.name",
+      "description": "tier2.quest26.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -113552,8 +112896,8 @@
     },
     {
       "questID": 1167,
-      "name": "Lithium",
-      "description": "Lithium can be washed out of Lepidolite Ore or centrifuged out of Spodumene Ore. At MV you can electrolyze clay dust for it. Look for canyons to find hardened clay and macerate it for dust.",
+      "name": "tier2.quest82.name",
+      "description": "tier2.quest82.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -113618,13 +112962,13 @@
         }
       ],
       "preRequisites": [
-        622
+        609
       ]
     },
     {
       "questID": 1168,
-      "name": "Sodium",
-      "description": "Sodium can be washed out of Glauconite Ore and Sand. It can also be electrolyzed out of salt.",
+      "name": "tier2.quest89.name",
+      "description": "tier2.quest89.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -113689,7 +113033,7 @@
         }
       ],
       "preRequisites": [
-        621
+        609
       ]
     },
     {
@@ -113755,7 +113099,7 @@
     {
       "questID": 1170,
       "name": "Bath Soap",
-      "description": "Oh you feel so dirty. Get the soap and take a long hot bath to get rid of some of that nasty Warp.",
+      "description": "Oh you feel so dirty. Go and take the soap and a shower.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -113874,8 +113218,8 @@
     },
     {
       "questID": 1172,
-      "name": "Cheaper Annealed Production",
-      "description": "It\u0027 s even faster and cheaper to make annealed copper in the arc furnace than in the electric blast furnace. Annealed copper is a very good material for cables in MV. It only loses 1 EU per block.",
+      "name": "tier2.quest98.name",
+      "description": "tier2.quest98.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -114225,7 +113569,7 @@
     {
       "questID": 1177,
       "name": "Thaumium cooking",
-      "description": "Now it is time to cook your first thaumium ingots. After researching it you need iron ingots and praecantatio aspect to make it. ",
+      "description": "Now it is time to cook your first thaumium ingots. After you researched it you need iron ingots and praecantatio aspect to make it. ",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -114336,8 +113680,8 @@
     },
     {
       "questID": 1178,
-      "name": "Food 2.0",
-      "description": "Forget everything you know about food and values. With your new canning machine you are able to fill tin cans with very nourishing food. This food can be consumed in milliseconds and makes you full and happy. And you can eat as much as you want without getting tired of the food.\nEating before you are starving restores saturation and conserves cans.",
+      "name": "tier2.quest75.name",
+      "description": "tier2.quest75.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -114461,8 +113805,8 @@
     },
     {
       "questID": 1179,
-      "name": "EBF Infos",
-      "description": "You can use a scanner to manually check how your EBF works, or you can make an information panel from nuclear control and always see the status. Make a GT sensor kit and place the sensor card in your info panel. Enable it with a redstone signal.",
+      "name": "multiblock.goals.quest28.name",
+      "description": "multiblock.goals.quest28.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -114587,8 +113931,8 @@
     },
     {
       "questID": 1180,
-      "name": "Chunkloading",
-      "description": "Using the MV bender you can finally press dense plates. Let\u0027s craft some chunkloaders.\n3x3 chunks are loaded. You need coins to power the chunkloader. Personal and passive anchors can be powered with ender pearls for 1 hour per pearl. World anchors are always loaded. Personal anchors are loaded while the player is logged in. Passive only loads once the owner visits, and stays loaded until they logout.",
+      "name": "Chunckloading",
+      "description": "Using the MV bender you can finally press dense plates. Let\u0027s craft some chunkloaders.\n3x3 chunks are loaded. You need coins to power the chunkloader. Personal and passive anchors can be powered with ender pearls for 1 hour per pearl.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -114665,7 +114009,7 @@
     {
       "questID": 1181,
       "name": "Minecart with Tank, Workbench or Furnace",
-      "description": "You want to transport oil or other fluids, have a portable crafting table or a portable chest? Then you need to craft some minecarts with tanks, chests or crafting tables.",
+      "description": "You want to transport oil or other fluids, have a portable crafting table or a portable chest? Then you need to craft some minecarts with tanks, mhests or crafting tables.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -115284,8 +114628,8 @@
     },
     {
       "questID": 1187,
-      "name": "The transcontinental railroad - high speed",
-      "description": "Did you ever dream of driving in a railcart at high speeds? Well your dreams can come true with the high speed tracks. Be careful though; you need to lower the speed when your rails change direction or when the track ends.",
+      "name": "The transcontinental railroad in high speed",
+      "description": "Did you ever dream of driving in a railcart at high speeds? Well your dreams can come true with the high speed tracks. Be careful though; you need to lower the speed when you rails change direction or when the track ends.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -115416,7 +114760,7 @@
     },
     {
       "questID": 1188,
-      "name": "The transcontinental railroad - blast proof",
+      "name": "The transcontinental railroad blast proof",
       "description": "Railroads in the nether are dangerous. The reinforced tracks are blast proof. Hope you are blast proof too. \nYou can move 25% faster than with normal tracks.",
       "isMain": false,
       "isSilent": false,
@@ -115766,8 +115110,8 @@
     },
     {
       "questID": 1191,
-      "name": "Magic \"Staffter\"",
-      "description": "It is also possible to create a bizarre hybrid of staff and scepter (sometimes called a \"staffter\"), by using a staff core instead of a wand core in the scepter recipe. The resulting device can neither hold a focus nor be placed in a crafting table, but it can still be used to activate constructs, or as a \"vis battery\" for Repair-enchanted equipment or Runic shielding.",
+      "name": "XP berry bush",
+      "description": "Farming your XP instead of harming monsters or aninmals.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -115784,92 +115128,24 @@
       "logic": "AND",
       "taskLogic": "AND",
       "icon": {
-        "id": "Thaumcraft:WandCasting",
+        "id": "TConstruct:ore.berries.two",
         "Count": 1,
         "OreDict": "",
-        "Damage": 8,
-        "tag": {
-          "cap:8": "iron",
-          "rod:8": "greatwood_staff",
-          "AttributeModifiers:9": [
-            {
-              "UUIDMost:4": -3801225194067177672,
-              "UUIDLeast:4": -6586624321849018929,
-              "Amount:6": 6.0,
-              "AttributeName:8": "generic.attackDamage",
-              "Operation:4": 0,
-              "Name:8": "Weapon modifier"
-            }
-          ]
-        }
+        "Damage": 9
       },
       "visibility": "UNLOCKED",
       "tasks": [
         {
           "partialMatch": true,
           "ignoreNBT": false,
-          "consume": false,
+          "consume": true,
           "autoConsume": false,
           "requiredItems": [
             {
-              "id": "Thaumcraft:WandRod",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 50
-            },
-            {
-              "id": "dreamcraft:item.IronWandCap",
+              "id": "dreamcraft:item.CoinFarmerI",
               "Count": 3,
               "OreDict": "",
               "Damage": 0
-            },
-            {
-              "id": "TwilightForest:item.fieryBlood",
-              "Count": 2,
-              "OreDict": "",
-              "Damage": 0
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 2,
-              "OreDict": "",
-              "Damage": 27028
-            },
-            {
-              "id": "Thaumcraft:ItemResource",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 15
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        },
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "Thaumcraft:WandCasting",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 12,
-              "tag": {
-                "cap:8": "iron",
-                "rod:8": "greatwood_staff",
-                "sceptre:4": 1,
-                "AttributeModifiers:9": [
-                  {
-                    "UUIDMost:4": -3801225194067177672,
-                    "UUIDLeast:4": -6586624321849018929,
-                    "Amount:6": 6.0,
-                    "AttributeName:8": "generic.attackDamage",
-                    "Operation:4": 0,
-                    "Name:8": "Weapon modifier"
-                  }
-                ]
-              }
             }
           ],
           "taskID": "bq_standard:retrieval"
@@ -115879,34 +115155,17 @@
         {
           "rewards": [
             {
-              "id": "Thaumcraft:ItemResource",
-              "Count": 2,
+              "id": "TConstruct:ore.berries.two",
+              "Count": 5,
               "OreDict": "",
-              "Damage": 15
-            },
-            {
-              "id": "Thaumcraft:ItemLootBag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 2
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinDarkWizardII",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
+              "Damage": 9
             }
           ],
           "rewardID": "bq_standard:item"
         }
       ],
       "preRequisites": [
-        878
+        89
       ]
     },
     {
@@ -115966,7 +115225,7 @@
         }
       ],
       "preRequisites": [
-        89
+        879
       ]
     },
     {
@@ -116026,7 +115285,7 @@
         }
       ],
       "preRequisites": [
-        88
+        877
       ]
     },
     {
@@ -116086,7 +115345,7 @@
         }
       ],
       "preRequisites": [
-        76
+        876
       ]
     },
     {
@@ -116146,7 +115405,7 @@
         }
       ],
       "preRequisites": [
-        76
+        878
       ]
     },
     {
@@ -116206,13 +115465,13 @@
         }
       ],
       "preRequisites": [
-        76
+        887
       ]
     },
     {
       "questID": 1197,
-      "name": "Fusion reactor MK2 - bigger, better, fusor",
-      "description": "Now that you have some europium, put it to use by making an mk2 reactor. This one will require the same block placement, but replacing LuV casings with fusion machine casings, superconducting coil blocks with fusion coil blocks, and using ZPM tier hatches. This reactor can handle recipes up to 320M eu startup. In addition, if you perform an mk1 recipe on an mk2, you will overclock it. Fusion overclocking is different than normal gt. It will take 2x the power, but the recipe will go 2x faster.",
+      "name": "Fusion reactor MK2",
+      "description": "Now that you have some europium, put it to use by making an mk2 reactor. This one will require the same block placement, but replacing LuV casings with fusion casings, and using ZPM tier hatches. This reactor can handle recipes up to 65536eu/t and 320M eu startup. In addition, if you perform an mk1 recipe on an mk2, you will overclock it. Fusion overclocking is different than normal gt. It will take 2x the power, but the recipe will go 2x faster. ",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -116361,7 +115620,7 @@
     {
       "questID": 1198,
       "name": "Upgrading the reactor",
-      "description": "A mark 2 is nice, but why not make a mark 3? It will double the power needed per recipe, while cutting the processing time in half. This time you will need UV or above hatches, as well as Fusion machine casings MK2. This reactor is capable of doing all fusion recipes. Each energy hatch is capable of providng up to 8192eu/t, per energy hatch, for the recipe. The reactor can take as little as 8192eu/t to run. The UV hatch can accept up to 2 amps of 524288eu/t before it explodes, as usual.",
+      "description": "A mark 2 is nice, but why not make a mark 3? It will double the power needed per recipe, while cutting the processing time in half. This time you will need UV or above hatces, as well as Fusion machine casings MK2. This reactor is capable of doing all fusion recipes. Each energy hatch is capable of inputting up to 8192eu/t, and can take as little as 8192eu/t to run, and up to 2 amps of 524288eu/t before it explodes. ",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -116510,7 +115769,7 @@
     {
       "questID": 1199,
       "name": "Making americium",
-      "description": "Before you can upgrade your reactor, you will need to get some americium. The recipe will look pretty expensive, but once you made the next tier of reactor, you will unlock a simplier and cheaper one. You will need at least 128 plates for the reactor casings, 9 to scan for the recipe, and 4 to build one.",
+      "description": "Before you can upgrade your reactor, you will need americium. The recipe to make it will seem expensive, but once you make the next tier of reactor, you will unlock a simplier and cheaper recipe. You will need at least 128 plates for for the reactor casings, 9 to scan for the the recipe, and 4 for the recipe itself. ",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -116795,7 +116054,7 @@
     {
       "questID": 1201,
       "name": "Turbine Time",
-      "description": "Your fancy new Large Plasma Turbine will need a rotor to go inside of it. You can make it out of any gt material, but the best are trinium, awakened draconium and neutronium. Trinium will give you the most eu/t out of a single multiblock, with the best efficiency. Neutronium will give you the longest lasting turbine rotors with a lower efficiency, and less power per reactor. Awakened draconium will give you a balance between the two. You can make turbines in 4 different sizes. The larger the turbine the more eu/t it will produce. However, the largest turbine isn\u0027t also the most efficient. When using turbines be careful of flow rates. To find the optimal flow rate, you divide the optimal energy flow rate listen on the turbine, by the energy value for the plasma. Make sure to use a fluid regulator set to this flow rate.",
+      "description": "Your fancy new Large Plasma Turbine will need a rotor to go inside of it. You can make it out of any gt material, but the best are trinium, awakened draconium and neutronium. Trinium will give you the most eu/t out of a single multiblock, with the best efficiency. Neutronium will give you the longest lasting turbine rotors with a lower efficiency, and less power per reactor. Awakened draconium will give you a balance between the two. You can make turbines in 4 different sizes. The larger the turbine the more eu/t it will produce. However, the largest turbine isn\u0027t also the most efficient. When using turbines be careful of flow rates. To find the optimal flow rate, you divide the optimal energy flow rate listen on the turbine, by the energy value for the plasma. ",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -117033,8 +116292,8 @@
     },
     {
       "questID": 1204,
-      "name": "Crafting time",
-      "description": "It\u0027s time to get yourself a 3x3 crafting area. Grab some flint and some wood, and build one!",
+      "name": "tier0.quest4.name",
+      "description": "tier0.quest4.desc",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -117102,8 +116361,8 @@
     },
     {
       "questID": 1205,
-      "name": "Hoppers",
-      "description": "Hoppers come in handy when you want to automate your machines. \nYou can input items via hoppers directly into GT pipes and you don\u0027t have to use a conveyor belt. \nHowever, the input rate is much slower, and the hopper must be beneath its source inventory.",
+      "name": "tier1.quest1.name",
+      "description": "tier1.quest1.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -117458,7 +116717,7 @@
     },
     {
       "questID": 1210,
-      "name": "Cart modules: Thermal Engine",
+      "name": "Cart modules: Power Thermal",
       "description": "Your cart needs power, obviously. A cart can be powered via coal, solar or lava. Why not power your cart with lava?",
       "isMain": false,
       "isSilent": false,
@@ -117613,7 +116872,7 @@
     {
       "questID": 1212,
       "name": "Starting Fusion",
-      "description": "Now that your power needs are increasing, you need a way to keep up with demand. To generate over 1A ZPM with a single machine you have two options: solars, and fusion. While solars are simpler to set up, solars cap out at 524288eu/t. Fusion can reach levels close to eight times that with the right setup. For your first reactor, you will need a controller, 2-16 fluid input hatches, 1-16 fluid output hatches, and 16 energy hatches. All hatches have to be LuV tier or better. Each hatch provides 2048eu/t for the recipe, and has a storage capacity of 160M eu. This means you can do any fusion recipe that takes less than 32768eu/t or less, and has a startup of 160M eu or less. Using more fluid hatches means you need less fusion casings. While this doesn\u0027t matter as much for the mk1 reactor, this principle helps tremendously with the high reactor tiers. ",
+      "description": "Now that your power needs are increasing, you need a way to keep up with demand. To generate over 1A ZPM with a single machine you have two options. Solars, and fusion. While solars are simpler to set up, solars cap out at 524288eu/t. Fusion can reach levels close to eight times that with the right setup. For your first reactor, you will need a controller, 2-16 fluid input hatches, 1-16 fluid output hatches, and 16 energy hatches. All hatches have to be LuV tier or better. Each hatch inputs 2048eu/t, and has a storage capacity of 160M eu. This means you can do any fusion recipe that takes less than 32768eu/t or less, and has a startup of 160M eu or less. Using more fluid hatches means you need less fusion casings. While this doesn’t matter as much for the mk1 reactor, this principle helps tremendously with the high reactor tiers. ",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -118156,7 +117415,7 @@
     {
       "questID": 1216,
       "name": "Peat fired Engine",
-      "description": "Peat fired engines use Peat or Bituminous Peat to run. Peat burns for 5000 ticks and produces 10 RF every tick, 1 peat makes 0.66 Ash, so you get 2 Ash for burning 3 peat.\nBituminous Peat burns for 6000 ticks and produces 20 RF/tick.\n\nPeat Farms can be setup by using a managed farm with tin electron tubes. It is possible with a manual farm too.",
+      "description": "Peat fired engines using Peat or Bituminous Peat to run. Peat burns for 5000 ticks and produces 10 RF every tick, 1 peat makes 0.66 Ash, so you get 2 Ash for burning 3 peat.\nBituminous Peat burns for 6000 ticks and produces 20 RF/tick.\n\nPeat Farms can be setup by using a managed farm with tin electron tubes. It is possible with manual farm too.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -119123,7 +118382,7 @@
     {
       "questID": 1224,
       "name": "Epoxid",
-      "description": "Epoxid is needed for your advanced Circuits boards. You need Sodium Hydroxide, Epichlorohydrin and Bispenol A to make it.",
+      "description": "Epoxid is needed for your advanced Circuits boards. You need Sodiumhydroxide, Epichlorohydrine and Bispenol A to make it.",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -119249,7 +118508,7 @@
     {
       "questID": 1225,
       "name": "IV Circuit Mainframe",
-      "description": "Mainframes are the first IV Circuits you can make in HV. Used for EV and IV machines and components.",
+      "description": "With your workstation circuits you can craft an HV circuit assembler. This is needed for higher tier circuits.",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -119554,8 +118813,8 @@
     },
     {
       "questID": 1228,
-      "name": "Epichlorohydrin",
-      "description": "Epichlorohydrin is another product needed in your epoxid production. Mix glycerol and HCl together.",
+      "name": "Epichlorohydrine",
+      "description": "Epichlorohydrine is another product used in your epoxid production. Mix glycerol and HCl together.",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -119665,7 +118924,7 @@
     {
       "questID": 1229,
       "name": "Phenol",
-      "description": "The easiest way is to get phenol out of heavy fuel. There are other ways, like getting it out of wood tar from a pyrolyse oven, isopropylbenzene and oxygen, or chlorobenzene and water.",
+      "description": "The easiest way is to get phenol out of heavy fuel. There are other ways, like getting it out of isopropylbenzene and oxygen or chlorobenzene and water.",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -119749,7 +119008,7 @@
     {
       "questID": 1230,
       "name": "Bisphenol A",
-      "description": "To get Bisphenol A you need to combine Phenol, Acetone and HCl in a chemical reactor.",
+      "description": "To get Bisphenol A your need to combine Phenol, Aceton and HCl in a chemical reactor.",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -120051,7 +119310,7 @@
     {
       "questID": 1233,
       "name": "Ender Eyes",
-      "description": "Ender eyes are available at HV in the chemical reactor. Combine some ender pearls with blaze powder.",
+      "description": "Ender eyes are available in HV in the chemical reactor. Combine some ender pearls with blaze powder.",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -120506,7 +119765,7 @@
     {
       "questID": 1237,
       "name": "Glowstone Doped Monocrystalline Silicon",
-      "description": "To make more advanced wafers, you need to make glowstone dopped monocrystalline silicon first. The process takes 600 seconds and requires silicon dust and glowstone dust in the electric blast furnace. You can make 32 wafers out of every boule.",
+      "description": "To make wafers, you need to make monocrystalline silicon first. The process takes 450 seconds and requires silicon dust and gallium arsenide dust in the electric blast furnace. You can make 16 wafers out of every boule.",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -120693,7 +119952,7 @@
     {
       "questID": 1239,
       "name": "Nor and Nand chips",
-      "description": "The data stick requires nand chips. Nor chips are needed for more advanced circuits. You can get these by cutting nand and nor wafers.\nA cleanroom is required.",
+      "description": "The data stick requires nand chips. Nor chips are needed for more advanced circuits. You can get these by cutting a nand and a nor wafer.\nA cleanroom is required.",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -120939,7 +120198,7 @@
     {
       "questID": 1241,
       "name": "Radeon",
-      "description": "Radon is used for quantum eyes, quantum stars and emitters and sensors in the EV machines. Try to find a Pitchblende vein first and/or recycle your plutonium and uranium from your reactor.\n\nThis Vein can be found on Mars and Phobos.",
+      "description": "Radon is used for quantum eyes, quantum stars and emitters and sensors in the EV machines. Try to find a pitch blend vein first and/or recycle your plutonium and uranium from your reactor.",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -121037,14 +120296,14 @@
         }
       ],
       "preRequisites": [
-        176
+        1242
       ]
     },
     {
       "questID": 1242,
       "name": "EV Chemical reactor",
-      "description": "An EV chemical reactor is required to get some indium or make your radon production much faster. If you already made a large chemical reactor use that instead.",
-      "isMain": false,
+      "description": "An EV chemical rector is required to get some indium or make your radon production quite faster.",
+      "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
       "simultaneous": false,
@@ -121111,7 +120370,7 @@
           "rewards": [
             {
               "id": "dreamcraft:item.CoinTechnicianII",
-              "Count": 1,
+              "Count": 2,
               "OreDict": "",
               "Damage": 0
             }
@@ -121215,7 +120474,7 @@
     {
       "questID": 1244,
       "name": "Scheelite, Tungstate",
-      "description": "Tungstensteel is the material you need but first go find some scheelite and tungstate mix on Mars. Look at Y 20-60.",
+      "description": "Tungstensteel is the material you need but go find some scheelite and tungstate mix on Mars first. Look at Y 20-60.",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -121304,7 +120563,7 @@
     {
       "questID": 1245,
       "name": "You gonna hate this 1-4 in EV",
-      "description": "Pumps, pistons, conveyor belts and robot arms are the most needed machine parts in EV. Go and craft one of each.",
+      "description": "Pumps, pistons, conveyor belts and robot arms are the most needed machine parts in HV. Go and craft one of each.",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -121734,7 +120993,7 @@
     {
       "questID": 1249,
       "name": "Nano CPU Wafer and Chip",
-      "description": "The Nano CPU Wafer is made out of a CPU Wafer with carbon fiber and molten glowstone in an EV chemical reactor. Cut it for nano CPU chips.\nA cleanroom is needed.",
+      "description": "The Nano CPU Wafer is made out of a CPU Wafer with carbon fiber and molten glowstone in an EV chemical reactor. Cut into the nano CPU chip.\nA cleanroom is needed.",
       "isMain": true,
       "isSilent": false,
       "lockedProgress": false,
@@ -122100,7 +121359,7 @@
     },
     {
       "questID": 1252,
-      "name": "HV Chemical Bath",
+      "name": "Chemical Bath",
       "description": "An HV chemical bath is needed for the quantum eye.",
       "isMain": true,
       "isSilent": false,
@@ -122184,7 +121443,7 @@
     {
       "questID": 1253,
       "name": "16k Component",
-      "description": "Second largest storage component, used to make 16k ME storage cell, or can be upgraded to make 64k ME storage component. Can be recovered from a crafted 16k ME storage cell by fully emptying the storage cell, and shift clicking it in your hand.",
+      "description": "Second largest storage component, used to make 16k ME storage cell, or can be upgraded to make 64k ME storage component.Can be recovered from a crafted 16k ME storage cell by fully emptying the storage cell, and shift clicking it in your hand.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -122377,7 +121636,7 @@
       "tasks": [
         {
           "partialMatch": true,
-          "ignoreNBT": true,
+          "ignoreNBT": false,
           "consume": false,
           "autoConsume": false,
           "requiredItems": [
@@ -123074,7 +122333,7 @@
     {
       "questID": 1263,
       "name": "Blue Steel",
-      "description": "Your sunnarium batteries are made out of blue steel: a mixture of steel, black steel, brass and rose gold.",
+      "description": "Your sunnarium batteries are made out of blue steel; a mixture of steel, black steel, brass and rose gold.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -123190,7 +122449,7 @@
     {
       "questID": 1264,
       "name": "EV Sunnarium Battery",
-      "description": "Your first EV sunnarium battery used in EV tier. You make it with the sunnarium you generated before.",
+      "description": "Your fist EV sunnarium battery used in EV tier. You make it with the sunnarium you generated before.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -123460,8 +122719,8 @@
     },
     {
       "questID": 1266,
-      "name": "Low Voltage Transformer",
-      "description": "It\u0027s possible to run MV machines while still in LV age. Build a transformer and use 4 power sources 32 eu/t to power one 128 eu/t machine. You can change the mode of a transformer with a soft mallet. If the transformer is wired and loaded then DO NOT change the mode otherwise there probably will be a big explosion. Be careful when switching directions - better to break and replace than rotate with the wrench and blow up a line of machines.",
+      "name": "tier2.quest10.name",
+      "description": "tier2.quest10.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -123531,8 +122790,8 @@
     },
     {
       "questID": 1267,
-      "name": "Medium Voltage Transformer",
-      "description": "It\u0027s possible to run HV machines while still in MV age. Build a transformer and use 4 power sources 128 eu/t to power one 512 eu/t machine. You can change the mode of a transformer with a soft mallet. If the transformer is wired and loaded then DO NOT change the mode otherwise there probably will be a big explosion.",
+      "name": "Transformer MV-HV",
+      "description": "It\u0027s possible to run HV machines while still in MV age. Build a transformer and use 4 power sources 128 eu/t to power one 512 eu/t machine. You can change the mode of a transformer with a soft mallet. If the transformer is wired and loaded then do NOT! change the mode otherwise there probably will be a big explosion.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -123603,8 +122862,8 @@
     },
     {
       "questID": 1268,
-      "name": "LV High-Amp Transformer",
-      "description": "If you need a transformer with more than 4 amperes you need a high amp transformer. You can input four 128 eu/t power sources and output 16 ampere at 32 eu/t.\nModes can be changed with a soft mallet.",
+      "name": "Transformer MV-HV High Amp",
+      "description": "If you need a transformer with more than 4 Ampere you need a high amp transformer. You can input four 128 eu/t power sources and output 16 ampere at 32 eu/t.\nModes can be changed with a soft mallet.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -123674,8 +122933,8 @@
     },
     {
       "questID": 1269,
-      "name": "Low Voltage Power Transformer",
-      "description": "If you need even more amps then craft a power tranformer with a max LV output of 64 amps. You can input sixteen 128 eu/t power sources and output 64 amps at 32 eu/t. Modes can be changed with a soft mallet.",
+      "name": "Transformator MV-HV High Amp",
+      "description": "If you need even more then craft a power tranformer with max 64 amps. You can input sixteen 128 eu/t power sources and output 64 ampere at 32 eu/t. Modes can be changed with a soft mallet.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -123746,7 +123005,7 @@
     {
       "questID": 1270,
       "name": "Time for a Spade",
-      "description": "Having a Weeding Trowel, Hoe and Shovel in your Inventory is painful when dealing with crops. Get the Spade - it combines these items, is unbreakable, and increases the chance of getting seeds from plants.",
+      "description": "Having Weeding Trowel, Hoe and Shovel in Inventroy seems to be painful when dealing with crops. Get the Spade, that combines these Items, it\u0027s unbreakable andhighers the chanche of getting seeds from plants.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -123866,20 +123125,6 @@
               "Damage": 0,
               "tag": {
                 "owner:8": "berriespp",
-                "name:8": "Yellow Stonelilly",
-                "scan:4": 4,
-                "growth:4": 1,
-                "resistance:4": 1,
-                "gain:4": 1
-              }
-            },
-            {
-              "id": "IC2:itemCropSeed",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0,
-              "tag": {
-                "owner:8": "berriespp",
                 "name:8": "Goldfish Plant",
                 "scan:4": 4,
                 "growth:4": 1,
@@ -123893,13 +123138,13 @@
       ],
       "preRequisites": [
         724,
-        1081
+        1271
       ]
     },
     {
       "questID": 1271,
-      "name": "Extruder HV",
-      "description": "The HV Extruder is needed to extrude tough metals like Tungstensteel and HSS.",
+      "name": "Plate Bending HV",
+      "description": "This Plate Bending Machine allows you to directly make double, triple or more compressed plates, which might be useful for your first rocket.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -123933,7 +123178,7 @@
               "id": "gregtech:gt.blockmachines",
               "Count": 1,
               "OreDict": "",
-              "Damage": 283
+              "Damage": 223
             }
           ],
           "taskID": "bq_standard:retrieval"
@@ -123943,10 +123188,10 @@
         {
           "choices": [
             {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 16,
-              "OreDict": "",
-              "Damage": 11306
+              "id": "IC2:itemDensePlates",
+              "Count": 3,
+              "OreDict": "plateDenseSteel",
+              "Damage": 5
             },
             {
               "id": "IC2:itemPartCircuitAdv",
@@ -124049,7 +123294,7 @@
     {
       "questID": 1273,
       "name": "Brewing, the Industrial Way",
-      "description": "If you want brews or alcohol, I recommend you to build one of these. You might have noticed that you cannot build a brewing stand without Thaumcraft. But fear not, you can still find them in chests. Better get searching...",
+      "description": "If you want brews or alcohol, i recommend you to build one of these.You might have notice that you can not build a brewing stand without Thaumcraft. But fear not, you can still find them in chests.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -124191,8 +123436,8 @@
     },
     {
       "questID": 1275,
-      "name": "Fake Jï¿½germeister",
-      "description": "Jï¿½germeister is a common drink in germany, why don\u0027t you grab a bottle? This one seems to be a cheap fake tho...",
+      "name": "Fake Jägermeister",
+      "description": "Jägermeister is a common drink in germany, why don\u0027t you grab a bottle? This one does seems to be a cheap fake tho...",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -124266,7 +123511,7 @@
     {
       "questID": 1276,
       "name": "Korn and Doppelkorn",
-      "description": "Korn is german for wheat. That\u0027s why this special alcoholic brew is named like this. Doppelkorn means double-wheat.",
+      "description": "Korn is german for wheat. That\u0027s why this special alcoholic brew is called like this. Doppelkorn means double-wheat.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -124399,7 +123644,7 @@
     {
       "questID": 1278,
       "name": "Vodka",
-      "description": "Vodka is Russian for \"small Water\". It is a rather high proof alcoholic fluid.",
+      "description": "Vodka is russian for \"small Water\". It is a rather high proof alcoholic fluid.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -124466,7 +123711,7 @@
     {
       "questID": 1279,
       "name": "Firestone Ore/Dust",
-      "description": "Firestone ore is handy for some base building machines. Unforunately, it\u0027s in the nether...at the bottom of the lava ocean! Here are some tips for finding it\n\nFirestone can be mined with the GT miners, if you place it within range.\nFirestone only spawns in deep lava, at least 6 deep. It will only replace netherrack, so a fjord filled with soulsand won\u0027t have any. Can you think of ways to check the lava depth, and what\u0027s down there?\nNormally you can\u0027t see through lava, but if you enable nightvision on the nanosuit, you can see a short distance at the bottom. But how to prevent getting burned?\nAlternatively, if you keep your head at just the correct height above the lava and at the correct angle, you\u0027ll be able to see underneath it - surely there must be a hovering jetpack?\nFirestone ore and products will cause random fires to start nearby, so get it into a backpack quickly!",
+      "description": "Firestone ore is handy for some base building machines. Unforunately, it\u0027s in the nether...at the bottom of the lava ocean! Here are some tips for finding it\n\nFirestone can be mined with the GT miners, if you place it within range.\nFirestone only spawns in deep lava, at least 6 deep. It will only replace netherrack, so a fjord filled with soulsand won\u0027t have any. Can you think of ways to check the lava depth, and what\u0027s down there?\nNormally you can\u0027t see through lava, but if you enable nightvision on the nanosuit, you can see a short distance at the bottom. But how to prevent getting burned?\nAlternatively, if you keep your head at just the correct height above the lava and at the correct angle, you\u0027ll be able to see underneath it, Surely there must be a hovering jetpack?\nFirestone ore and products will cause random fires to start nearby, so get it into a backpack quickly!",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -124700,7 +123945,7 @@
     {
       "questID": 1282,
       "name": "The gathering: Sugar",
-      "description": "Stockpiling sugar might be a good idea if you have a sweet tooth. Or not?",
+      "description": "Stockpileing Sugar might be a good idea. Or not?",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -124835,8 +124080,8 @@
     },
     {
       "questID": 1284,
-      "name": "Wasps honey",
-      "description": "Giant wasps can be found in the Nether. Quick! Sneak into their hive and steal some honey!",
+      "name": "Whisps honey",
+      "description": "Giant whisps can be found in the Nether, quick! Sneak into their hive and steal some honey!",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -124858,7 +124103,7 @@
         "OreDict": "",
         "Damage": 3
       },
-      "visibility": "UNLOCKED",
+      "visibility": "NORMAL",
       "tasks": [
         {
           "consume": false,
@@ -124906,7 +124151,7 @@
     {
       "questID": 1285,
       "name": "Non-Industrial Rum",
-      "description": "Brewing rum is not an industrial task. It only requires a barrel and some sugarcanes.",
+      "description": "Brewing rum is not an industrial task. It only requiers a barrel and some sugarcanes.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -125014,7 +124259,7 @@
     {
       "questID": 1286,
       "name": "Primal Shrooms",
-      "description": "Primal shrooms allow you to refill wands easier before you can move nodes to your base.\nGo and find some in a magical forest biome. Try using a Nature\u0027s Compass. Or buy some if no biome is close to your location.",
+      "description": "Primal shrooms allow you to refill wands easier before you can move nodes to your base.\nGo and find some in a magical forrest biome or buy some if no biome is close to your location.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -125118,7 +124363,7 @@
     {
       "questID": 1287,
       "name": "Vish Shroom",
-      "description": "Magic mushrooms whoooo!",
+      "description": "Oh you feel so dirty. Go and take a bath.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -125172,13 +124417,13 @@
         }
       ],
       "preRequisites": [
-        1286
+        1097
       ]
     },
     {
       "questID": 1288,
       "name": "Hops, the source of beer",
-      "description": "If you don\u0027t want pure alcohol, but beer, get some hops by crossbreeding ICï¿½ crops.",
+      "description": "If you don\u0027t want pure alcohol, but beer, get some hops by crossbreeding IC² crops.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -125243,8 +124488,8 @@
     },
     {
       "questID": 1289,
-      "name": "Looting II",
-      "description": "The butchery knife from GT comes with a looting effect depending on the material. You will most likely use iron which will result in looting 2. Can be used to finish off mobs or to simply make your animal farms more efficient.",
+      "name": "tier0.5.quest3.name",
+      "description": "tier0.5.quest3.desc",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -125721,7 +124966,7 @@
     {
       "questID": 1294,
       "name": "Speeding up growth",
-      "description": "Used to accelerate the process of purifying crystals, which allows you to create pure certus quartz crystal, pure nether quartz crystal and pure fluix crystal. Must be powered by an ME Network via the top or bottom, and consumes a steady 8 ae/t while plugged in. Crystal Seeds must be in an adjacent water block to be affected - the seeds will shimmer more rapidly when in the presence of a powered crystal growth accelerator. Can only connect to cables, or other networked machines on the top and bottom of the machine.",
+      "description": "Used to accelerate the process of purifying crystals, which allows you to create pure certus quartz crystal, pure nether quartz crystal and pure fluix crystal. Must be powered by an ME Network via the top or bottom, and consumes a steady 8 ae/t while plugged in. Crystal Seeds must be in an adjacent water block to be effected, the seeds will shimmer more rapidly when in the presence of a powered crystal growth accelerator. Can only connect to cables, or other networked machines on the top and bottom of the machine.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -125917,7 +125162,7 @@
     {
       "questID": 1296,
       "name": "Purifying the impure",
-      "description": "Purified versions of nether, certus and fluix crystals",
+      "description": "Purified version of nether, certus and fluix crystal",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -126156,7 +125401,7 @@
     {
       "questID": 1298,
       "name": "Wireless Setup",
-      "description": "Allows you to configure which users, and what permissions the users have with the ME System. By existing it enforces permissions on the usage of the system.\n\nThe security system does not prevent destructive tampering, removing cables / machines or breaking of drives. If you need to protect your system from physical vandalism you will need another form of physical security. This block provides network level security.\n\nThe player who places the ME security terminal has full control over the network and cannot exclude himself any rights. By adding a blank biometric card you define a default behavior for every player who has no biometric card registered.\n\nIn addition to security on the software layer, you can link up your wireless terminal with the network and access it wirelessly.\n\n\nAllows wireless access via a wireless terminal. Range and power usage is determined based on the number of wireless boosters installed into the ME wireless access point. A network can have any number of ME wireless access point with any number of wireless boosters in each one, allowing you to optimize power usage and range by altering your setup. Requires a channel to be operational.",
+      "description": "Allows you to configure which users, and what permissions the users have with the ME System. By existing it enforces permissions on the usage of the system.\n\nThe security system does not prevent destructive tampering, removing cables / machines or breaking of drives. If you need to protect your system from physical vandalism you will need another form of physical security. This block provides network level security.\n\nThe player who places the ME security terminal has full control over the network and cannot exclude himself any rights. By adding a blank biometric card you define a default behavior for every player who has no own biometric card registered.\n\nOther than adding security on software layer, you can link up your wireless terminal with the network and access it wirelessly.\n\n\nAllows wireless access via a wireless terminal. Range and power usage is determined based on the number of wireless boosters installed into the ME wireless access point. A network can have any number of ME wireless access point with any number of wireless boosters in each one, allowing you to optimize power usage and range by altering your setup. Requires a channel to be operational.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -126252,7 +125497,7 @@
     },
     {
       "questID": 1299,
-      "name": "Dense boys",
+      "name": "Dense boyes",
       "description": "Giving your network even more stability. Dense energy cells store AE energy up to 1.6 million units. They do not accept power directly but are used to buffer power in an already existing ME Network.",
       "isMain": false,
       "isSilent": false,
@@ -126774,7 +126019,7 @@
     {
       "questID": 1305,
       "name": "For Fluid Recipes",
-      "description": "ME interface for fluids only.",
+      "description": "Me interface for fluids only.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -127422,7 +126667,7 @@
       "tasks": [
         {
           "partialMatch": true,
-          "ignoreNBT": true,
+          "ignoreNBT": false,
           "consume": false,
           "autoConsume": false,
           "requiredItems": [
@@ -127675,7 +126920,7 @@
       "tasks": [
         {
           "partialMatch": true,
-          "ignoreNBT": true,
+          "ignoreNBT": false,
           "consume": false,
           "autoConsume": false,
           "requiredItems": [
@@ -127928,7 +127173,7 @@
         {
           "partialMatch": true,
           "ignoreNBT": false,
-          "consume": false,
+          "consume": true,
           "autoConsume": false,
           "requiredItems": [
             {
@@ -127984,7 +127229,7 @@
     {
       "questID": 1320,
       "name": "Advanced Compressor",
-      "description": "The MV compressor is twice as fast as the LV one but uses 4x the power. I suggest crafting 4 MV compressors for the new biomass processing line.",
+      "description": "The mv compressor is double fast than the LV one and use 4x power. I suggest crafting 4 MV compressors for the new bio diesel processing line.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -128073,7 +127318,7 @@
     {
       "questID": 1321,
       "name": "Advanced Macerator",
-      "description": "The MV macerator is twice as fast as the LV one but uses 4x the power.",
+      "description": "The mv macerator is double fast than the LV one and use 4x power.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -128162,7 +127407,7 @@
     {
       "questID": 1322,
       "name": "Advanced Centrifuge",
-      "description": "The MV centrifuge is twice as fast as the LV one but uses 4x the power.",
+      "description": "The mv centrifuge is double fast than the LV one and use 4x power.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -128251,7 +127496,7 @@
     {
       "questID": 1323,
       "name": "Biomass",
-      "description": "Chose the IC2 or the gregtech way to make biomass. Water and BioChaff is needed.",
+      "description": "Chose the ic2 or the gregtech way to make biomass. Water and BioChaff is needed.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -128346,7 +127591,7 @@
     {
       "questID": 1324,
       "name": "Advanced Fluid Extractor",
-      "description": "The MV fluid extractor is twice as fast as the LV one but uses 4x the power.",
+      "description": "The mv fluid extractor is double fast than the LV one and use 4x power.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -128430,83 +127675,6 @@
       ],
       "preRequisites": [
         848
-      ]
-    },
-    {
-      "questID": 1325,
-      "name": "Dagger of Sacrifice",
-      "description": "Time to get more blood. Mobs are a good source for more blood. Transform your knife of sacrifice in your tier 2 altar into a dagger of sacrifice.",
-      "isMain": true,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "AWWayofTime:daggerOfSacrifice",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 0
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "AWWayofTime:daggerOfSacrifice",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 16
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinSurvivorII",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            },
-            {
-              "id": "dreamcraft:item.CoinBloodII",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        409
       ]
     },
     {
@@ -128678,7 +127846,7 @@
     {
       "questID": 1328,
       "name": "Pattern Terminal",
-      "description": "A specialized version of the ME crafting terminal designed to encode blank patterns into encoded patterns.\n\nLets you browse the contents of your network like other terminals, but also contains an area for designing patterns. There are two modes for pattern encoding. Crafting patterns, and processing patterns. Processing patterns are designed for use with machines that do not use standard crafting recipes - such as furnaces, or other machines. To select between modes, click the button to the right of the interface: when it shows a standard crafting table, it will create crafting patterns, and when it shows a furnace, it will create processing patterns.\n\nFor crafting patterns (\"Crafts...\"), you specify the input crafting materials on a standard 3x3 crafting grid, and the output materials are determined automatically.\n\nFor processing patterns (\"Creates...\"), you specify the input materials and output materials, including quantity, by placing stacks of items in the interface. If a processing operation is not guaranteed to succeed (such as secondary products from some machines), it will not work correctly as a processing pattern.\n\nWhen designing crafting patterns you can click the output to extract a crafted item as long as you have the materials required to craft the item.\nDon\u0027t forget to enable oredict substitution where needed.",
+      "description": "A specialized version of the ME crafting terminal designed to encode blank patterns into encoded patterns.\n\nLets you browse the contents of your network like other terminals, but also contains a area for designing patterns. There are two modes for pattern encoding. Crafting patterns, and processing patterns. Processing patterns are designed for use with machines that do not use standard crafting recipes; such as furnaces, or other machines. To select between modes, click the button to the right of the interface; when it shows a standard crafting table, it will create crafting patterns, and when it shows a furnace, it will create processing patterns.\n\nFor crafting patterns (\"Crafts...\"), you specify the input crafting materials on a standard 3x3 crafting grid, and the output materials are determined automatically.\n\nFor processing patterns (\"Creates...\"), you specify the input materials and output materials, including quantity, by placing stacks of items in the interface. If a processing operation is not guaranteed to succeed (such as secondary products from some machines), it will not work correctly as a processing pattern.\n\nWhen designing crafting patterns you can click the output to extract a crafted item as long as you have the materials required to craft the item.\nDon\u0027t forget to enable oredict substitution where needed.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -128761,7 +127929,7 @@
     {
       "questID": 1329,
       "name": "ME in your Cleanroom",
-      "description": "Wireless connector ï¿½ close range quantum bridge alternative.\nConnections are point-to-point ï¿½ you can\u0027t connect more than 2 blocks together. Each block will use 10 + distance2 AE/t. Does not work across dimensions. Power needs to be provided on only one side. Up to 32 channels can be transferred through the connection. Can connect directly to dense cables. ",
+      "description": "Wireless connector – close range quantum bridge alternative.\nConnections are point-to-point – you can\u0027t connect more than 2 blocks together. Each block will use 10 + distance2 AE/t. Does not work across dimensions. Power needs to be provided on only one side. Up to 32 channels can be transferred through the connection. Can connect directly to dense cables. ",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -128856,7 +128024,7 @@
     {
       "questID": 1330,
       "name": "Ore Dictionary Output",
-      "description": "The ME ore dictionary export bus will attempt to push the configured item/fluid [From the same ore dictionary] from the ME network into a machine or other input inventory. To configure an item/liquid, type in the item\u0027s name [e.g. if you want to export all ores put \"ore*\"]. The rate of export is very fast.",
+      "description": "The ME ore dictionary export bus  will attempt to push the configured item/fluid [From the same ore dictionary] from the ME network into a machine or other input inventory. To configure an item/liquid, type in the item\u0027s name [e.g. if you want to export all ores put \"ore*\"]. The rate of export is very fast.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -129024,7 +128192,7 @@
     {
       "questID": 1332,
       "name": "Compressed Solar LV",
-      "description": "ï¿½lThe power of the sun x10.ï¿½rThis solar panel works like 10 regular ones, but costs only 9. How is this possible? Magic! ï¿½ ï¿½lNOTE: They give out GT EU. NO TRANSFORMER NEEDED!",
+      "description": "§lThe power of the sun x10.§rThis solar panel works like 10 regular ones, but costs only 9. How is this possible? Magic! § §lNOTE: They give out GTEU. NO TRANSFORMER NEEDED!",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -129056,7 +128224,7 @@
           "requiredItems": [
             {
               "id": "IC2:blockGenerator",
-              "Count": 8,
+              "Count": 9,
               "OreDict": "",
               "Damage": 3
             },
@@ -129065,6 +128233,27 @@
               "Count": 1,
               "OreDict": "",
               "Damage": 0
+            }
+          ],
+          "taskID": "bq_standard:retrieval"
+        },
+        {
+          "partialMatch": false,
+          "ignoreNBT": true,
+          "consume": false,
+          "autoConsume": false,
+          "requiredItems": [
+            {
+              "id": "gregtech:gt.blockmachines",
+              "Count": 1,
+              "OreDict": "",
+              "Damage": 21
+            },
+            {
+              "id": "IC2:blockElectric",
+              "Count": 1,
+              "OreDict": "",
+              "Damage": 3
             }
           ],
           "taskID": "bq_standard:retrieval"
@@ -129105,14 +128294,14 @@
         }
       ],
       "preRequisites": [
-        237,
-        935
+        62,
+        237
       ]
     },
     {
       "questID": 1333,
       "name": "Essentia Generator: Potentia",
-      "description": "Aren\u0027t you tired of voiding all that useless potentia essentia? Well here\u0027s the solution:\nA generator that consumes potentia and outputs GT EU.\nï¿½oï¿½oï¿½rï¿½lNO TRANSFORMER NEEDED!",
+      "description": "Arent you tired of voiding all that useless potentia essentia? Well here\u0027s the solution:\nA generator that consumes potentia and outputs GTEU.\n§o§o§r§lNO TRANSFORMER NEEDED!",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -129200,7 +128389,7 @@
     {
       "questID": 1334,
       "name": "Essentia Generator: Auram",
-      "description": "This Generator is quite tricky. It requires Auram Essentia, that isn\u0027t that common, but its output is nice.",
+      "description": "This Generator is quite tricky. It requieres Auram Essentia, that isn\u0027t that common, but its output is nice.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -129422,7 +128611,7 @@
     {
       "questID": 1336,
       "name": "Double Compressed Solar",
-      "description": "100EU/t for 72x1EU/t Solars? Sounds like a good deal. Get one of these. They can be Infused as well.",
+      "description": "100EU/t for 72x1EU/t Solars? Sounds like a good deal. Get one of these. They can be Infused aswell.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -129497,7 +128686,7 @@
     {
       "questID": 1337,
       "name": "Even more Infused",
-      "description": "You can infuse double or triple compressed solars as well.",
+      "description": "You can infuse double or triplecompressed solars aswell.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -129534,7 +128723,7 @@
     {
       "questID": 1338,
       "name": "Full power",
-      "description": "Triple Compressed Solars. Yes, that\u0027s right. They are a bit more expensive than their lower counterparts, 576 Solars in total. But they give out 1,000 GT EU per tick and have no need to be cleaned.  How so? Magic.",
+      "description": "Triple Compressed Solars. Yes, thats right. They are a bit more expensive than their lower counterparts, 576 Solars in total. But they give out 1.000IC2EU per tick and have no  need to be cleaned due to their inner magic. How so? Magic.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -129704,7 +128893,7 @@
     {
       "questID": 1340,
       "name": "Essentia Generator: Arbor",
-      "description": "When using magical plants to get Praecantatio Essentia, you\u0027ll end up with a couple dozen of Arbor Essentia jars.  But no worries! This generator runs on Arbor! Awesome!",
+      "description": "When it comes to getting Precantatio Essentia, you\u0027ll end up with a couple dozends of Arbor Essentia jars.  But no worries! This generator runs on Arbor! Awesome!",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -129784,7 +128973,7 @@
     {
       "questID": 1341,
       "name": "Essentia Generator: Aer",
-      "description": "Sugarcanes to power...? This generator runs on Aer Essentia, it might not be as powerful as it\u0027s counterparts, but it\u0027s fuel is cheap.",
+      "description": "Sugarcanes to power...? This generator runs on Aer Essentia, it might not be as powerfull as it\u0027s counterparts, but it\u0027s fuel is cheap.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -129864,7 +129053,7 @@
     {
       "questID": 1342,
       "name": "Essentia Generator: Lucrum",
-      "description": "This highly-warped, high-power Essentia generator is a lifesaver, when you run out of energy. Just toss some gold into your Arcane Furnace and burn the Lucrum you get.",
+      "description": "This highly-warped-high-power Essentia generator is a lifesaver, when you run out of energy. Just toss some gold into your Arcane Furnace and burn the Lucrum you got.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -130010,8 +129199,8 @@
     },
     {
       "questID": 1344,
-      "name": "Angel Wings",
-      "description": "Since you have access to better materials than cardboard now, you wanted to make wings. Angel wings.",
+      "name": "Angle Wings",
+      "description": "Since you have access to better materials than cardboard now, you wanted to make wings. Angle wings.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -130077,8 +129266,8 @@
     },
     {
       "questID": 1345,
-      "name": "Secret-Angel-Assasin",
-      "description": "Infusing your Wings with Nano-Technologies seems to be the next step, to further improve them and combine magic and technology.",
+      "name": "Secret-Angle-Assasin",
+      "description": "Infusing your Wings with Nano-Technologies seems to be the next step, to further improofe them and combine magic and technology.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -130517,7 +129706,7 @@
     {
       "questID": 1350,
       "name": "Nano Goggles",
-      "description": "The #1 product for spies and wanna-be-spies. Nano-Goggles. Don\u0027t you want one of these too? But they are sold out? Craft some!",
+      "description": "The #1 product for spys and wanna-be-spys. Nano-Goggles. Don\u0027t you want one of these too? But they are sold out? Craft some!",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -130599,7 +129788,7 @@
     {
       "questID": 1351,
       "name": "Quantum Goggles",
-      "description": "As you continue to progress, you notice that your black goggles don\u0027t match your nice white and shiny armor. You decide to get a pair of white ones.",
+      "description": "As you continue to progress, you notice that your black goggles don\u0027t fit to your nice white and shiny armor. You decide to get a pair of white ones.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -130768,7 +129957,7 @@
     {
       "questID": 1353,
       "name": "Sparking Nitor...?",
-      "description": "ï¿½eYELLOW!ï¿½0 What an ungly color! I want ï¿½5PURPLE ï¿½0Nitor! Get me some and you\u0027ll receive something nice in exchange.",
+      "description": "§eYELLOW!§0 What an ungly color! I want §5PURPLE §0Nitor! Get me some and you\u0027ll recive something nice in exchange.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -130842,8 +130031,8 @@
     },
     {
       "questID": 1354,
-      "name": "Rechargeable Scribing Tools",
-      "description": "Are you tired of getting all the Ink for your scribing and you don\u0027t want to use ï¿½4your bloodï¿½0 either? Get this Hi-Tech Scribing Device which will make your life much easier!",
+      "name": "Rechageable Scribing Tools",
+      "description": "Are you tired of getting all the Ink for your scribing and you don\u0027t want to use §4your blood§0 aswell? Get this Hi-Tech Scribing Device which will make your life much easier!",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -130929,8 +130118,8 @@
     },
     {
       "questID": 1355,
-      "name": "Angel Wings - Ultra Force!",
-      "description": "From ore to ingot, from nano to quantum, as you progress, your technology level increases, so should your wings as well.",
+      "name": "Angle Wings - Ultra Force!",
+      "description": "From ore to ingot, from nano to quantum, as you progress, your technology level increases, so should your wings aswell.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -131038,7 +130227,7 @@
     },
     {
       "questID": 1356,
-      "name": "Angel Wings - Combine!",
+      "name": "Angle Wings - Combine!",
       "description": "The last step is to combine the quantum armor with your quantum wings.",
       "isMain": false,
       "isSilent": false,
@@ -131406,7 +130595,7 @@
     {
       "questID": 1361,
       "name": "What the Heck...?",
-      "description": "You found a yellow-ish glowing ball. It might be useful later on.",
+      "description": "You found a yellow-ish glowing ball. It might be usefull later on.",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -131466,7 +130655,7 @@
     {
       "questID": 1362,
       "name": "The One Ring.",
-      "description": "So you found it. The One Ring, forged by a mighty Dark Wizard. A strange feeling tells you to put it on. The Ring seems to whisper to you as well...",
+      "description": "So you found it. The One Ring, forged by a mighty Dark Wizzard. A strange feeling tells you to put it on. The Ring seems to whisper to you aswell...",
       "isMain": false,
       "isSilent": false,
       "lockedProgress": false,
@@ -131660,5579 +130849,12 @@
       ],
       "rewards": [],
       "preRequisites": []
-    },
-    {
-      "questID": 1366,
-      "name": "Ocean Bees",
-      "description": "Want some Ocean Bees? Buy some!",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": 48000,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "Forestry:beeQueenGE",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 0,
-        "tag": {
-          "MaxH:4": 20,
-          "Mate:10": {
-            "Chromosomes:9": [
-              {
-                "UID1:8": "extrabees.species.ocean",
-                "UID0:8": "extrabees.species.ocean",
-                "Slot:4": 0
-              },
-              {
-                "UID1:8": "forestry.speedSlowest",
-                "UID0:8": "forestry.speedSlowest",
-                "Slot:4": 1
-              },
-              {
-                "UID1:8": "forestry.lifespanShorter",
-                "UID0:8": "forestry.lifespanShorter",
-                "Slot:4": 2
-              },
-              {
-                "UID1:8": "forestry.fertilityNormal",
-                "UID0:8": "forestry.fertilityNormal",
-                "Slot:4": 3
-              },
-              {
-                "UID1:8": "forestry.toleranceNone",
-                "UID0:8": "forestry.toleranceNone",
-                "Slot:4": 4
-              },
-              {
-                "UID1:8": "forestry.boolFalse",
-                "UID0:8": "forestry.boolFalse",
-                "Slot:4": 5
-              },
-              {
-                "UID1:8": "forestry.toleranceBoth1",
-                "UID0:8": "forestry.toleranceBoth1",
-                "Slot:4": 7
-              },
-              {
-                "UID1:8": "forestry.boolTrue",
-                "UID0:8": "forestry.boolTrue",
-                "Slot:4": 8
-              },
-              {
-                "UID1:8": "forestry.boolFalse",
-                "UID0:8": "forestry.boolFalse",
-                "Slot:4": 9
-              },
-              {
-                "UID1:8": "extrabees.flower.water",
-                "UID0:8": "extrabees.flower.water",
-                "Slot:4": 10
-              },
-              {
-                "UID1:8": "forestry.floweringSlowest",
-                "UID0:8": "forestry.floweringSlowest",
-                "Slot:4": 11
-              },
-              {
-                "UID1:8": "forestry.territoryAverage",
-                "UID0:8": "forestry.territoryAverage",
-                "Slot:4": 12
-              },
-              {
-                "UID1:8": "extrabees.effect.water",
-                "UID0:8": "extrabees.effect.water",
-                "Slot:4": 13
-              }
-            ]
-          },
-          "Health:4": 20,
-          "IsAnalyzed:4": 1,
-          "Genome:10": {
-            "Chromosomes:9": [
-              {
-                "UID1:8": "extrabees.species.ocean",
-                "UID0:8": "extrabees.species.ocean",
-                "Slot:4": 0
-              },
-              {
-                "UID1:8": "forestry.speedSlowest",
-                "UID0:8": "forestry.speedSlowest",
-                "Slot:4": 1
-              },
-              {
-                "UID1:8": "forestry.lifespanShorter",
-                "UID0:8": "forestry.lifespanShorter",
-                "Slot:4": 2
-              },
-              {
-                "UID1:8": "forestry.fertilityNormal",
-                "UID0:8": "forestry.fertilityNormal",
-                "Slot:4": 3
-              },
-              {
-                "UID1:8": "forestry.toleranceNone",
-                "UID0:8": "forestry.toleranceNone",
-                "Slot:4": 4
-              },
-              {
-                "UID1:8": "forestry.boolFalse",
-                "UID0:8": "forestry.boolFalse",
-                "Slot:4": 5
-              },
-              {
-                "UID1:8": "forestry.toleranceBoth1",
-                "UID0:8": "forestry.toleranceBoth1",
-                "Slot:4": 7
-              },
-              {
-                "UID1:8": "forestry.boolTrue",
-                "UID0:8": "forestry.boolTrue",
-                "Slot:4": 8
-              },
-              {
-                "UID1:8": "forestry.boolFalse",
-                "UID0:8": "forestry.boolFalse",
-                "Slot:4": 9
-              },
-              {
-                "UID1:8": "extrabees.flower.water",
-                "UID0:8": "extrabees.flower.water",
-                "Slot:4": 10
-              },
-              {
-                "UID1:8": "forestry.floweringSlowest",
-                "UID0:8": "forestry.floweringSlowest",
-                "Slot:4": 11
-              },
-              {
-                "UID1:8": "forestry.territoryAverage",
-                "UID0:8": "forestry.territoryAverage",
-                "Slot:4": 12
-              },
-              {
-                "UID1:8": "extrabees.effect.water",
-                "UID0:8": "extrabees.effect.water",
-                "Slot:4": 13
-              }
-            ]
-          }
-        }
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": true,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "dreamcraft:item.CoinBeesI",
-              "Count": 5,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "Forestry:beePrincessGE",
-              "Count": 4,
-              "OreDict": "",
-              "Damage": 0,
-              "tag": {
-                "MaxH:4": 20,
-                "Health:4": 20,
-                "IsAnalyzed:4": 1,
-                "Genome:10": {
-                  "Chromosomes:9": [
-                    {
-                      "UID1:8": "extrabees.species.ocean",
-                      "UID0:8": "extrabees.species.ocean",
-                      "Slot:4": 0
-                    },
-                    {
-                      "UID1:8": "forestry.speedSlowest",
-                      "UID0:8": "forestry.speedSlowest",
-                      "Slot:4": 1
-                    },
-                    {
-                      "UID1:8": "forestry.lifespanShorter",
-                      "UID0:8": "forestry.lifespanShorter",
-                      "Slot:4": 2
-                    },
-                    {
-                      "UID1:8": "forestry.fertilityNormal",
-                      "UID0:8": "forestry.fertilityNormal",
-                      "Slot:4": 3
-                    },
-                    {
-                      "UID1:8": "forestry.toleranceNone",
-                      "UID0:8": "forestry.toleranceNone",
-                      "Slot:4": 4
-                    },
-                    {
-                      "UID1:8": "forestry.boolFalse",
-                      "UID0:8": "forestry.boolFalse",
-                      "Slot:4": 5
-                    },
-                    {
-                      "UID1:8": "forestry.toleranceBoth1",
-                      "UID0:8": "forestry.toleranceBoth1",
-                      "Slot:4": 7
-                    },
-                    {
-                      "UID1:8": "forestry.boolTrue",
-                      "UID0:8": "forestry.boolTrue",
-                      "Slot:4": 8
-                    },
-                    {
-                      "UID1:8": "forestry.boolFalse",
-                      "UID0:8": "forestry.boolFalse",
-                      "Slot:4": 9
-                    },
-                    {
-                      "UID1:8": "extrabees.flower.water",
-                      "UID0:8": "extrabees.flower.water",
-                      "Slot:4": 10
-                    },
-                    {
-                      "UID1:8": "forestry.floweringSlowest",
-                      "UID0:8": "forestry.floweringSlowest",
-                      "Slot:4": 11
-                    },
-                    {
-                      "UID1:8": "forestry.territoryAverage",
-                      "UID0:8": "forestry.territoryAverage",
-                      "Slot:4": 12
-                    },
-                    {
-                      "UID1:8": "extrabees.effect.water",
-                      "UID0:8": "extrabees.effect.water",
-                      "Slot:4": 13
-                    }
-                  ]
-                }
-              }
-            },
-            {
-              "id": "Forestry:beeDroneGE",
-              "Count": 4,
-              "OreDict": "",
-              "Damage": 0,
-              "tag": {
-                "MaxH:4": 20,
-                "Health:4": 20,
-                "IsAnalyzed:4": 1,
-                "Genome:10": {
-                  "Chromosomes:9": [
-                    {
-                      "UID1:8": "extrabees.species.ocean",
-                      "UID0:8": "extrabees.species.ocean",
-                      "Slot:4": 0
-                    },
-                    {
-                      "UID1:8": "forestry.speedSlowest",
-                      "UID0:8": "forestry.speedSlowest",
-                      "Slot:4": 1
-                    },
-                    {
-                      "UID1:8": "forestry.lifespanShorter",
-                      "UID0:8": "forestry.lifespanShorter",
-                      "Slot:4": 2
-                    },
-                    {
-                      "UID1:8": "forestry.fertilityNormal",
-                      "UID0:8": "forestry.fertilityNormal",
-                      "Slot:4": 3
-                    },
-                    {
-                      "UID1:8": "forestry.toleranceNone",
-                      "UID0:8": "forestry.toleranceNone",
-                      "Slot:4": 4
-                    },
-                    {
-                      "UID1:8": "forestry.boolFalse",
-                      "UID0:8": "forestry.boolFalse",
-                      "Slot:4": 5
-                    },
-                    {
-                      "UID1:8": "forestry.toleranceBoth1",
-                      "UID0:8": "forestry.toleranceBoth1",
-                      "Slot:4": 7
-                    },
-                    {
-                      "UID1:8": "forestry.boolTrue",
-                      "UID0:8": "forestry.boolTrue",
-                      "Slot:4": 8
-                    },
-                    {
-                      "UID1:8": "forestry.boolFalse",
-                      "UID0:8": "forestry.boolFalse",
-                      "Slot:4": 9
-                    },
-                    {
-                      "UID1:8": "extrabees.flower.water",
-                      "UID0:8": "extrabees.flower.water",
-                      "Slot:4": 10
-                    },
-                    {
-                      "UID1:8": "forestry.floweringSlowest",
-                      "UID0:8": "forestry.floweringSlowest",
-                      "Slot:4": 11
-                    },
-                    {
-                      "UID1:8": "forestry.territoryAverage",
-                      "UID0:8": "forestry.territoryAverage",
-                      "Slot:4": 12
-                    },
-                    {
-                      "UID1:8": "extrabees.effect.water",
-                      "UID0:8": "extrabees.effect.water",
-                      "Slot:4": 13
-                    }
-                  ]
-                }
-              }
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        1121
-      ]
-    },
-    {
-      "questID": 1367,
-      "name": "Upgrade your Forestry Backpack",
-      "description": "With your woven silk you can upgrade your Forestry backpacks. Each Pack has 45 slots.\nYou need a carpenter, your old backpack and a bit of seed oil.\n\nIf the recipe is not working, put the bag in a crafting grid to reset additional nbt data.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "Forestry:diggerBag",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 0
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "Forestry:craftingMaterial",
-              "Count": 18,
-              "OreDict": "",
-              "Damage": 3
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        },
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "Forestry:diggerBagT2",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            },
-            {
-              "id": "Forestry:minerBagT2",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "choices": [
-            {
-              "id": "Forestry:craftingMaterial",
-              "Count": 9,
-              "OreDict": "",
-              "Damage": 3
-            },
-            {
-              "id": "gregtech:gt.metatool.01",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 28,
-              "tag": {
-                "GT.ToolStats:10": {
-                  "PrimaryMaterial:8": "DamascusSteel",
-                  "MaxDamage:4": 128000,
-                  "SecondaryMaterial:8": "DamascusSteel"
-                }
-              }
-            },
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 26
-            }
-          ],
-          "rewardID": "bq_standard:choice"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinBeesI",
-              "Count": 5,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        486,
-        995
-      ]
-    },
-    {
-      "questID": 1368,
-      "name": "Lost in the Twilight Forest",
-      "description": "If you stay in the Twilight Forest and your portal gets broken, you are stuck. Every 24h you are able to exchange some materials to get a new portal crystal to escape.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": 1728000,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "dreamcraft:item.TwilightCrystal",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 0
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": true,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "TwilightForest:item.tfFeather",
-              "Count": 2,
-              "OreDict": "",
-              "Damage": 0
-            },
-            {
-              "id": "TwilightForest:tile.TFFirefly",
-              "Count": 4,
-              "OreDict": "",
-              "Damage": 0
-            },
-            {
-              "id": "TwilightForest:tile.TFPlant",
-              "Count": 4,
-              "OreDict": "",
-              "Damage": 3
-            },
-            {
-              "id": "TwilightForest:tile.TFLog",
-              "Count": 64,
-              "OreDict": "",
-              "Damage": 1
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.TwilightCrystal",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        225
-      ]
-    },
-    {
-      "questID": 1369,
-      "name": "Time to find some Amber",
-      "description": "Every Thaumcraft Infused Stone vein has a bit of amber ore in it. Go and find some amber ore.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "Thaumcraft:ItemResource",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 6
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.blockores",
-              "Count": 16,
-              "OreDict": "",
-              "Damage": 514
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "Thaumcraft:ItemResource",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 1
-            },
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 9
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinAdventure",
-              "Count": 25,
-              "OreDict": "",
-              "Damage": 0
-            },
-            {
-              "id": "dreamcraft:item.CoinDarkWizard",
-              "Count": 25,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        255
-      ]
-    },
-    {
-      "questID": 1370,
-      "name": "Light it up!",
-      "description": "The arcane lamp creates additional light sources which acts like a Torch in a sphere with a radius of 16 blocks centered on it.\nWhen attached to the base of an arcane bore, the arcane lamp gains an additional ability: It will light up the tunnel that the bore digs.\"",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "Thaumcraft:blockMetalDevice",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 7
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "Thaumcraft:blockMetalDevice",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 7
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "Thaumcraft:blockCosmeticOpaque",
-              "Count": 4,
-              "OreDict": "",
-              "Damage": 0
-            },
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 9
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinDarkWizard",
-              "Count": 25,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        1369
-      ]
-    },
-    {
-      "questID": 1371,
-      "name": "LOX and Bagels",
-      "description": "The LOX canister is an alternate solution to refilling your oxygen tanks.\nTo make liquid oxygen you need 16 oxygen cells, a universal fluid cell, and a circuit config 16. Transfer the oxygen gas into an MV+ assembler, and put in the universal fluid cell and circuit to get 1 cell of compressed oxygen.\nPut this in the vacuum freeezer to get 1 cell of liquid oxygen.\nTransfer this liquid oxygen into a tank, and then into a LOX canister.\nTo refill your oxygen tanks just put the tank and the LOX canister in the crafting grid to transfer oxygen.\nEach LOX canister can fill 4 Heavy Oxygen Tanks, 6 Medium Oxygen Tanks, or 12 Light Oxygen Tanks.\n\nSo much Greggy!",
-      "isMain": true,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "GalacticraftMars:item.canisterPartialLOX",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 1
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": true,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 16,
-              "OreDict": "",
-              "Damage": 30013
-            },
-            {
-              "id": "IC2:itemFluidCell",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0,
-              "tag": {}
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        },
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "IC2:itemFluidCell",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0,
-              "tag": {
-                "Fluid:10": {
-                  "FluidName:8": "compressedoxygen",
-                  "Amount:4": 1000
-                }
-              }
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        },
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "IC2:itemFluidCell",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0,
-              "tag": {
-                "Fluid:10": {
-                  "FluidName:8": "liquidoxygen",
-                  "Amount:4": 1000
-                }
-              }
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        },
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "GalacticraftCore:item.oilCanisterPartial",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 1001
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        },
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "GalacticraftMars:item.canisterPartialLOX",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 1
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "choices": [
-            {
-              "id": "GalacticraftCore:item.oilCanisterPartial",
-              "Count": 2,
-              "OreDict": "",
-              "Damage": 1001
-            },
-            {
-              "id": "GalacticraftCore:tile.oxygenPipe",
-              "Count": 16,
-              "OreDict": "",
-              "Damage": 0
-            },
-            {
-              "id": "GalacticraftCore:item.oxygenTankLightFull",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 900
-            },
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 6
-            }
-          ],
-          "rewardID": "bq_standard:choice"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinTechnicianII",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        827
-      ]
-    },
-    {
-      "questID": 1372,
-      "name": "Wand Focus Fire",
-      "description": "The Wand Focus: Fire is a basic wand focus. When equipped to a wand, it will be able to spew a short-range cone of fire by holding down the right mouse button. Its base vis cost is 0.1 ignis per second.\n\nThis focus can be upgraded at the Focal Manipulator.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "Thaumcraft:FocusFire",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 0
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "Thaumcraft:FocusFire",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 9
-            },
-            {
-              "id": "Thaumcraft:ItemLootBag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinDarkWizard",
-              "Count": 25,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        230
-      ]
-    },
-    {
-      "questID": 1373,
-      "name": "Wand Focus Excavation",
-      "description": "The Wand Focus: Excavation when equipped to a wand, will emit a green beam of light that will mine blocks of any hardness (except for blocks like Bedrock) from a distance.\nIts base vis cost is 0.15  terra per tick that it mines a block. It is also used in operating the Arcane Bore.\n\nThis focus can be upgraded at the Focal Manipulator.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "Thaumcraft:FocusExcavation",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 0
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "Thaumcraft:FocusExcavation",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 9
-            },
-            {
-              "id": "Thaumcraft:ItemLootBag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 1
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinDarkWizardI",
-              "Count": 5,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        1372,
-        234
-      ]
-    },
-    {
-      "questID": 1374,
-      "name": "Wand Focus Shock",
-      "description": "The Wand Focus: Shock when equipped to a wand will shoot a bolt of lightning when the right mouse button is pressed. It homes in slightly to the nearest mob/player from where it is aimed. Its base vis cost is 0.25 air per cast.\n\nThis focus can be upgraded at the Focal Manipulator.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "Thaumcraft:FocusShock",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 0
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "Thaumcraft:FocusShock",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 9
-            },
-            {
-              "id": "Thaumcraft:ItemLootBag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 1
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinDarkWizardI",
-              "Count": 5,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        1372,
-        234
-      ]
-    },
-    {
-      "questID": 1375,
-      "name": "Wand Focus Equal Trade",
-      "description": "Wand Focus: Equal Trade is a wand focus added by Thaumcraft 4. It is used to switch out blocks in the world with blocks in the player\u0027s inventory. Shift right-clicking on a block with it equipped will attune the focus to the block, making it the substitute block. Left-clicking on another block will replace it with the substitute block. Right-clicking will transform a 3x3 area of blocks that the player can see (the focus will not affect blocks behind those). This range can be extended by using a Focal Manipulator. Each use costs 0.05 ordo 0.05 perditio and 0.05 terra.\n\nThis focus can be upgraded at the Focal Manipulator.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "Thaumcraft:FocusTrade",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 0
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "Thaumcraft:FocusTrade",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 9
-            },
-            {
-              "id": "Thaumcraft:ItemLootBag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 1
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinDarkWizardI",
-              "Count": 5,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        1372,
-        234
-      ]
-    },
-    {
-      "questID": 1376,
-      "name": "Wand Focus Frost",
-      "description": "The Wand Focus: Frost when equipped to a wand will launch a ball of ice that can bounce off of blocks and mobs if their hardness is high enough.  It will inflict Slowness on mobs, freeze water and solidify lava.  Its base vis cost is 0.05 aqua 0.02 ignis and 0.02 perditio per cast.\n\nThis focus can be upgraded at the Focal Manipulator.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "Thaumcraft:FocusFrost",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 0
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "Thaumcraft:FocusFrost",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 9
-            },
-            {
-              "id": "Thaumcraft:ItemLootBag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 1
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinDarkWizardI",
-              "Count": 5,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        1372,
-        234
-      ]
-    },
-    {
-      "questID": 1377,
-      "name": "Wand Focus Warding",
-      "description": "The Wand Focus: Warding can be used to make blocks invincible. To ward a block, right click on it with a wand or staff with this focus on it. This will make the block invincible until it is unwarded by right clicking it again with the wand. Take note that only the player who warded the block can unward it. \n\nWarded Blocks are completely indestructible and will produce particle effects similiar to runic shielding when the owner or another player tries to break it. Also, blocks that are affected by gravity(such as sand and gravel) will not fall when warded. Warded blocks cannot be affected by any outside influence such as redstone and pistons. If you attempt to ward glass, it will break the glass instead. There is a block known as warded glass available within the warded arcana research. The only way to break the warded block is via the owner right clicking with a wand in hand. Warding a block costs 0.1 aqua, 0.25 ordo and 0.25 terra.\n\nSpecial Note: Warded blocks emit light.\n\nThis focus can be upgraded at the Focal Manipulator.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "Thaumcraft:FocusWarding",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 0
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "Thaumcraft:FocusWarding",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 10
-            },
-            {
-              "id": "Thaumcraft:ItemLootBag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 2
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinDarkWizardII",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        1373,
-        238
-      ]
-    },
-    {
-      "questID": 1378,
-      "name": "Wand Focus Portable Hole",
-      "description": "The Wand Focus: Portable Hole when equipped to a wand will create a temporary 3x3 hole centered on the targeted block that will go 32 blocks. Some blocks cannot be passed through, such as Bedrock. Its base vis cost is air 0.1  and perditio 0.1  per cast.\n\nThis focus can be upgraded at the Focal Manipulator.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "Thaumcraft:FocusPortableHole",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 0
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "Thaumcraft:FocusPortableHole",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 10
-            },
-            {
-              "id": "Thaumcraft:ItemLootBag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 2
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinDarkWizardII",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        1375,
-        238
-      ]
-    },
-    {
-      "questID": 1379,
-      "name": "Cart with Chunkloader",
-      "description": "When transporting oil from long distances, a train is going to need a chunk loader. Craft one, and I\u0027ll give you a second one for free.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "Railcraft:cart.anchor",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 0
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "Railcraft:cart.anchor",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "Railcraft:cart.anchor",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            },
-            {
-              "id": "dreamcraft:item.CoinChunkloaderTierI",
-              "Count": 4,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinAdventureI",
-              "Count": 5,
-              "OreDict": "",
-              "Damage": 0
-            },
-            {
-              "id": "dreamcraft:item.CoinTechnicianI",
-              "Count": 5,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        1182,
-        1180
-      ]
-    },
-    {
-      "questID": 1380,
-      "name": "Wand Focus Pech\u0027s Curse",
-      "description": "The Pech\u0027s Curse is a rare wand focus which cannot be crafted by the player. It can only be obtained from a Pech Thaumaturge -- either by trading, or by killing it for the drop. (If attacked, the Pech will use it against you!)  Its vis cost per shot is 0.1 Perditio, 0.1 Terra and 0.1 Aqua.\n\nThe focus fires a small ball of energy with a bright bluish-green trail. This missile is affected by gravity, so the shots need to be \"arced\" to hit distant targets. When the shot hits a mob, it does one heart of damage and randomly inflicts one of several effects on the target: Poison, Weakness, or Slowness. A 5th-level upgrade to the focus can make it give all the effects at once.\n\nThis focus can be upgraded at the Focal Manipulator.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "Thaumcraft:FocusPech",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 0
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "Thaumcraft:FocusPech",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 10
-            },
-            {
-              "id": "Thaumcraft:ItemLootBag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 2
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinDarkWizardII",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        234
-      ]
-    },
-    {
-      "questID": 1381,
-      "name": "Wand Focus Primal",
-      "description": "The Wand Focus: Primal will hurl an orb of primal energy while holding right-click with it equipped. The orb explodes on impact, and has a small chance to cause other effects, such as creating taint, or a node at the impact site. Its base vis cost changes every tick.\n\nThis focus can be upgraded at the Focal Manipulator.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "Thaumcraft:FocusPrimal",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 0
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "Thaumcraft:FocusPrimal",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 10
-            },
-            {
-              "id": "Thaumcraft:ItemLootBag",
-              "Count": 2,
-              "OreDict": "",
-              "Damage": 2
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinDarkWizardII",
-              "Count": 2,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        285
-      ]
-    },
-    {
-      "questID": 1382,
-      "name": "Pimp your Wand Focus",
-      "description": "The Manipulator requires both XP levels and centi-vis in order to upgrade foci. Each Focus can be upgraded a total of five times, with the level and vis cost increasing by 8 for each upgrade. Some upgrades can be applied only at certain levels (often only at level 3), and others have prerequisite upgrades. Some upgrades like Frugal and Potency can be applied multiple times. All upgrades are permanent, and there is currently no way to remove them.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "Thaumcraft:blockStoneDevice",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 13
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "Thaumcraft:blockStoneDevice",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 13
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "Thaumcraft:ItemResource",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 15
-            },
-            {
-              "id": "Thaumcraft:ItemLootBag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 1
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinDarkWizardI",
-              "Count": 5,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        275
-      ]
-    },
-    {
-      "questID": 1383,
-      "name": "Advanced Node Stabilizer",
-      "description": "The advanced node stabilizer acts like a normal node stabilizer but with key differences. It will still stop the node it affects from being drained but the node can now drain from other lesser nodes. It also has a higher chance to improve fading and unstable nodes. The downside is that any nodes it affects will have their recharge rates effectively reduced to nothing. They will recharge at an extremely reduced rate.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "Thaumcraft:blockStoneDevice",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 10
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "Thaumcraft:blockStoneDevice",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 10
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "Thaumcraft:ItemResource",
-              "Count": 4,
-              "OreDict": "",
-              "Damage": 0
-            },
-            {
-              "id": "Thaumcraft:ItemResource",
-              "Count": 4,
-              "OreDict": "",
-              "Damage": 1
-            },
-            {
-              "id": "Thaumcraft:ItemLootBag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 1
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinDarkWizardI",
-              "Count": 5,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        276
-      ]
-    },
-    {
-      "questID": 1384,
-      "name": "Wand Focus Efreet\u0027s Flame",
-      "description": "The Wand Focus: Efreet\u0027s Flame is a Wand Focus that smelts blocks like a Furnace would when pointed and fired at them. It shoots a beam similar to the Wand Focus: Excavation. Each usage consumes 0.45 Ignis and 0.12 Perditio\n\nThis focus can be upgraded at the Focal Manipulator.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "ThaumicTinkerer:focusSmelt",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 0
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "ThaumicTinkerer:focusSmelt",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 9
-            },
-            {
-              "id": "Thaumcraft:ItemLootBag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 1
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinDarkWizardI",
-              "Count": 5,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        234,
-        1373
-      ]
-    },
-    {
-      "questID": 1385,
-      "name": "Wand Focus Dislocation",
-      "description": "Wand Focus: Dislocation allows the user to take and place any blocks, even Tile Entities and things usually unobtainable, like Aura Nodes and their energized counterparts.\nIt uses:\n5 Ordo + 5 Perditio + 1 Terra to take any solid block. \n25 Ordo + 25 Perditio + 5 Terra to take any block with tile entities (such as Chest). \n100 Ordo + 100 Perditio + 20 Terra to take Mob Spawner.\n\nThis focus can be upgraded at the Focal Manipulator.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "ThaumicTinkerer:focusDislocation",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 0
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "ThaumicTinkerer:focusDislocation",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 10
-            },
-            {
-              "id": "Thaumcraft:ItemLootBag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 2
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinDarkWizardII",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        1375,
-        238,
-        1388
-      ]
-    },
-    {
-      "questID": 1386,
-      "name": "Wand Focus Mending",
-      "description": "The Wand Focus: Mending is a wand focus that will slowly mend the Caster\u0027s wounds by expending Vis. The Focus consumes 0.45 Aqua and 0.45 Terra per cast, healing half a heart (1 health).\n\nThis focus can be upgraded at the Focal Manipulator.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "ThaumicTinkerer:focusHeal",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 0
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "ThaumicTinkerer:focusHeal",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 10
-            },
-            {
-              "id": "Thaumcraft:ItemLootBag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 2
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinDarkWizardII",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        1380,
-        238,
-        1388
-      ]
-    },
-    {
-      "questID": 1387,
-      "name": "Wand Focus Uprising",
-      "description": "The Wand Focus: Uprising is a wand focus that propels the player in the direction they\u0027re facing. When used, the focus consumes 0.15 Aer per cast.\n\nThis focus can be upgraded at the Focal Manipulator.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "ThaumicTinkerer:focusFlight",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 0
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "ThaumicTinkerer:focusFlight",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 9
-            },
-            {
-              "id": "Thaumcraft:ItemLootBag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 1
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinDarkWizardI",
-              "Count": 5,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        1384,
-        238
-      ]
-    },
-    {
-      "questID": 1388,
-      "name": "Wand Focus Disorientation",
-      "description": "The Wand Focus: Distortion can be equipped on any wand.  It protects the caster from \"ordinary\" projectiles such as arrows, snowballs, and potions. The focus can be enabled by cycling through the foci currently in the player\u0027s inventory, which is done with the F-key. The focus consumes 0.04 Aer and 0.08 Ordo per tick from the Vis stored in the wand while in use.\n\nThis focus can be upgraded at the Focal Manipulator.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "ThaumicTinkerer:focusDeflect",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 0
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "ThaumicTinkerer:focusDeflect",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 9
-            },
-            {
-              "id": "Thaumcraft:ItemLootBag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 1
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinDarkWizardI",
-              "Count": 5,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        1387
-      ]
-    },
-    {
-      "questID": 1389,
-      "name": "Wand Focus Ender Rift",
-      "description": "The Wand Focus: Ender Rift is a Wand Focus that opens the vanilla Ender Chest remotely when the player right-clicks with it. When used, the focus consumes 0.9 Ordo + 0.9 Perditio\n\nThis focus can be upgraded at the Focal Manipulator.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "ThaumicTinkerer:focusEnderChest",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 0
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "ThaumicTinkerer:focusEnderChest",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 10
-            },
-            {
-              "id": "Thaumcraft:ItemLootBag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 2
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinDarkWizardII",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        1388
-      ]
-    },
-    {
-      "questID": 1390,
-      "name": "Wand Focus Telekinesis",
-      "description": "Wand Focus: Telekinesis is a wand focus that can move nearby objects such as dropped items, arrows etc. where you are pointing with the wand or towards you, if you hold Shift key while using it. Consumes 0.05 Aer + 0.05 Perditio per tick used.\n\nThis focus can be upgraded at the Focal Manipulator.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "ThaumicTinkerer:focusTelekinesis",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 0
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "ThaumicTinkerer:focusTelekinesis",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 9
-            },
-            {
-              "id": "Thaumcraft:ItemLootBag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 1
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinDarkWizardI",
-              "Count": 5,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        238,
-        1387
-      ]
-    },
-    {
-      "questID": 1391,
-      "name": "Wand Focus Experience Drain",
-      "description": "Wand Focus: Experience Drain will drain the player\u0027s experience at a rate of 15 xp per tick, restoring vis at a rather fast rate.\n\nThis focus can be upgraded at the Focal Manipulator.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "ThaumicTinkerer:focusXPDrain",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 0
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "ThaumicTinkerer:focusXPDrain",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 11
-            },
-            {
-              "id": "Thaumcraft:ItemLootBag",
-              "Count": 2,
-              "OreDict": "",
-              "Damage": 2
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinDarkWizardII",
-              "Count": 5,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        238,
-        320
-      ]
-    },
-    {
-      "questID": 1392,
-      "name": "Wand Focus Shadow Beam",
-      "description": "Wand Focus: Shadowbeam shoots a beam of energy that is reflected by any block and damages everything it passes through. The beam travels a rather short distance though. Consumes 0.15 Aer + 0.25 Ordo + 0.25 Perditio per cast.\n\nThis focus can be upgraded at the Focal Manipulator.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "ThaumicTinkerer:focusShadowbeam",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 0
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "ThaumicTinkerer:focusShadowbeam",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 11
-            },
-            {
-              "id": "Thaumcraft:ItemLootBag",
-              "Count": 2,
-              "OreDict": "",
-              "Damage": 2
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinDarkWizardII",
-              "Count": 5,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        238,
-        320
-      ]
-    },
-    {
-      "questID": 1393,
-      "name": "Wand Focus Tainted Storm",
-      "description": "Wand Focus: Tainted Storm can be equipped on any wand and will emit a stream of tainted particles which will damage anything in a short distance and inflict Taint Poison for 5 seconds. The focus will also debuff the caster with Flux Flu III for 10 seconds unless enchanted with Antibody. The foci can be enchanted with Frugal, Potency, Enlarge, Antibody and Corrosive. Each cast costs 0.1 Aqua + 0.1 Perditio\n\nThis focus can be upgraded at the Focal Manipulator.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "TaintedMagic:ItemFocusTaint",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 0
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "TaintedMagic:ItemFocusTaint",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 10
-            },
-            {
-              "id": "Thaumcraft:ItemLootBag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 2
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinDarkWizardII",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        1380,
-        238
-      ]
-    },
-    {
-      "questID": 1394,
-      "name": "Wand Focus Tainted Shockwave",
-      "description": "Wand Focus: Tainted Shockwave will release a powerful shockwave around the caster which travels 15-20 blocks and will damage all mobs in the radius and push them back the same as a Knockback II enchantment. After using this foci the caster will be unable to use any other magic for 15 seconds. The foci can be enchanted with Frugal and Enlarge, each level of Enlarge will add 1 block to the shockwave radius. Each cast costs 10 Aqua + 5 Ordo + 10 Terra + 10 Perditio.\n\nThis focus can be upgraded at the Focal Manipulator.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "TaintedMagic:ItemFocusTaintedBlast",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 0
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "TaintedMagic:ItemFocusTaintedBlast",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 11
-            },
-            {
-              "id": "Thaumcraft:ItemLootBag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 2
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinDarkWizardII",
-              "Count": 2,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        1393
-      ]
-    },
-    {
-      "questID": 1395,
-      "name": "Wand Focus Vis Shard",
-      "description": "Wand Focus: Vis Shard can be equipped on any wand. While equipped, it can be right-clicked to cast a homing projectile which deals 2-5 damage points. This projectile can bounce off of solid blocks. If the target is not hit in 10 seconds, the projectile disappears. This focus can be enchanted with Frugal, Potency and Persistent.\n\nThis focus can be upgraded at the Focal Manipulator.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "TaintedMagic:ItemFocusVisShard",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 0
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "TaintedMagic:ItemFocusVisShard",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 9
-            },
-            {
-              "id": "Thaumcraft:ItemLootBag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 1
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinDarkWizardI",
-              "Count": 5,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        243
-      ]
-    },
-    {
-      "questID": 1396,
-      "name": "Wand Focus Dark Matter",
-      "description": "Wand Focus: Dark Matter allows the player to cast the projectiles Eldritch Guardians cast. Can be upgraded with Potency, Frugal, Sanity, Diffusion and Corrosive. For each projectile cast the player will get Temporary Warp. This will not happen if the focus is enchanted with Sanity. Enchanting the focus with Diffusion will change its firing mode from single projectiles to short-range black gas which acts as a flamethrower.\n\nEach cast costs 0.2 Ignis + 0.2 Perditio. With Corrosive each cast will cost additionally 0.2 Aqua + 0.3 Ignis\n\nThis focus can be upgraded at the Focal Manipulator.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "TaintedMagic:ItemFocusEldritch",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 0
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "TaintedMagic:ItemFocusEldritch",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 11
-            },
-            {
-              "id": "Thaumcraft:ItemLootBag",
-              "Count": 2,
-              "OreDict": "",
-              "Damage": 2
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinDarkWizardII",
-              "Count": 5,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        320,
-        284,
-        1378
-      ]
-    },
-    {
-      "questID": 1397,
-      "name": "Wand Focus Time",
-      "description": "Wand Focus: Time can be equipped by any wand. When used during day, will set the time to dusk.  When used during night, will set the time to sunrise. Each cast costs 10 of all primal aspects and will make the player unable to use any other foci for 30 seconds.\n\nThis focus can be upgraded at the Focal Manipulator.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "TaintedMagic:ItemFocusTime",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 0
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "TaintedMagic:ItemFocusTime",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 11
-            },
-            {
-              "id": "Thaumcraft:ItemLootBag",
-              "Count": 2,
-              "OreDict": "",
-              "Damage": 2
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinDarkWizardII",
-              "Count": 5,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        320,
-        284,
-        1396
-      ]
-    },
-    {
-      "questID": 1398,
-      "name": "Wand Focus Meteorology",
-      "description": "Wand Focus: Meteorology can be equipped by any wand. When used during rain will stop rain, when used during sunny weather, will start rain. Each cast costs 10 of each primal aspect and will make the caster unable to use any other foci for 30 seconds.\n\nThis focus can be upgraded at the Focal Manipulator.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "TaintedMagic:ItemFocusMeteorology",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 0
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "TaintedMagic:ItemFocusMeteorology",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 11
-            },
-            {
-              "id": "Thaumcraft:ItemLootBag",
-              "Count": 2,
-              "OreDict": "",
-              "Damage": 2
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinDarkWizardII",
-              "Count": 5,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        320,
-        284,
-        1396
-      ]
-    },
-    {
-      "questID": 1399,
-      "name": "Wand Focus Mage\u0027s Mace",
-      "description": "Wand Focus: Mage\u0027s Mace can be equipped by any wand and will boost attack damage up to 15 hearts. It can be enchanted with Frugal, Potency and Bloodlust. Each attack with this focus costs 0.5 Perditio.\n\nThis focus can be upgraded at the Focal Manipulator.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "TaintedMagic:ItemFocusMageMace",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 0
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "TaintedMagic:ItemFocusMageMace",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 9
-            },
-            {
-              "id": "Thaumcraft:ItemLootBag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 1
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinDarkWizardI",
-              "Count": 5,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        238
-      ]
-    },
-    {
-      "questID": 1400,
-      "name": "Wand Focus Blink",
-      "description": "Wand Focus: Blink is a very powerful focus allowing to teleport whenever you click, as long as the destination is less then 50 blocks away from you. But, as there is no teleport cooldown, you can travel extremely fast with it. Consumes 3 Perditio per cast.\n\nThis focus can be upgraded at the Focal Manipulator.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "ForbiddenMagic:BlinkFocus",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 0
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "ForbiddenMagic:BlinkFocus",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 10
-            },
-            {
-              "id": "Thaumcraft:ItemLootBag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 2
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinDarkWizardII",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        1378
-      ]
-    },
-    {
-      "questID": 1401,
-      "name": "Infuse your Focus",
-      "description": "Try to add Potency to your Shock Focus. At Level 3 you can add Chain Lightning or Shock Wave.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "Thaumcraft:FocusShock",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 0,
-        "tag": {
-          "upgrade:9": [
-            {
-              "id:4": 0
-            },
-            {
-              "id:4": -1
-            },
-            {
-              "id:4": -1
-            },
-            {
-              "id:4": -1
-            },
-            {
-              "id:4": -1
-            }
-          ]
-        }
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "Thaumcraft:FocusShock",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0,
-              "tag": {
-                "upgrade:9": [
-                  {
-                    "id:4": 0
-                  },
-                  {
-                    "id:4": -1
-                  },
-                  {
-                    "id:4": -1
-                  },
-                  {
-                    "id:4": -1
-                  },
-                  {
-                    "id:4": -1
-                  }
-                ]
-              }
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "Thaumcraft:ItemLootBag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 2
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        1382
-      ]
-    },
-    {
-      "questID": 1402,
-      "name": "Iridium screws",
-      "description": "Chrome screws are nice, but they seem to break if too much vis channels through them. Get some Iridium screws.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "gregtech:gt.metaitem.01",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 27084
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 4,
-              "OreDict": "",
-              "Damage": 27084
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinDarkWizardII",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        274
-      ]
-    },
-    {
-      "questID": 1403,
-      "name": "HV Steam Turbine",
-      "description": "If you decide to use steam in HV tier then it\u0027s time to build a steam turbine.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "gregtech:gt.blockmachines",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 1122
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.blockmachines",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 1122
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 5
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinTechnicianI",
-              "Count": 5,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        160
-      ]
-    },
-    {
-      "questID": 1404,
-      "name": "Superconductors 128 eu/t",
-      "description": "How about losless 128 EU MV Wires ? Pentacadmiummagnesiumhexaoxid is a superconductor wire and will transfer your energy without any loss. Every Voltages have now a superconductor wire and a bas wire with only a very small loss.\nMix cadmium, magnesium and oxygen in a mv mixer. Now you got the base dust wich need an EBF with Kanthal Coils. A vacuumfreezer is also needed to cool it down. Make some MV Superconductor base Wires and use an assembler to combining these wires with Nitrogen, Helium, Stainless Steel pipes and hv pumps to get your 128 eu/t superconductor wires.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "gregtech:gt.blockmachines",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 2320
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 5,
-              "OreDict": "",
-              "Damage": 2055
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 2018
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 6,
-              "OreDict": "",
-              "Damage": 30013
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        },
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 12,
-              "OreDict": "",
-              "Damage": 2987
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        },
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 12,
-              "OreDict": "",
-              "Damage": 11987
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        },
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.blockmachines",
-              "Count": 24,
-              "OreDict": "",
-              "Damage": 2200
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        },
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.blockmachines",
-              "Count": 24,
-              "OreDict": "",
-              "Damage": 2200
-            },
-            {
-              "id": "gregtech:gt.blockmachines",
-              "Count": 16,
-              "OreDict": "",
-              "Damage": 5140
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 16,
-              "OreDict": "",
-              "Damage": 32612
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 16,
-              "OreDict": "",
-              "Damage": 30004
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 16,
-              "OreDict": "",
-              "Damage": 30012
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        },
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.blockmachines",
-              "Count": 24,
-              "OreDict": "",
-              "Damage": 2320
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 6
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinSmithI",
-              "Count": 5,
-              "OreDict": "",
-              "Damage": 0
-            },
-            {
-              "id": "dreamcraft:item.CoinChemistI",
-              "Count": 5,
-              "OreDict": "",
-              "Damage": 0
-            },
-            {
-              "id": "dreamcraft:item.CoinDarkWizardI",
-              "Count": 5,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        160,
-        81,
-        78
-      ]
-    },
-    {
-      "questID": 1405,
-      "name": "Superconductors 512 eu/t",
-      "description": "How about losless 512 EU HV Wires ? Titaniumonabariumdecacoppereikosaoxid is a superconductor wire and will transfer your energy without any loss. Every Voltages have now a superconductor wire and a bas wire with only a very small loss.\nMix titanium, barium, copper and oxygen in a hv mixer. Now you got the base dust wich need an EBF with Nichrome Coils. A vacuumfreezer is also needed to cool it down. Make some HV Superconductor base Wires and use an assembler to combining these wires with Nitrogen, Helium, Titanium pipes and ev pumps to get your 512 eu/t superconductor wires.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "gregtech:gt.blockmachines",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 2340
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 3,
-              "OreDict": "",
-              "Damage": 1028
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 27,
-              "OreDict": "",
-              "Damage": 1063
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 30,
-              "OreDict": "",
-              "Damage": 1035
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 15,
-              "OreDict": "",
-              "Damage": 30013
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        },
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 24,
-              "OreDict": "",
-              "Damage": 2988
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        },
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 24,
-              "OreDict": "",
-              "Damage": 11988
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        },
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.blockmachines",
-              "Count": 48,
-              "OreDict": "",
-              "Damage": 2220
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        },
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.blockmachines",
-              "Count": 48,
-              "OreDict": "",
-              "Damage": 2220
-            },
-            {
-              "id": "gregtech:gt.blockmachines",
-              "Count": 32,
-              "OreDict": "",
-              "Damage": 5150
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 16,
-              "OreDict": "",
-              "Damage": 32613
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 16,
-              "OreDict": "",
-              "Damage": 30004
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 16,
-              "OreDict": "",
-              "Damage": 30012
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        },
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.blockmachines",
-              "Count": 48,
-              "OreDict": "",
-              "Damage": 2340
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 7
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinSmithII",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            },
-            {
-              "id": "dreamcraft:item.CoinChemistII",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            },
-            {
-              "id": "dreamcraft:item.CoinDarkWizardII",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        176,
-        79
-      ]
-    },
-    {
-      "questID": 1406,
-      "name": "EV Assembler",
-      "description": "An EV asembler is required to make some lapotron crystals. Other recipes are twice faster than with an HV assembler.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "gregtech:gt.blockmachines",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 214
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.blockmachines",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 214
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "choices": [
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 8,
-              "OreDict": "",
-              "Damage": 11028
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 8,
-              "OreDict": "",
-              "Damage": 11067
-            },
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 7
-            }
-          ],
-          "rewardID": "bq_standard:choice"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinTechnicianII",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        1245
-      ]
-    },
-    {
-      "questID": 1407,
-      "name": "EV Laser Engraver",
-      "description": "An EV precission laser is required to make some quantum crystals. Other recipes are twice faster than with an HV precission laser.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "gregtech:gt.blockmachines",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 594
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.blockmachines",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 594
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "choices": [
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 8,
-              "OreDict": "",
-              "Damage": 11028
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 8,
-              "OreDict": "",
-              "Damage": 11085
-            },
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 7
-            }
-          ],
-          "rewardID": "bq_standard:choice"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinTechnicianII",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        806,
-        1246
-      ]
-    },
-    {
-      "questID": 1408,
-      "name": "Superconductors 2048 eu/t",
-      "description": "How about losless 2048 EU EV Wires ? Uraniumtriplatinid is a superconductor wire and will transfer your energy without any loss. Every Voltages have now a superconductor wire and a bas wire with only a very small loss.\nMix uranium 238 and platinum in a hv mixer. Now you got the base dust wich need an EBF with Tungstensteel Coils. A vacuumfreezer is also needed to cool it down. Make some EV Superconductor base Wires and use an assembler to combining these wires with Nitrogen, Helium, Tungstensteel pipes andivv pumps to get your 2048 eu/t superconductor wires.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "gregtech:gt.blockmachines",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 2360
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 3,
-              "OreDict": "",
-              "Damage": 2098
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 9,
-              "OreDict": "",
-              "Damage": 2085
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        },
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 12,
-              "OreDict": "",
-              "Damage": 2989
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        },
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 12,
-              "OreDict": "",
-              "Damage": 11989
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        },
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.blockmachines",
-              "Count": 18,
-              "OreDict": "",
-              "Damage": 2240
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        },
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.blockmachines",
-              "Count": 18,
-              "OreDict": "",
-              "Damage": 2240
-            },
-            {
-              "id": "gregtech:gt.blockmachines",
-              "Count": 12,
-              "OreDict": "",
-              "Damage": 5160
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 4,
-              "OreDict": "",
-              "Damage": 32614
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 6,
-              "OreDict": "",
-              "Damage": 30012
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 6,
-              "OreDict": "",
-              "Damage": 30004
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        },
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.blockmachines",
-              "Count": 18,
-              "OreDict": "",
-              "Damage": 2360
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 7
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinSmithII",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            },
-            {
-              "id": "dreamcraft:item.CoinChemistII",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            },
-            {
-              "id": "dreamcraft:item.CoinDarkWizardII",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        861,
-        1243,
-        86
-      ]
-    },
-    {
-      "questID": 1409,
-      "name": "Superconductors 8192 eu/t",
-      "description": "How about losless 8192 EU IV Wires ? Vanadiumtriindinid is a superconductor wire and will transfer your energy without any loss. Every Voltages have now a superconductor wire and a bas wire with only a very small loss.\nMix vanadium and indium in a hv mixer. Now you got the base dust wich need an EBF with HSSG Coils. A vacuumfreezer is also needed to cool it down. Make some IV Superconductor base Wires and use an assembler to combining these wires with Nitrogen, Helium, Niobiomtitanium pipes and iv pumps to get your 8192 eu/t superconductor wires.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "gregtech:gt.blockmachines",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 2380
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 3,
-              "OreDict": "",
-              "Damage": 2029
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 9,
-              "OreDict": "",
-              "Damage": 2056
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        },
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 12,
-              "OreDict": "",
-              "Damage": 2990
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        },
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 12,
-              "OreDict": "",
-              "Damage": 11990
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        },
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.blockmachines",
-              "Count": 24,
-              "OreDict": "",
-              "Damage": 2260
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        },
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.blockmachines",
-              "Count": 24,
-              "OreDict": "",
-              "Damage": 2260
-            },
-            {
-              "id": "gregtech:gt.blockmachines",
-              "Count": 16,
-              "OreDict": "",
-              "Damage": 5180
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 4,
-              "OreDict": "",
-              "Damage": 32614
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 8,
-              "OreDict": "",
-              "Damage": 30012
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 8,
-              "OreDict": "",
-              "Damage": 30004
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        },
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.blockmachines",
-              "Count": 24,
-              "OreDict": "",
-              "Damage": 2380
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 8
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinSmithII",
-              "Count": 2,
-              "OreDict": "",
-              "Damage": 0
-            },
-            {
-              "id": "dreamcraft:item.CoinChemistII",
-              "Count": 2,
-              "OreDict": "",
-              "Damage": 0
-            },
-            {
-              "id": "dreamcraft:item.CoinDarkWizardII",
-              "Count": 2,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        475,
-        1410
-      ]
-    },
-    {
-      "questID": 1410,
-      "name": "IV Mixer",
-      "description": "An IV mixer is required to mixe niobiumtitanium and vanadiumgallium dust. Other recipes are twice faster than with an EV mixer.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "gregtech:gt.blockmachines",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 585
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.blockmachines",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 585
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "choices": [
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 8,
-              "OreDict": "",
-              "Damage": 11316
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 8,
-              "OreDict": "",
-              "Damage": 11047
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 8,
-              "OreDict": "",
-              "Damage": 11037
-            },
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 8
-            }
-          ],
-          "rewardID": "bq_standard:choice"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinTechnicianII",
-              "Count": 2,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        213
-      ]
-    },
-    {
-      "questID": 1411,
-      "name": "Some rare high tier metals",
-      "description": "Small pile of Platinum, Palladium, Iridium and Osmium can be get during some chemical reactoin with nitric acid. You dont have the technology to process it right now but later on you need large amount of it. You can start now to collect some dust and process it later.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "gregtech:gt.metaitem.01",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 2241
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 128,
-              "OreDict": "",
-              "Damage": 30653
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 64,
-              "OreDict": "",
-              "Damage": 6855
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 64,
-              "OreDict": "",
-              "Damage": 6909
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        },
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 14,
-              "OreDict": "",
-              "Damage": 2241
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        },
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 85
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 52
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 84
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 83
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "choices": [
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 16,
-              "OreDict": "",
-              "Damage": 30659
-            },
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 6
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 64,
-              "OreDict": "",
-              "Damage": 6855
-            }
-          ],
-          "rewardID": "bq_standard:choice"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinChemistI",
-              "Count": 5,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        854,
-        851
-      ]
-    },
-    {
-      "questID": 1412,
-      "name": "Assembling Line",
-      "description": "The assembling line (short form \u0027Ass Line\u0027) is a multiblock and important for high tier Components in LuV tier and above for Motors, Pistons, Robot Arms, Pumps and many more.\n\nThe machine can be 5-16 blocks long. The minimum length required depends on the number of components and fluids required by the recipe it\u0027s crafting. A length of 11 blocks will fit 80% of all recipes in GTNH.\nThe bottom layer must have on one outer side all the Input Hatches for fluids (4), in the bottom middle layer Input Busses for items(10), and on the end 1 Output Bus. Also on the bottom outer layer must be one Maintainance Hatch. The rest is Solid Steel Machine Casings.\n\nThe second layer on the outer sides left and right are Reinforced Glass and in the middle center Assembling Line Casing.\n\nThe third layer has on the left and right Grate Machine Casings and in the middle Assembler Machine Casings (Note the name change!). The Assembling Line control block and Data Access Hatch are on the opposite edge from the Input Hatches - not at the end with the Output Bus.\n\nThe fourth layer is a single line of Solid Steel Machine Casings in the middle(11), with one Energy Hatch for power.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "gregtech:gt.blockmachines",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 1170
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.blockcasings2",
-              "Count": 39,
-              "OreDict": "",
-              "Damage": 0
-            },
-            {
-              "id": "gregtech:gt.blockmachines",
-              "Count": 4,
-              "OreDict": "",
-              "Damage": 55
-            },
-            {
-              "id": "gregtech:gt.blockmachines",
-              "Count": 10,
-              "OreDict": "",
-              "Damage": 75
-            },
-            {
-              "id": "gregtech:gt.blockmachines",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 85
-            },
-            {
-              "id": "gregtech:gt.blockmachines",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 90
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        },
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "IC2:blockAlloyGlass",
-              "Count": 22,
-              "OreDict": "",
-              "Damage": 0
-            },
-            {
-              "id": "gregtech:gt.blockcasings2",
-              "Count": 11,
-              "OreDict": "",
-              "Damage": 5
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        },
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.blockmachines",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 1170
-            },
-            {
-              "id": "gregtech:gt.blockmachines",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 46
-            },
-            {
-              "id": "gregtech:gt.blockmachines",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 145
-            },
-            {
-              "id": "gregtech:gt.blockcasings3",
-              "Count": 20,
-              "OreDict": "",
-              "Damage": 10
-            },
-            {
-              "id": "gregtech:gt.blockcasings2",
-              "Count": 15,
-              "OreDict": "",
-              "Damage": 9
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "minecraft:paper",
-              "Count": 64,
-              "OreDict": "",
-              "Damage": 0
-            },
-            {
-              "id": "IC2:itemFluidCell",
-              "Count": 64,
-              "OreDict": "",
-              "Damage": 0,
-              "tag": {
-                "Fluid:10": {
-                  "FluidName:8": "squidink",
-                  "Amount:4": 1000
-                }
-              }
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 4,
-              "OreDict": "",
-              "Damage": 32708
-            },
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 2,
-              "OreDict": "",
-              "Damage": 8,
-              "tag": {
-                "ench:9": [
-                  {
-                    "lvl:4": 3,
-                    "id:4": 35
-                  }
-                ]
-              }
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinTechnicianIII",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        213
-      ]
-    },
-    {
-      "questID": 1413,
-      "name": "You gonna hate this 1-4 in IV",
-      "description": "Pumps, pistons, conveyor belts and robot arms are the most needed machine parts in IV. Go and craft one of each.",
-      "isMain": true,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "gregtech:gt.metaitem.01",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 32654
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 32614
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 32644
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 32634
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 32654
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 32,
-              "OreDict": "",
-              "Damage": 11028
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 8,
-              "OreDict": "",
-              "Damage": 11316
-            },
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 8
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinTechnicianII",
-              "Count": 5,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        213
-      ]
-    },
-    {
-      "questID": 1414,
-      "name": "You gonna hate this 5 and 6 in IV",
-      "description": "Some machines need emitters and sensors, like the analyzer or the circuit assembler.",
-      "isMain": true,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "gregtech:gt.metaitem.01",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 32694
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 32684
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 32694
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 8,
-              "OreDict": "",
-              "Damage": 11084
-            },
-            {
-              "id": "gregtech:gt.metaitem.01",
-              "Count": 8,
-              "OreDict": "",
-              "Damage": 11316
-            },
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 8
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinTechnicianII",
-              "Count": 5,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        1413
-      ]
-    },
-    {
-      "questID": 1415,
-      "name": "Scheelite, Tungstate Mars Moons",
-      "description": "Tungstensteel is the material you need but first go find some scheelite and tungstate mix on Mars moon Deimos. Look at Y 20-60.",
-      "isMain": true,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "gregtech:gt.blockores",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 841
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.blockores",
-              "Count": 64,
-              "OreDict": "",
-              "Damage": 910
-            },
-            {
-              "id": "gregtech:gt.blockores",
-              "Count": 16,
-              "OreDict": "",
-              "Damage": 841
-            },
-            {
-              "id": "gregtech:gt.blockores",
-              "Count": 8,
-              "OreDict": "",
-              "Damage": 6
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 7
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinSpaceII",
-              "Count": 2,
-              "OreDict": "",
-              "Damage": 0
-            },
-            {
-              "id": "dreamcraft:item.CoinAdventureII",
-              "Count": 2,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        186
-      ]
-    },
-    {
-      "questID": 1416,
-      "name": "Mallard Rust Smelly",
-      "description": "Or is it Alloy Blast Smelter? Well, that makes more sense. This multibock creates the higher tier alloys needed for the more advanced GT++ multiblocks. It directly smelts into liquids.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "gregtech:gt.blockmachines",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 810
-      },
-      "visibility": "NORMAL",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.blockmachines",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 810
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [],
-      "preRequisites": [
-        213
-      ]
-    },
-    {
-      "questID": 1417,
-      "name": "Cough cough - Something needs to be done about the smell",
-      "description": "Birds falling out of the sky, fish dead and floating belly up in the rivers, acid rain melting the ground...Time to start picking up the trash and cleaning up the air. Small steel turbines should be fine for now. You\u0027ll need two amps of steady power to keep the scrubber working.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "gregtech:gt.blockmachines",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 758
-      },
-      "visibility": "NORMAL",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.blockmachines",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 756
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        },
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "miscutils:itemAirFilter",
-              "Count": 11,
-              "OreDict": "",
-              "Damage": 0,
-              "tag": {
-                "AirFilter:10": {
-                  "Damage:4": 0
-                }
-              }
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        },
-        {
-          "partialMatch": true,
-          "ignoreNBT": true,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.metatool.01",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 170
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        },
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.blockmachines",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 759
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [],
-      "preRequisites": [
-        77
-      ]
-    },
-    {
-      "questID": 1418,
-      "name": "EU packets flowing everywhere...",
-      "description": "...in my dreams. What if instead of having battery packs on every generator, we could centralize all the generation in one location? Put it away from the well travelled parts of the the base? Out in the country somewhere?  Let the animals deal with the pollution.  Anyways, let\u0027s start working on a Power Sub-Station to store EU and deliver it to our base.              ",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "gregtech:gt.blockmachines",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 812
-      },
-      "visibility": "NORMAL",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.blockmachines",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 812
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [],
-      "preRequisites": [
-        861
-      ]
-    },
-    {
-      "questID": 1419,
-      "name": "Who cares about a little cancer...",
-      "description": "...when it means you don\u0027t have to strip naked to recharge your nanosuit? \nThe Wireless Charger will keep your armor and tools charged up without \nhaving to put them into a battery buffer. \n\nYou didn\u0027t want kids anyways...     ",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "gregtech:gt.blockmachines",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 892
-      },
-      "visibility": "NORMAL",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.blockmachines",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 892
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 6
-            },
-            {
-              "id": "dreamcraft:item.CoinTechnicianI",
-              "Count": 5,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        779
-      ]
-    },
-    {
-      "questID": 1420,
-      "name": "Shake that booty...",
-      "description": "...out of the purified ores.  Anyways, a Large Sifter will increase your sifting rate significantly. What will you do with all these gems??",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "gregtech:gt.blockmachines",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 840
-      },
-      "visibility": "NORMAL",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.blockmachines",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 840
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [],
-      "preRequisites": [
-        213
-      ]
-    },
-    {
-      "questID": 1421,
-      "name": "Hulk Smash!",
-      "description": "Mass destruction! Or at least, lots and lots of crushed ores. Build a maceration statck to keep up with all the ores you are getting.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "gregtech:gt.blockmachines",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 797
-      },
-      "visibility": "NORMAL",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.blockmachines",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 797
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [],
-      "preRequisites": [
-        213
-      ]
-    },
-    {
-      "questID": 1422,
-      "name": "The rocks in the washer...",
-      "description": "...go round and round, all the live long day. A large orewashing plant gets your rocks nice and clean.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "gregtech:gt.blockmachines",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 850
-      },
-      "visibility": "NORMAL",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.blockmachines",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 850
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [],
-      "preRequisites": [
-        213
-      ]
-    },
-    {
-      "questID": 1423,
-      "name": "Dancing in circles",
-      "description": "Spinning around, getting hot - sounds like a dance. Or a thermal centrifuge.  Build a large thermal refinery to get the most out of your ores.",
-      "isMain": false,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "gregtech:gt.blockmachines",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 849
-      },
-      "visibility": "NORMAL",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.blockmachines",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 849
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [],
-      "preRequisites": [
-        213
-      ]
-    },
-    {
-      "questID": 1424,
-      "name": "Find Titanium",
-      "description": "If you are lucky you will find a pure Titanium veins to make the process much easier.\nTitanium can be found on moon at Y Level 10-70.",
-      "isMain": true,
-      "isSilent": false,
-      "lockedProgress": false,
-      "simultaneous": false,
-      "globalParticipation": 0.0,
-      "globalQuest": false,
-      "globalShare": true,
-      "autoClaim": false,
-      "repeatTime": -1,
-      "sounds": {
-        "complete": "random.levelup",
-        "update": "random.levelup"
-      },
-      "logic": "AND",
-      "taskLogic": "AND",
-      "icon": {
-        "id": "gregtech:gt.blockores",
-        "Count": 1,
-        "OreDict": "",
-        "Damage": 28
-      },
-      "visibility": "UNLOCKED",
-      "tasks": [
-        {
-          "partialMatch": true,
-          "ignoreNBT": false,
-          "consume": false,
-          "autoConsume": false,
-          "requiredItems": [
-            {
-              "id": "gregtech:gt.blockores",
-              "Count": 64,
-              "OreDict": "",
-              "Damage": 28
-            },
-            {
-              "id": "gregtech:gt.blockores",
-              "Count": 64,
-              "OreDict": "",
-              "Damage": 825
-            },
-            {
-              "id": "gregtech:gt.blockores",
-              "Count": 16,
-              "OreDict": "",
-              "Damage": 842
-            },
-            {
-              "id": "gregtech:gt.blockores",
-              "Count": 16,
-              "OreDict": "",
-              "Damage": 925
-            }
-          ],
-          "taskID": "bq_standard:retrieval"
-        }
-      ],
-      "rewards": [
-        {
-          "rewards": [
-            {
-              "id": "enhancedlootbags:lootbag",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 6
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        },
-        {
-          "rewards": [
-            {
-              "id": "dreamcraft:item.CoinSpaceII",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            },
-            {
-              "id": "dreamcraft:item.CoinAdventureII",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            },
-            {
-              "id": "dreamcraft:item.CoinTechnicianII",
-              "Count": 1,
-              "OreDict": "",
-              "Damage": 0
-            }
-          ],
-          "rewardID": "bq_standard:item"
-        }
-      ],
-      "preRequisites": [
-        162
-      ]
     }
   ],
   "questLines": [
     {
-      "name": "Tier 0 - It begins",
-      "description": "The very first tier, tier zero. This chapter will introduce you to the basic mechanics of this modpack. Mods covered: Vanilla, Pam\u0027s Harvestcraft.",
+      "name": "tier0.name",
+      "description": "tier0.desc",
       "quests": [
         {
           "id": 0,
@@ -137377,8 +130999,8 @@
       ]
     },
     {
-      "name": "Tier 0.5 - Stone Age",
-      "description": "Basically the \"Tier 0\" of all your progression. This set helps you through the first tier until you can build your first steam machine",
+      "name": "tier0.5.name",
+      "description": "tier0.5.desc",
       "quests": [
         {
           "id": 15,
@@ -137683,8 +131305,8 @@
       ]
     },
     {
-      "name": "Tier 1 - Steam",
-      "description": "Quest set for all steam-based machines.",
+      "name": "tier1.name",
+      "description": "tier1.desc",
       "quests": [
         {
           "id": 44,
@@ -138094,8 +131716,8 @@
       ]
     },
     {
-      "name": "Tier 2 - 32 EU (LV)",
-      "description": "The first \"voltage\" tier of this pack. Things are getting easier...",
+      "name": "tier2.name",
+      "description": "tier2.desc",
       "quests": [
         {
           "id": 88,
@@ -138409,13 +132031,13 @@
         },
         {
           "id": 621,
-          "x": 600,
+          "x": 648,
           "y": 444
         },
         {
           "id": 622,
           "x": 600,
-          "y": 408
+          "y": 372
         },
         {
           "id": 623,
@@ -138669,12 +132291,12 @@
         },
         {
           "id": 1167,
-          "x": 636,
+          "x": 600,
           "y": 408
         },
         {
           "id": 1168,
-          "x": 636,
+          "x": 600,
           "y": 444
         },
         {
@@ -138696,7 +132318,7 @@
     },
     {
       "name": "Tier 3 - 128 EU (MV)",
-      "description": "Your second voltage tier. Don\u0027t mix different voltage levels, or you will be punished in a hard way. Start thinking about how to expand your base. ",
+      "description": "Your second voltage tier. Don\u0027t mix different voltage levels, or you will be punished in a hard way.",
       "quests": [
         {
           "id": 89,
@@ -139371,7 +132993,7 @@
         },
         {
           "id": 770,
-          "x": 180,
+          "x": 144,
           "y": 192
         },
         {
@@ -139396,8 +133018,8 @@
         },
         {
           "id": 860,
-          "x": 348,
-          "y": 384
+          "x": 342,
+          "y": 306
         },
         {
           "id": 932,
@@ -139406,58 +133028,58 @@
         },
         {
           "id": 859,
-          "x": 144,
-          "y": 540
+          "x": 96,
+          "y": 384
         },
         {
           "id": 858,
           "x": 144,
-          "y": 492
+          "y": 432
         },
         {
           "id": 854,
           "x": 144,
-          "y": 396
+          "y": 384
         },
         {
           "id": 857,
-          "x": 84,
-          "y": 396
+          "x": 204,
+          "y": 432
         },
         {
           "id": 856,
-          "x": 84,
-          "y": 492
+          "x": 204,
+          "y": 480
         },
         {
           "id": 147,
-          "x": 84,
-          "y": 540
+          "x": 144,
+          "y": 480
         },
         {
           "id": 855,
           "x": 204,
-          "y": 396
+          "y": 384
         },
         {
           "id": 851,
-          "x": 204,
-          "y": 492
+          "x": 288,
+          "y": 384
         },
         {
           "id": 853,
-          "x": 204,
-          "y": 444
+          "x": 240,
+          "y": 384
         },
         {
           "id": 841,
-          "x": 252,
-          "y": 492
+          "x": 288,
+          "y": 432
         },
         {
           "id": 557,
-          "x": 252,
-          "y": 540
+          "x": 348,
+          "y": 432
         },
         {
           "id": 943,
@@ -139516,7 +133138,7 @@
         },
         {
           "id": 1012,
-          "x": 348,
+          "x": 342,
           "y": 348
         },
         {
@@ -139591,7 +133213,7 @@
         },
         {
           "id": 1164,
-          "x": 264,
+          "x": 180,
           "y": 192
         },
         {
@@ -139658,26 +133280,6 @@
           "id": 1271,
           "x": 288,
           "y": 312
-        },
-        {
-          "id": 1403,
-          "x": 192,
-          "y": 72
-        },
-        {
-          "id": 1404,
-          "x": 264,
-          "y": 156
-        },
-        {
-          "id": 1411,
-          "x": 168,
-          "y": 444
-        },
-        {
-          "id": 1424,
-          "x": 288,
-          "y": 384
         }
       ]
     },
@@ -139687,167 +133289,167 @@
       "quests": [
         {
           "id": 176,
-          "x": 252,
+          "x": 192,
           "y": 168
         },
         {
           "id": 186,
-          "x": 156,
+          "x": 120,
           "y": 240
         },
         {
           "id": 187,
-          "x": 156,
+          "x": 120,
           "y": 204
         },
         {
           "id": 188,
-          "x": 192,
+          "x": 156,
           "y": 240
         },
         {
           "id": 189,
-          "x": 360,
+          "x": 336,
           "y": 168
         },
         {
           "id": 190,
-          "x": 444,
+          "x": 420,
           "y": 168
         },
         {
           "id": 191,
-          "x": 444,
+          "x": 420,
           "y": 276
         },
         {
           "id": 192,
-          "x": 504,
+          "x": 480,
           "y": 240
         },
         {
           "id": 193,
-          "x": 468,
+          "x": 444,
           "y": 240
         },
         {
           "id": 194,
-          "x": 552,
+          "x": 528,
           "y": 132
         },
         {
           "id": 195,
-          "x": 552,
+          "x": 528,
           "y": 168
         },
         {
           "id": 196,
-          "x": 504,
+          "x": 480,
           "y": 204
         },
         {
           "id": 197,
-          "x": 504,
+          "x": 480,
           "y": 168
         },
         {
           "id": 198,
-          "x": 504,
+          "x": 480,
           "y": 276
         },
         {
           "id": 199,
-          "x": 252,
+          "x": 192,
           "y": 384
         },
         {
           "id": 200,
-          "x": 288,
+          "x": 228,
           "y": 348
         },
         {
           "id": 201,
-          "x": 288,
+          "x": 228,
           "y": 384
         },
         {
           "id": 202,
-          "x": 324,
+          "x": 264,
           "y": 384
         },
         {
           "id": 204,
-          "x": 192,
+          "x": 120,
           "y": 276
         },
         {
           "id": 205,
-          "x": 108,
+          "x": 84,
           "y": 204
         },
         {
           "id": 206,
-          "x": 144,
+          "x": 120,
           "y": 384
         },
         {
           "id": 207,
-          "x": 324,
+          "x": 300,
           "y": 240
         },
         {
           "id": 209,
-          "x": 324,
+          "x": 300,
           "y": 276
         },
         {
           "id": 210,
-          "x": 360,
+          "x": 336,
           "y": 276
         },
         {
           "id": 208,
-          "x": 360,
+          "x": 336,
           "y": 240
         },
         {
           "id": 211,
-          "x": 360,
+          "x": 336,
           "y": 204
         },
         {
           "id": 212,
-          "x": 324,
+          "x": 240,
           "y": 120
         },
         {
           "id": 805,
-          "x": 216,
-          "y": 120
+          "x": 174,
+          "y": 276
         },
         {
           "id": 806,
-          "x": 216,
-          "y": 84
+          "x": 174,
+          "y": 312
         },
         {
           "id": 807,
-          "x": 180,
-          "y": 48
+          "x": 120,
+          "y": 312
         },
         {
           "id": 861,
-          "x": 132,
+          "x": 84,
           "y": 312
         },
         {
           "id": 936,
-          "x": 144,
+          "x": 120,
           "y": 348
         },
         {
           "id": 937,
-          "x": 192,
+          "x": 174,
           "y": 348
         },
         {
@@ -139877,224 +133479,179 @@
         },
         {
           "id": 1223,
-          "x": 132,
+          "x": 108,
           "y": 48
         },
         {
           "id": 1224,
-          "x": 288,
+          "x": 192,
           "y": 84
         },
         {
           "id": 1228,
-          "x": 288,
+          "x": 192,
           "y": 120
         },
         {
           "id": 1229,
-          "x": 252,
+          "x": 156,
           "y": 120
         },
         {
           "id": 1230,
-          "x": 252,
+          "x": 156,
           "y": 84
         },
         {
           "id": 1234,
-          "x": 288,
+          "x": 192,
           "y": 48
         },
         {
           "id": 1241,
-          "x": 60,
-          "y": 120
+          "x": 36,
+          "y": 132
         },
         {
           "id": 1243,
-          "x": 108,
+          "x": 84,
           "y": 240
         },
         {
           "id": 1244,
-          "x": 108,
+          "x": 84,
           "y": 276
         },
         {
           "id": 1245,
-          "x": 132,
+          "x": 108,
           "y": 120
         },
         {
           "id": 1246,
-          "x": 132,
+          "x": 108,
           "y": 84
         },
         {
           "id": 1242,
-          "x": 360,
-          "y": 120
+          "x": 108,
+          "y": 168
         },
         {
           "id": 1247,
-          "x": 96,
+          "x": 72,
           "y": 84
         },
         {
           "id": 1248,
-          "x": 132,
+          "x": 108,
           "y": 0
         },
         {
           "id": 1249,
-          "x": 252,
+          "x": 156,
           "y": 48
         },
         {
           "id": 1250,
-          "x": 180,
+          "x": 156,
           "y": 0
         },
         {
           "id": 1251,
-          "x": 216,
+          "x": 192,
           "y": 0
         },
         {
           "id": 1252,
-          "x": 60,
+          "x": 36,
           "y": 84
         },
         {
           "id": 1261,
-          "x": 252,
+          "x": 228,
           "y": 0
         },
         {
           "id": 1262,
-          "x": 144,
+          "x": 120,
           "y": 420
         },
         {
           "id": 1263,
-          "x": 108,
+          "x": 84,
           "y": 420
         },
         {
           "id": 1264,
-          "x": 108,
+          "x": 84,
           "y": 456
         },
         {
           "id": 1265,
-          "x": 144,
+          "x": 120,
           "y": 456
-        },
-        {
-          "id": 1405,
-          "x": 288,
-          "y": 204
-        },
-        {
-          "id": 1406,
-          "x": 180,
-          "y": 120
-        },
-        {
-          "id": 1407,
-          "x": 180,
-          "y": 84
-        },
-        {
-          "id": 1408,
-          "x": 72,
-          "y": 276
-        },
-        {
-          "id": 1415,
-          "x": 156,
-          "y": 276
         }
       ]
     },
     {
-      "name": "Tier 6 - 8192 EU (IV)",
-      "description": "The last regular tier that will \"guide\" you",
+      "name": "Tier 6 and beyond",
+      "description": "The last regular tier that will \"guide\" you ",
       "quests": [
         {
           "id": 213,
-          "x": 72,
+          "x": 24,
           "y": 0
         },
         {
           "id": 214,
-          "x": 72,
-          "y": 96
+          "x": 24,
+          "y": 80
         },
         {
           "id": 215,
-          "x": 72,
-          "y": 48
+          "x": 24,
+          "y": 40
         },
         {
           "id": 216,
-          "x": 120,
-          "y": 48
+          "x": 72,
+          "y": 40
         },
         {
           "id": 217,
-          "x": 48,
-          "y": 144
+          "x": 0,
+          "y": 120
         },
         {
           "id": 218,
-          "x": 96,
-          "y": 144
+          "x": 48,
+          "y": 120
         },
         {
           "id": 219,
-          "x": 120,
+          "x": 72,
           "y": 0
         },
         {
           "id": 220,
-          "x": 160,
+          "x": 112,
           "y": 0
         },
         {
           "id": 221,
-          "x": 200,
+          "x": 152,
           "y": 0
         },
         {
           "id": 222,
-          "x": 200,
+          "x": 152,
           "y": 40
         },
         {
           "id": 223,
-          "x": 240,
+          "x": 192,
           "y": 0
-        },
-        {
-          "id": 1409,
-          "x": 0,
-          "y": 0
-        },
-        {
-          "id": 1410,
-          "x": 36,
-          "y": 0
-        },
-        {
-          "id": 1414,
-          "x": 0,
-          "y": 48
-        },
-        {
-          "id": 1413,
-          "x": 36,
-          "y": 48
         }
       ]
     },
@@ -140209,8 +133766,33 @@
           "y": 36
         },
         {
-          "id": 950,
+          "id": 876,
           "x": 0,
+          "y": 72
+        },
+        {
+          "id": 877,
+          "x": 0,
+          "y": 144
+        },
+        {
+          "id": 878,
+          "x": 36,
+          "y": 72
+        },
+        {
+          "id": 879,
+          "x": 0,
+          "y": 180
+        },
+        {
+          "id": 887,
+          "x": 72,
+          "y": 72
+        },
+        {
+          "id": 950,
+          "x": 36,
           "y": 216
         },
         {
@@ -140684,13 +134266,18 @@
           "y": 0
         },
         {
-          "id": 1192,
+          "id": 1191,
           "x": 0,
+          "y": 216
+        },
+        {
+          "id": 1192,
+          "x": 36,
           "y": 180
         },
         {
           "id": 1193,
-          "x": 0,
+          "x": 36,
           "y": 144
         },
         {
@@ -140732,11 +134319,6 @@
           "id": 1307,
           "x": 840,
           "y": 396
-        },
-        {
-          "id": 1366,
-          "x": 216,
-          "y": 420
         }
       ]
     },
@@ -140836,8 +134418,8 @@
         },
         {
           "id": 994,
-          "x": 96,
-          "y": 48
+          "x": 204,
+          "y": 72
         },
         {
           "id": 1214,
@@ -140878,7 +134460,7 @@
     },
     {
       "name": "Steve Carts",
-      "description": "Basic auto farming and mining.  Protect them from lightning strikes!",
+      "description": "Auto farming and mining ",
       "quests": [
         {
           "id": 108,
@@ -141108,13 +134690,13 @@
         },
         {
           "id": 258,
-          "x": 348,
+          "x": 312,
           "y": 252
         },
         {
           "id": 259,
           "x": 312,
-          "y": 252
+          "y": 216
         },
         {
           "id": 610,
@@ -141134,12 +134716,12 @@
         {
           "id": 1070,
           "x": 48,
-          "y": 0
+          "y": 36
         },
         {
           "id": 1071,
           "x": 0,
-          "y": 0
+          "y": 36
         },
         {
           "id": 1096,
@@ -141148,22 +134730,22 @@
         },
         {
           "id": 1100,
-          "x": 348,
+          "x": 312,
           "y": 180
         },
         {
           "id": 1101,
-          "x": 384,
+          "x": 348,
           "y": 180
         },
         {
           "id": 1103,
-          "x": 420,
+          "x": 384,
           "y": 180
         },
         {
           "id": 1104,
-          "x": 384,
+          "x": 348,
           "y": 216
         },
         {
@@ -141189,21 +134771,6 @@
         {
           "id": 1286,
           "x": 156,
-          "y": 216
-        },
-        {
-          "id": 1368,
-          "x": 0,
-          "y": 36
-        },
-        {
-          "id": 1369,
-          "x": 156,
-          "y": 108
-        },
-        {
-          "id": 1370,
-          "x": 192,
           "y": 108
         }
       ]
@@ -141214,318 +134781,273 @@
       "quests": [
         {
           "id": 260,
-          "x": 132,
+          "x": 36,
           "y": 96
         },
         {
           "id": 261,
-          "x": 408,
+          "x": 324,
           "y": 132
         },
         {
           "id": 263,
-          "x": 360,
+          "x": 288,
           "y": 132
         },
         {
           "id": 265,
-          "x": 240,
+          "x": 144,
           "y": 96
         },
         {
           "id": 266,
-          "x": 312,
+          "x": 216,
           "y": 96
         },
         {
           "id": 267,
-          "x": 276,
+          "x": 180,
           "y": 192
         },
         {
           "id": 268,
-          "x": 276,
+          "x": 180,
           "y": 156
         },
         {
           "id": 269,
-          "x": 276,
+          "x": 180,
           "y": 36
         },
         {
           "id": 270,
-          "x": 276,
+          "x": 180,
           "y": 0
         },
         {
           "id": 271,
-          "x": 276,
+          "x": 180,
           "y": 72
         },
         {
           "id": 264,
-          "x": 276,
+          "x": 180,
           "y": 120
         },
         {
           "id": 262,
-          "x": 408,
+          "x": 324,
           "y": 96
         },
         {
           "id": 272,
-          "x": 132,
+          "x": 36,
           "y": 252
         },
         {
           "id": 273,
-          "x": 408,
-          "y": 204
+          "x": 372,
+          "y": 168
         },
         {
           "id": 274,
-          "x": 408,
+          "x": 324,
           "y": 168
         },
         {
           "id": 275,
-          "x": 96,
-          "y": 216
-        },
-        {
-          "id": 276,
-          "x": 96,
-          "y": 168
-        },
-        {
-          "id": 277,
-          "x": 96,
-          "y": 132
-        },
-        {
-          "id": 278,
-          "x": 132,
-          "y": 216
-        },
-        {
-          "id": 279,
-          "x": 504,
-          "y": 168
-        },
-        {
-          "id": 281,
-          "x": 576,
-          "y": 168
-        },
-        {
-          "id": 280,
-          "x": 540,
-          "y": 168
-        },
-        {
-          "id": 283,
-          "x": 504,
-          "y": 204
-        },
-        {
-          "id": 284,
-          "x": 504,
-          "y": 252
-        },
-        {
-          "id": 285,
-          "x": 504,
-          "y": 132
-        },
-        {
-          "id": 286,
-          "x": 540,
-          "y": 96
-        },
-        {
-          "id": 288,
-          "x": 468,
-          "y": 132
-        },
-        {
-          "id": 289,
-          "x": 576,
-          "y": 96
-        },
-        {
-          "id": 282,
-          "x": 576,
-          "y": 132
-        },
-        {
-          "id": 290,
-          "x": 96,
-          "y": 288
-        },
-        {
-          "id": 291,
-          "x": 228,
-          "y": 252
-        },
-        {
-          "id": 292,
-          "x": 276,
-          "y": 252
-        },
-        {
-          "id": 293,
-          "x": 324,
-          "y": 252
-        },
-        {
-          "id": 294,
-          "x": 372,
-          "y": 252
-        },
-        {
-          "id": 295,
-          "x": 168,
-          "y": 288
-        },
-        {
-          "id": 296,
-          "x": 132,
-          "y": 288
-        },
-        {
-          "id": 297,
-          "x": 168,
-          "y": 168
-        },
-        {
-          "id": 298,
-          "x": 168,
-          "y": 216
-        },
-        {
-          "id": 300,
-          "x": 228,
-          "y": 288
-        },
-        {
-          "id": 299,
-          "x": 168,
-          "y": 252
-        },
-        {
-          "id": 301,
-          "x": 96,
-          "y": 252
-        },
-        {
-          "id": 287,
-          "x": 540,
-          "y": 132
-        },
-        {
-          "id": 302,
-          "x": 168,
-          "y": 132
-        },
-        {
-          "id": 303,
-          "x": 360,
-          "y": 168
-        },
-        {
-          "id": 304,
-          "x": 360,
-          "y": 204
-        },
-        {
-          "id": 305,
-          "x": 96,
-          "y": 96
-        },
-        {
-          "id": 306,
-          "x": 204,
-          "y": 132
-        },
-        {
-          "id": 833,
-          "x": 468,
-          "y": 96
-        },
-        {
-          "id": 1055,
-          "x": 132,
-          "y": 48
-        },
-        {
-          "id": 1097,
-          "x": 132,
-          "y": 12
-        },
-        {
-          "id": 1098,
-          "x": 168,
-          "y": 12
-        },
-        {
-          "id": 1099,
-          "x": 96,
-          "y": 12
-        },
-        {
-          "id": 1102,
-          "x": 408,
-          "y": 48
-        },
-        {
-          "id": 1105,
-          "x": 408,
-          "y": 0
-        },
-        {
-          "id": 1382,
-          "x": 48,
-          "y": 216
-        },
-        {
-          "id": 1383,
-          "x": 48,
-          "y": 168
-        },
-        {
-          "id": 1401,
           "x": 0,
           "y": 216
         },
         {
-          "id": 1402,
+          "id": 276,
+          "x": 0,
+          "y": 168
+        },
+        {
+          "id": 277,
+          "x": 0,
+          "y": 132
+        },
+        {
+          "id": 278,
+          "x": 36,
+          "y": 216
+        },
+        {
+          "id": 279,
+          "x": 408,
+          "y": 168
+        },
+        {
+          "id": 281,
+          "x": 480,
+          "y": 168
+        },
+        {
+          "id": 280,
           "x": 444,
           "y": 168
         },
         {
-          "id": 877,
-          "x": 204,
-          "y": 36
-        },
-        {
-          "id": 878,
-          "x": 324,
-          "y": 168
-        },
-        {
-          "id": 879,
-          "x": 204,
-          "y": 72
-        },
-        {
-          "id": 887,
-          "x": 324,
+          "id": 283,
+          "x": 408,
           "y": 204
         },
         {
-          "id": 1191,
-          "x": 324,
+          "id": 284,
+          "x": 408,
+          "y": 252
+        },
+        {
+          "id": 285,
+          "x": 408,
           "y": 132
+        },
+        {
+          "id": 286,
+          "x": 444,
+          "y": 96
+        },
+        {
+          "id": 288,
+          "x": 372,
+          "y": 132
+        },
+        {
+          "id": 289,
+          "x": 480,
+          "y": 96
+        },
+        {
+          "id": 282,
+          "x": 480,
+          "y": 132
+        },
+        {
+          "id": 290,
+          "x": 0,
+          "y": 288
+        },
+        {
+          "id": 291,
+          "x": 108,
+          "y": 252
+        },
+        {
+          "id": 292,
+          "x": 144,
+          "y": 252
+        },
+        {
+          "id": 293,
+          "x": 180,
+          "y": 252
+        },
+        {
+          "id": 294,
+          "x": 216,
+          "y": 252
+        },
+        {
+          "id": 295,
+          "x": 72,
+          "y": 288
+        },
+        {
+          "id": 296,
+          "x": 36,
+          "y": 288
+        },
+        {
+          "id": 297,
+          "x": 72,
+          "y": 168
+        },
+        {
+          "id": 298,
+          "x": 72,
+          "y": 216
+        },
+        {
+          "id": 300,
+          "x": 120,
+          "y": 288
+        },
+        {
+          "id": 299,
+          "x": 72,
+          "y": 252
+        },
+        {
+          "id": 301,
+          "x": 0,
+          "y": 252
+        },
+        {
+          "id": 287,
+          "x": 444,
+          "y": 132
+        },
+        {
+          "id": 302,
+          "x": 72,
+          "y": 132
+        },
+        {
+          "id": 303,
+          "x": 288,
+          "y": 168
+        },
+        {
+          "id": 304,
+          "x": 288,
+          "y": 204
+        },
+        {
+          "id": 305,
+          "x": 0,
+          "y": 96
+        },
+        {
+          "id": 306,
+          "x": 108,
+          "y": 132
+        },
+        {
+          "id": 833,
+          "x": 372,
+          "y": 96
+        },
+        {
+          "id": 1055,
+          "x": 36,
+          "y": 48
+        },
+        {
+          "id": 1097,
+          "x": 72,
+          "y": 48
+        },
+        {
+          "id": 1098,
+          "x": 72,
+          "y": 12
+        },
+        {
+          "id": 1099,
+          "x": 108,
+          "y": 48
+        },
+        {
+          "id": 1102,
+          "x": 324,
+          "y": 48
+        },
+        {
+          "id": 1105,
+          "x": 324,
+          "y": 0
         }
       ]
     },
@@ -141762,142 +135284,6 @@
       ]
     },
     {
-      "name": "Focus on Wand Foci",
-      "description": "Did you know which wand focus is useful and which not?",
-      "quests": [
-        {
-          "id": 1372,
-          "x": 132,
-          "y": 0
-        },
-        {
-          "id": 1373,
-          "x": 132,
-          "y": 36
-        },
-        {
-          "id": 1374,
-          "x": 84,
-          "y": 36
-        },
-        {
-          "id": 1375,
-          "x": 180,
-          "y": 36
-        },
-        {
-          "id": 1376,
-          "x": 228,
-          "y": 36
-        },
-        {
-          "id": 1377,
-          "x": 132,
-          "y": 72
-        },
-        {
-          "id": 1378,
-          "x": 228,
-          "y": 72
-        },
-        {
-          "id": 1380,
-          "x": 36,
-          "y": 72
-        },
-        {
-          "id": 1381,
-          "x": 276,
-          "y": 144
-        },
-        {
-          "id": 1384,
-          "x": 84,
-          "y": 72
-        },
-        {
-          "id": 1385,
-          "x": 180,
-          "y": 144
-        },
-        {
-          "id": 1386,
-          "x": 36,
-          "y": 144
-        },
-        {
-          "id": 1387,
-          "x": 84,
-          "y": 108
-        },
-        {
-          "id": 1388,
-          "x": 84,
-          "y": 144
-        },
-        {
-          "id": 1389,
-          "x": 84,
-          "y": 180
-        },
-        {
-          "id": 1390,
-          "x": 132,
-          "y": 108
-        },
-        {
-          "id": 1391,
-          "x": 132,
-          "y": 180
-        },
-        {
-          "id": 1392,
-          "x": 180,
-          "y": 180
-        },
-        {
-          "id": 1393,
-          "x": 0,
-          "y": 108
-        },
-        {
-          "id": 1394,
-          "x": 0,
-          "y": 144
-        },
-        {
-          "id": 1395,
-          "x": 0,
-          "y": 72
-        },
-        {
-          "id": 1396,
-          "x": 228,
-          "y": 180
-        },
-        {
-          "id": 1397,
-          "x": 228,
-          "y": 216
-        },
-        {
-          "id": 1398,
-          "x": 276,
-          "y": 216
-        },
-        {
-          "id": 1399,
-          "x": 36,
-          "y": 36
-        },
-        {
-          "id": 1400,
-          "x": 276,
-          "y": 108
-        }
-      ]
-    },
-    {
       "name": "Electro Magic",
       "description": "This Tab focus on Electro Magic Tools and Thaumic Energistics. These are some nice mods, that will help you with machinery and magic.",
       "quests": [
@@ -142059,8 +135445,8 @@
       ]
     },
     {
-      "name": "Multiblock Goals",
-      "description": "This set is a global tracker for multiblock structure goals. As you can build several parts of many multiblocks way earlier than the respective tier.",
+      "name": "multiblock.goals",
+      "description": "multiblock.goals.desc",
       "quests": [
         {
           "id": 74,
@@ -142301,62 +135687,6 @@
           "id": 1179,
           "x": 96,
           "y": 108
-        },
-        {
-          "id": 876,
-          "x": 336,
-          "y": 72
-        },
-        {
-          "id": 1412,
-          "x": 288,
-          "y": 252
-        }
-      ]
-    },
-    {
-      "name": "GT++ Multiblocks",
-      "description": "GT++ adds new functionality to GT, including high speed multiblocks - Under Construction",
-      "quests": [
-        {
-          "id": 1416,
-          "x": 144,
-          "y": 0
-        },
-        {
-          "id": 1417,
-          "x": 96,
-          "y": 0
-        },
-        {
-          "id": 1418,
-          "x": 48,
-          "y": 0
-        },
-        {
-          "id": 1419,
-          "x": 0,
-          "y": 0
-        },
-        {
-          "id": 1420,
-          "x": 336,
-          "y": 0
-        },
-        {
-          "id": 1421,
-          "x": 192,
-          "y": 0
-        },
-        {
-          "id": 1422,
-          "x": 240,
-          "y": 0
-        },
-        {
-          "id": 1423,
-          "x": 288,
-          "y": 0
         }
       ]
     },
@@ -142547,8 +135877,8 @@
       ]
     },
     {
-      "name": "Fishing Farming Cooking",
-      "description": "Catch it, grow it, eat it!",
+      "name": "Cooking Farming Fishing",
+      "description": "Cooking basic and more advanced food",
       "quests": [
         {
           "id": 627,
@@ -142754,7 +136084,7 @@
     },
     {
       "name": "Transportation",
-      "description": "From four legged steeds to iron horses",
+      "description": "All kinds of transportation means",
       "quests": [
         {
           "id": 666,
@@ -142875,11 +136205,6 @@
           "id": 1190,
           "x": 312,
           "y": 168
-        },
-        {
-          "id": 1379,
-          "x": 312,
-          "y": 96
         }
       ]
     },
@@ -142889,133 +136214,128 @@
       "quests": [
         {
           "id": 809,
-          "x": 132,
-          "y": 0
-        },
-        {
-          "id": 810,
-          "x": 132,
-          "y": 216
-        },
-        {
-          "id": 811,
-          "x": 48,
-          "y": 60
-        },
-        {
-          "id": 812,
-          "x": 132,
-          "y": 60
-        },
-        {
-          "id": 813,
-          "x": 168,
-          "y": 96
-        },
-        {
-          "id": 814,
-          "x": 96,
-          "y": 96
-        },
-        {
-          "id": 815,
-          "x": 216,
-          "y": 96
-        },
-        {
-          "id": 816,
-          "x": 264,
-          "y": 132
-        },
-        {
-          "id": 817,
-          "x": 264,
-          "y": 96
-        },
-        {
-          "id": 818,
-          "x": 300,
-          "y": 132
-        },
-        {
-          "id": 819,
-          "x": 48,
-          "y": 96
-        },
-        {
-          "id": 820,
-          "x": 96,
-          "y": 216
-        },
-        {
-          "id": 821,
-          "x": 48,
-          "y": 216
-        },
-        {
-          "id": 822,
-          "x": 300,
-          "y": 0
-        },
-        {
-          "id": 823,
-          "x": 264,
-          "y": 0
-        },
-        {
-          "id": 824,
-          "x": 300,
-          "y": 96
-        },
-        {
-          "id": 827,
-          "x": 48,
-          "y": 156
-        },
-        {
-          "id": 828,
-          "x": 348,
-          "y": 132
-        },
-        {
-          "id": 829,
-          "x": 348,
-          "y": 96
-        },
-        {
-          "id": 830,
-          "x": 348,
-          "y": 0
-        },
-        {
-          "id": 831,
           "x": 84,
           "y": 0
         },
         {
-          "id": 832,
+          "id": 810,
+          "x": 84,
+          "y": 216
+        },
+        {
+          "id": 811,
+          "x": 0,
+          "y": 60
+        },
+        {
+          "id": 812,
+          "x": 84,
+          "y": 60
+        },
+        {
+          "id": 813,
+          "x": 120,
+          "y": 96
+        },
+        {
+          "id": 814,
           "x": 48,
+          "y": 96
+        },
+        {
+          "id": 815,
+          "x": 168,
+          "y": 96
+        },
+        {
+          "id": 816,
+          "x": 216,
+          "y": 132
+        },
+        {
+          "id": 817,
+          "x": 216,
+          "y": 96
+        },
+        {
+          "id": 818,
+          "x": 252,
+          "y": 132
+        },
+        {
+          "id": 819,
+          "x": 0,
+          "y": 96
+        },
+        {
+          "id": 820,
+          "x": 48,
+          "y": 216
+        },
+        {
+          "id": 821,
+          "x": 0,
+          "y": 216
+        },
+        {
+          "id": 822,
+          "x": 252,
+          "y": 60
+        },
+        {
+          "id": 823,
+          "x": 216,
+          "y": 60
+        },
+        {
+          "id": 824,
+          "x": 252,
+          "y": 96
+        },
+        {
+          "id": 827,
+          "x": 0,
+          "y": 156
+        },
+        {
+          "id": 828,
+          "x": 300,
+          "y": 132
+        },
+        {
+          "id": 829,
+          "x": 300,
+          "y": 96
+        },
+        {
+          "id": 830,
+          "x": 300,
+          "y": 60
+        },
+        {
+          "id": 831,
+          "x": 36,
+          "y": 0
+        },
+        {
+          "id": 832,
+          "x": 0,
           "y": 0
         },
         {
           "id": 1067,
-          "x": 168,
+          "x": 120,
           "y": 216
         },
         {
           "id": 1068,
-          "x": 96,
+          "x": 48,
           "y": 252
         },
         {
           "id": 1072,
-          "x": 132,
+          "x": 84,
           "y": 300
-        },
-        {
-          "id": 1371,
-          "x": 0,
-          "y": 156
         }
       ]
     },
@@ -143651,11 +136971,6 @@
           "id": 415,
           "x": 312,
           "y": 120
-        },
-        {
-          "id": 1325,
-          "x": 108,
-          "y": 120
         }
       ]
     },
@@ -144240,17 +137555,12 @@
           "id": 1123,
           "x": 252,
           "y": 144
-        },
-        {
-          "id": 1367,
-          "x": 150,
-          "y": 0
         }
       ]
     },
     {
       "name": "Be(e) Breeding",
-      "description": "Breeding Bees for Better Bling",
+      "description": "Explain how to breeding Bees",
       "quests": [
         {
           "id": 1116,

--- a/config/betterquesting/resources/gtnh/lang/en_US.lang
+++ b/config/betterquesting/resources/gtnh/lang/en_US.lang
@@ -1,0 +1,2339 @@
+betterquesting.title.quest_lines=Quest Lines
+betterquesting.title.edit_line1=Edit Quest Lines
+betterquesting.title.edit_line2=Edit Quest Line - %s
+betterquesting.title.edit_quest=Edit Quest
+betterquesting.title.edit_tasks=Edit Tasks
+betterquesting.title.edit_rewards=Edit Rewards
+betterquesting.title.edit_text=Text Editor
+betterquesting.title.pre_requisites=Edit Pre-Requisites
+betterquesting.title.json_object=Object
+betterquesting.title.json_array=List
+betterquesting.title.json_add=New Type
+betterquesting.title.select_item=Select Item
+betterquesting.title.select_fluid=Select Fluid
+betterquesting.title.select_entity=Select Entity
+betterquesting.title.party_none=Questing Party
+betterquesting.title.party=Manage Party - %s
+betterquesting.title.party_invite=Invite Users
+betterquesting.title.select_theme=Select Theme
+betterquesting.title.importers=Importers
+betterquesting.title.submit_station=Submit Station
+
+betterquesting.btn.rewards=Rewards
+betterquesting.btn.tasks=Tasks
+betterquesting.btn.advanced=Advanced
+betterquesting.btn.is_main=Is Main
+betterquesting.btn.requirements=Requirements
+betterquesting.btn.edit=Edit
+betterquesting.btn.new=Add New
+betterquesting.btn.import=Import
+betterquesting.btn.logic=Logic
+betterquesting.btn.show=Show
+betterquesting.btn.claim=Claim
+betterquesting.btn.detect_submit=Detect/Submit
+betterquesting.btn.add_remove_quests=Add/Remove Quests
+betterquesting.btn.designer=Designer
+betterquesting.btn.item=Item
+betterquesting.btn.list=List
+betterquesting.btn.fluid=Fluid
+betterquesting.btn.entity=Entity
+betterquesting.btn.text=Text
+betterquesting.btn.number=Number
+betterquesting.btn.object=Object
+betterquesting.btn.raw_nbt=Raw NBT
+betterquesting.btn.party_new=Create Party
+betterquesting.btn.party_leave=Leave
+betterquesting.btn.party_invite=Invite
+betterquesting.btn.party_kick=Kick
+betterquesting.btn.party_join=Join
+betterquesting.btn.party_share_lives=Share Lives
+betterquesting.btn.party_share_loot=Share Loot
+
+betterquesting.home.exit=Exit
+betterquesting.home.quests=Quests
+betterquesting.home.party=Party
+betterquesting.home.theme=Theme
+
+betterquesting.gui.name=Name
+betterquesting.gui.description=Description
+betterquesting.gui.quest_line=Quest Line
+betterquesting.gui.database=Database
+betterquesting.gui.selection=Selection
+betterquesting.gui.search=Search
+betterquesting.gui.folder=Folder
+betterquesting.gui.party_invites=Invites
+betterquesting.gui.party_members=Members
+betterquesting.gui.remaining_lives=Remaining Lives: %s
+betterquesting.gui.full_lives=Lives Full
+betterquesting.gui.closing_warning=Are you sure you want to close this editor?
+betterquesting.gui.closing_confirm=Changes may be lost!
+
+betterquesting.tooltip.tasks_complete=%s/%s Tasks Complete
+betterquesting.tooltip.complete=COMPLETE
+betterquesting.tooltip.incomplete=INCOMPLETE
+betterquesting.tooltip.rewards_pending=Unclaimed rewards
+betterquesting.tooltip.requires=Requires:
+betterquesting.tooltip.shift_advanced=Hold SHIFT for advanced info
+betterquesting.tooltip.reset_time=Cooldown: %s
+betterquesting.tooltip.main_quest=Main Quest: %s
+betterquesting.tooltip.global_quest=Global Quest: %s
+betterquesting.tooltip.global_share=Global Share: %s
+betterquesting.tooltip.task_logic=Task Logic: %s
+betterquesting.tooltip.simultaneous=Simultaneos Tasks: %s
+betterquesting.tooltip.auto_claim=Auto Claim: %s
+betterquesting.tooltip.repeat=Cooldown: %s
+
+betterquesting.notice.complete=Quest Complete
+betterquesting.notice.update=Quest Updated
+betterquesting.notice.unlock=Quest Unlocked
+
+betterquesting.msg.heart_disabled=Hardcore lives are not enabled. Use "/bq_admin hardcore" to toggle it
+
+key.betterquesting.quests=Open Quests
+key.betterquesting.party=Party Manager
+key.betterquesting.themes=Change Theme
+
+itemGroup.betterquesting=Better Questing
+
+fluid.betterquesting.placeholder=Placeholder
+
+item.betterquesting.placeholder.name=Item Placeholder
+item.betterquesting.extra_life.full.name=Extra Life
+item.betterquesting.extra_life.half.name=Half Heart
+item.betterquesting.extra_life.quarter.name=Quarter Heart
+item.betterquesting.guide.name=Better Questing Starter Guide
+
+tile.betterquesting.submit_station.name=Object Submission Station (OSS)
+
+betterquesting.btn.help1=Navigation
+betterquesting.btn.help2=OSS Block
+betterquesting.btn.help3=Making Quests
+betterquesting.btn.help4=Commands
+betterquesting.btn.help5=Importing
+betterquesting.btn.help6=Themes
+betterquesting.btn.help7=Localization
+betterquesting.btn.help8=Resources
+
+betterquesting.help.page1=§l§nGeneral Navigation%n§r%nBetter Questing's main questing GUIs do not rely on an item or block that could be easily lost but instead through a single keybinding which can be found and changed through the controls menu.%n%nIn the Quest Lines screen you can select any of your active lines from the list and drag around the box to navigate to the quest of your choosing to begin completing tasks.%n%nQuesting parties can be created or edited via the Party Management screens. Here you can also toggle options for sharing hardcore lives or quest rewards.%n%nIf you'd like to change the look of your questing UIs you can choose from the currently installed themes in the Theme selection screen.
+betterquesting.help.page2=§l§nSubmission Station%n§r%nAlthough many of the questing tasks can be submitted directly through your inventory (including liquids) sometimes you need a more automated solution. This is where the Object Submission Station (OSS) comes in handy. Tasks supporting the OSS can be selected through the built in interface to enable its use. Once setup, liquids and items can be either piped in or dropped into the interface's input slot however it will not void items or liquids if no task is selected or if it has already been completed making it relatively safe from accidental item/fluid deletion. Multiple OSS are also capable of taking on separate sub-tasks under the same quest simultaneously!
+betterquesting.help.page3=§l§nMaking Quests%n§r%nTo begin making quests and quest lines you will first have to enable edit mode by running the edit command (See commands for more info). You will then be able to add or remove quest lines however you do not require one to begin making quests. This is especially handy if you'd like to make secret quests that unlock other quests or quest lines.%n%nThere are several menus you will need to become familiar with while editing. These will be a little overwhelming at first compared to most other mods but over time it will get easier. Some advanced editing screens will edit raw questing data so you'd want to be very careful what you change as it could have adverse side effects however this should never result in corruption or a crash. If either occurs than you should immediately report it to a developer.
+betterquesting.help.page4=§l§nCommands%n§r%nThere are only a handful of commands you need to know when working with Better Questing. They are separated into user commands that anyone can run and admin commands which are restricted to server operators.%n%n§o/bq_user refresh%n§r%nManually resyncs the local questing database with the server in case of potential desync issues.%n%n§o/bq_user help%n§r%nGives the player a copy of this guide%n%n§o/bq_admin edit%n§r%nToggles quest editing mode on and off. When enabled, operators will be able to access the editing menus for quests and quest lines. Remember to disable this before publishing packs or quests.%n%n§o/bq_admin hardcore%n§r%nToggles on and off the use of hardcore lives. When all lives have been depleted, players will be banned from the server or have their world deleted as per standard vanilla hardcore.%n%n§o/bq_admin reset [all|<quest_id>] [username|uuid]%n§r%nErases quest completion data for the given user. Handy to use before publishing packs.%n%n§o/bq_admin default [save|load]%n§r%nSaves/loads the current quest database to/from the global default directory. Setting defaults means any newly created worlds will start with that particular set of quests. Saving will also preserve completion data, hardcore state and edit mode so be sure to use the various other command as necessary before running this one.%n%n§o/bq_admin complete <quest_id> [username|uuid]%n§r%nForce completes a quest for the given user%n%n§o/bq_admin delete [all|<quest_id>]%n§r%nDeletes given quest(s) and progression data however it does not delete new world defaults.%n%n§o/bq_admin lives [add|set|max|default] <value> [username]%n§r%nThese commands change the amount of lives players have or the starting and max values.
+betterquesting.help.page5=§l§nImporting%n§r%nSome expansion packs may include importers for other questing mods or allow pack makers to download online quest lines. To access these importers you can click on the 'Import' button in the main quest line editor. By default Better Questing does not have any importers so if you require a specific importer you'll need to either find an expansion with one or make it yourself.
+betterquesting.help.page6=§l§nThemes%n§r%nIf you're someone who prefers a certain color pallet in their UIs or are just a pack maker wanting to give it that more authentic look and feel then themes are your best friend. Themes can change the look of the questing UIs to suit whatever your needs may be whether it be futuristic, magical or just classic Minecraft. They can be installed either through resource packs, resource directory or via expansions packs.
+betterquesting.help.page7=§l§nLocalization%n§r%nBetter Questing supports full localization of quest names and descriptions so that if you wanted to release your pack to users of all nationalities now you now can! In order to begin localizing your quests you'll need to use unique keys such as "§omypack.quest1.name§r" instead of plain text. You can then create a resource pack containing only .lang files for all the language specific translations. These files can alternatively be stored in Better Questing's resource directory for better bundling in packs
+betterquesting.help.page8=§l§nResources%n§r%nIf you want to customise the home screen, bundle themes or add localization files then you can do so through: %n%n"§o/config/betterquesting/resources/<pack_name>/§r"%n%nAny folders here can be treated as unlisted resource packs containing everything required to personalize your pack.
+
+betterquesting.design.tree=Tree Design
+
+betterquesting.toolbox.tab.main=Main
+
+betterquesting.toolbox.tool.open.name=Open
+betterquesting.toolbox.tool.open.desc=Opens a quest for futher editing
+betterquesting.toolbox.tool.grab.name=Grab
+betterquesting.toolbox.tool.grab.desc=Picks up and moves quests elsewhere in the quest line
+betterquesting.toolbox.tool.link.name=Link
+betterquesting.toolbox.tool.link.desc=Sets a quest as prerequisites for others. If a link is already present then it is removed
+betterquesting.toolbox.tool.snap.name=Grid Snap
+betterquesting.toolbox.tool.snap.desc=Changes the grid snap resolution for various other tools
+betterquesting.toolbox.tool.copy.name=Copy
+betterquesting.toolbox.tool.copy.desc=Copies the given quest including prerequisites, tasks and rewards but not progression data
+betterquesting.toolbox.tool.new.name=New Quest
+betterquesting.toolbox.tool.new.desc=Creates a new empty quest
+betterquesting.toolbox.tool.delete.name=Delete Quest
+betterquesting.toolbox.tool.delete.desc=Deletes the given quest from the quest line and database
+betterquesting.toolbox.tool.remove.name=Remove Quest
+betterquesting.toolbox.tool.remove.desc=Removes the given quest only from the quest line. The quest will still be accessible through the database
+betterquesting.toolbox.tool.complete.name=Manual Complete
+betterquesting.toolbox.tool.complete.desc=Forcibly completes the selected quest
+betterquesting.toolbox.tool.reset.name=Reset Quest
+betterquesting.toolbox.tool.reset.desc=Resets completion status and all task progress
+betterquesting.toolbox.tool.icon.name=Select Icon
+betterquesting.toolbox.tool.icon.desc=Changes the quest's icon
+
+betterquesting.cmd.complete=Completed quest %s for %s
+betterquesting.cmd.default.save=Quest database saved as default
+betterquesting.cmd.default.load=Reloaded default quest database
+betterquesting.cmd.default.none=No default currently set
+betterquesting.cmd.delete.single=Deleted quest %s
+betterquesting.cmd.delete.all=Deleted all quests
+betterquesting.cmd.edit=Edit mode %s
+betterquesting.cmd.hardcore=Hardcore mode %s
+
+betterquesting.cmd.lives.add_player=Added %s lives to %s (Total: %s)
+betterquesting.cmd.lives.add_all=Added %s lives to all players
+betterquesting.cmd.lives.remove_player=Removed %s lives from %s (Total: %s)
+betterquesting.cmd.lives.remove_all=Removed %s lives from all players
+betterquesting.cmd.lives.set_player=Set %s's lives to %s
+betterquesting.cmd.lives.set_all=Set all player's lives to %s
+betterquesting.cmd.lives.max=Set max lives to %s
+betterquesting.cmd.lives.default=Set default lives to %s
+
+betterquesting.cmd.reset.player_single=Reset quest '%s' for %s
+betterquesting.cmd.reset.player_all=Reset all quests for %s
+betterquesting.cmd.reset.all_single=Reset quest '%s' for everyone
+betterquesting.cmd.reset.all_all=Reset all quests for everyone
+betterquesting.cmd.refresh=Refreshing local database...
+
+####################
+#Quest Localisation#
+####################
+
+########
+#Tier 0#
+########
+
+#Tier 0 - It begins
+#name
+tier0.name=Tier 0 - It begins
+#description
+tier0.desc=The very first tier, tier zero. This chapter will introduce you to the basic mechanics of this modpack. Mods covered: Vanilla, Pam's Harvestcraft.
+
+########
+#Quests#
+########
+
+#Your first night
+#name
+tier0.quest1.name=Your first night
+#description
+tier0.quest1.desc=Your first task will be to find food, and a shelter for the night. The nights will be cruel, as this pack has hardcore darkness. It probably would be a good idea to collect some food now...
+
+#Sticks 'n Stones
+#name
+tier0.quest2.name=Sticks 'n Stones
+#description
+tier0.quest2.desc=This book has a built-in reading light, lucky you! Most probably you will read this text while you are waiting for the night to be over. Once it is, go out and collect some gravel and wood. Keep in mind that you need food, so look for Pam's Harvestcraft gardens. (And save some of the vegetables for seeds!)
+
+#Where is the flint?
+#name
+tier0.quest3.name=Where is the flint?
+#description
+tier0.quest3.desc=As you might have noticed, while collecting gravel, no flint dropped for you. Well, there is a... recipe for that. Look up flint in NEI and craft some!
+
+#Crafting time
+#name
+tier0.quest4.name=Crafting time
+#description
+tier0.quest4.desc=It's time to get yourself a 3x3 crafting area. Grab some flint and some wood, and build one!
+
+#Main Quests and Secondary Quests
+#name
+tier0.quest5.name=Main Quests and Secondary Quests
+#description
+tier0.quest5.desc=Now that you have made it this far notice the two new quests. See how these two quests look different? The quest with a crown is a main quest and is linked to other main quests by a thick line. You must complete the main quests to unlock the next tier. The other quest is an optional quest, and is not needed to unlock new tiers. However, optional quests often introduce you to useful items or processes.%n%nNot all main quests have a connecting line to guide you through your adventure because of book size. If there is not an obvious linked main quest at any point, try completing some of the other main quests available to you to progress.
+
+#Storage for days
+#name
+tier0.quest6.name=Storage for days
+#description
+tier0.quest6.desc=Now that you've unlocked 3x3 crafting, it's about time to make some storage for your goods. Take some of your wood, and craft a chest. You will need 4 wood, 4 planks and 1 flint.
+
+#Bamboo fence
+#name
+tier0.quest7.name=Bamboo fence
+#description
+tier0.quest7.desc=Maybe you are lucky and start off in a bamboo forest.%nBamboo is a very useful tree since it grows really fast and when you place bamboo sticks they will grow and protect your base behind a 3 block tall wall.%nAlternatively, you can also use Berry Bushes.
+
+#Tools
+#name
+tier0.quest8.name=Tools
+#description
+tier0.quest8.desc=Now that you've got a shelter, crafting table, and a place to store your items, you should make some tools. (Unless you'd like to continue punching trees with your bare hand...)
+
+#You reap...
+#name
+tier0.quest9.name=You reap...
+#description
+tier0.quest9.desc=You won't always get food rewards from this book, so it might be a good idea to take care of that problem. As you've created a hoe already, go and find some water nearby and make a field. Let's trade some sticks for a carrot, so you can start your own farm.
+
+#Collecting some berries
+#name
+tier0.quest10.name=Collecting some berries
+#description
+tier0.quest10.desc=Are you now waiting for the carrots to grow? Go and find some berry bushes and berries. The berries are a good source of food and you can put these bushes around your house to make a wall. It should provide a good protection against all those monsters that want to come into your house and kill you.
+
+#Berry medley
+#name
+tier0.quest11.name=Berry medley
+#description
+tier0.quest11.desc=Hmmm... what can you do with all those berries? Just eating? You will see that they have a very low saturation Level. Let's plant the new berry bushes and mix the berries to make some better food.
+
+#Oak trees are not apple trees
+#name
+tier0.quest12.name=Oak trees are not apple trees
+#description
+tier0.quest12.desc=Oak trees which give apples?  Who the hell added this to minecraft? You find a way of combining an oak sapling and an apple to get an apple tree sapling. Try to plant one to get a permanent source of food.
+
+#Monster trap
+#name
+tier0.quest13.name=Monster trap
+#description
+tier0.quest13.desc=If you're lucky you spawn in a sand or rainforest biome and find some quicksand. Collect a stack of the stuff, dig a small ditch and fill it with the quicksand to protect your "dirt base" home.
+
+#Get that stone
+#name
+tier0.quest14.name=Get that stone
+#description
+tier0.quest14.desc=Look at you, with your shiny flint pickaxe! Time to mine some cobblestone. Yay! (And maybe you can improve this dirt-hut too...)
+
+#Can you hear the carrots grow?
+#name
+tier0.quest15.name=Can you hear the carrots grow?
+#description
+tier0.quest15.desc=Tired of waiting since your carrots grow sooooo slow... ?%nWell I got an idea, bone meal will help you grow food in seconds. Ok, chop down some trees and I will trade you some bone meal.
+
+#Your first long range weapon
+#name
+tier0.quest16.name=Your first long range weapon
+#description
+tier0.quest16.desc=Since you can't make any vanilla bow before LV and Tinkers weapons are not in this Tier you find a way to make a spear out of sticks, leather and a string. Get one because some infernal monsters are easier to kill with a long range weapon.
+
+#Sharpness: Over... 5...
+#name
+tier0.quest17.name=Sharpness: Over... 5...
+#description
+tier0.quest17.desc=It's about time to craft something more useful: A sword!
+
+#Fire, fire, Grandpa!
+#name
+tier0.quest18.name=Fire, fire, Grandpa!
+#description
+tier0.quest18.desc=Time to burn some stuff, isn't it? You can't make charcoal in it, but you sure will find some usage for it soon(tm).
+
+#"Backed" potatoes
+#name
+tier0.quest19.name="Backed" potatoes
+#description
+tier0.quest19.desc=Eating raw potatoes isn't that healthy, as you might have noticed. Some potatoes are green and poisonous already. After you get a furnace you can make delicious baked potatoes as another food alternative. Put a baked potato on a stick to make it even more delicious.
+
+#Food variants
+#name
+tier0.quest20.name=Food variants
+#description
+tier0.quest20.desc=Maybe you noticed already that eating the same food too often is very boring and not healthy any more. Some food like tea leaf can be taken to the furnace and processed further. So take a break and drink a cup of tea. Maybe munch some tasty raisins as they are very nice.
+
+#...what you sow
+#name
+tier0.quest21.name=...what you sow
+#description
+tier0.quest21.desc=If you, by chance, did read the previous quest and planted the carrot I gave you, then you're fine. Meanwhile, you should turn some more fruits and vegetables into seeds, and increase the size of your farm to get a steady supply of food.
+
+#Shield update
+#name
+tier0.quest22.name=Shield update
+#description
+tier0.quest22.desc=Your wooden shield is very weak. So you look for a better one. Looks like you need some leather, so go and find some cows.
+
+#Shields UP
+#name
+tier0.quest23.name=Shields UP
+#description
+tier0.quest23.desc=With a sword in one hand, what can you do with the other? Right, you need a shield. Let's make one.
+
+#Soft mallet adventure
+#name
+tier0.quest24.name=Soft mallet adventure
+#description
+tier0.quest24.desc=You now have some melon slices or pumpkins but what can you do with them? Well just eat them or... use a mallet to get some seeds... OK, let's craft one. Perhaps you can use this mallet for some other things too.
+
+#Rest in pieces
+#name
+tier0.quest25.name=Rest in pieces
+#description
+tier0.quest25.desc=It's GLOPPing time! Go kill some pigs to gather meat. (And yes, they will drop cooked porkchops. Now isn't that useful...)
+
+#Fluffy and red
+#name
+tier0.quest26.name=Fluffy and red
+#description
+tier0.quest26.desc=Epic quest: Kill some sheep! (And try to get some wool, for a bed, obviously...)
+
+#What is that...?
+#name
+tier0.quest27.name=What is that...?
+#description
+tier0.quest27.desc=You've seen a lot of trees, but there are a few that look really special. You are sure that these trees are much more than just wood to build your home with or used to get charcoal.
+
+#SO...TIRED...MUST...SLEEP...
+#name
+tier0.quest28.name=SO...TIRED...MUST...SLEEP...
+#description
+tier0.quest28.desc=Sleepy time, and the end of Tier 0. Congratulations, you've built your first hideout, and you should have a steady supply of food by now. See you again in tier 1!
+
+###############
+#End Of Tier 0#
+###############
+
+
+##########
+#Tier 0.5#
+##########
+
+#Tier 0.5 - Stone Age
+#name
+tier0.5.name=Tier 0.5 - Stone Age
+#description
+tier0.5.desc=Basically the "Tier 0" of all your progression. This set helps you through the first tier until you can build your first steam machine
+
+########
+#Quests#
+########
+
+#Even More Compact Storage
+#name
+tier0.5.quest1.name=Even More Compact Storage
+#description
+tier0.5.quest1.desc=If you found enough gold you can upgrade your chest to make it an even bigger inventory of 9x9. You can just build a new chest or upgrade the iron chest with a wood to gold chest upgrade item.
+
+#GT 6 styled Pipes
+#name
+tier0.5.quest2.name=GT 6 styled Pipes
+#description
+tier0.5.quest2.desc=Maybe you are wondering why the new pipes don't auto-connect anymore? This was changed to make the pipe smarter. You can now use a wrench to connect only the pipes you want. You don't need a plate or a foil to prevent pipes from connecting anymore. Shift clicking on the end of a pipe will disable the fluid input on that side. This is super handy, for example, to prevent coal boilers from feeding back steam into water pipes.%n%nHint: If you click one pipe onto the other they will auto-connect.
+
+#Looting II
+#name
+tier0.5.quest3.name=Looting II
+#description
+tier0.5.quest3.desc=The butchers knife from gt have looting 2. Go and find some treasures during your nightly monster slaying.
+
+#More Compact Storage
+#name
+tier0.5.quest4.name=More Compact Storage
+#description
+tier0.5.quest4.desc=Now that you are starting to find more and more iron and you feel your wood chests are too small to hold all the stuff you found and collected. Now it's time to upgrade your chests to iron chests. You can just build a new chest or upgrade the wood chest with a wood to iron chest upgrade item.
+
+#Chad a better way to make Paper
+#name
+tier0.5.quest5.name=Chad a better way to make Paper
+#description
+tier0.5.quest5.desc=Making paper out of wood pulp and water can be tedious and difficult. Why not using some sugar cane macerate it down to chad and press it with two stone plates to paper? Later on you can use the chemical bath for a even better ratio.
+
+#You shall proceed
+#name
+tier0.5.quest6.name=You shall proceed
+#description
+tier0.5.quest6.desc=As you've gathered and crafted all materials and tools you need for your basic steam machinery, you may now proceed to the next tier. Keep in mind that you'll need mountains of resources in order to craft even the simplest things, so you probably should stock up on all ores in this tier. But that's up to you.
+
+#Making bronze
+#name
+tier0.5.quest7.name=Making bronze
+#description
+tier0.5.quest7.desc=Now that you've found copper and tin, you should make yourself some bronze. Use your macer... mortar to grind up some copper and tin ingots, and mix them together!
+
+#Animal farms
+#name
+tier0.5.quest8.name=Animal farms
+#description
+tier0.5.quest8.desc=Trying to get some leather or wool? You probably need to spend a lot of time hunting animals and traveling around, or you coul simply make a farm to get a decent amount of leather, wool and meat.
+
+#Sheep hairdresser
+#name
+tier0.5.quest9.name=Sheep hairdresser
+#description
+tier0.5.quest9.desc=Killing sheep to get the wool is so ineffective. Making some shears would make sense if you need more wool.
+
+#Important tools
+#name
+tier0.5.quest10.name=Important tools
+#description
+tier0.5.quest10.desc=In order to craft even basic machines, you'll need new tools. Most of them can be replaced by machines later. For now, you should become familiar with each of their recipes, as you will need a lot of these tools, starting today.%n%nYour new tools can also be used to make Railcraft water tanks, a very useful multiblock considering the finite water feature.
+
+#Tanned leather
+#name
+tier0.5.quest11.name=Tanned leather
+#description
+tier0.5.quest11.desc=You have found a way to make leather more durable and more resistant by further processing it. Make some bound leather from four pieces of leather, some strings and a woven cotton. Now you only have to hang it on a drying rack and wait about 10 minutes to get some tanned leather.
+
+#Need more space?
+#name
+tier0.5.quest12.name=Need more space?
+#description
+tier0.5.quest12.desc=As you might know: tanned leather is more resistant and good enough for a backpack. Let's get a digger's backpack and a miner's backpack. Each pack holds different items. So use both for your first true back-packed mining experience.
+
+#You need them all!
+#name
+tier0.5.quest13.name=You need them all!
+#description
+tier0.5.quest13.desc=There are many more backpacks: Hunter, builder, forester...
+
+#Basic processing
+#name
+tier0.5.quest14.name=Basic processing
+#description
+tier0.5.quest14.desc=Most things are unavailable at the moment, so let's begin with something simple. Take some of your cobblestone and smelt it into regular stone. Since this modpack is evil, you'll need to use wood for that. How much fun is that?!
+
+#Ready, set, go!
+#name
+tier0.5.quest15.name=Ready, set, go!
+#description
+tier0.5.quest15.desc=You probably should have a home by now. A steady supply of food is a fundamental requirement at all times. Take this lunch bag, it will help you store some of your foods. You will have to travel far in this tier, better be prepared!
+
+#Gardener
+#name
+tier0.5.quest16.name=Gardener
+#description
+tier0.5.quest16.desc=If you are wondering: Why do I never get seeds when destroying grass? You are right. Try to work with your new mattock on the grass blocks that do not have water anywhere nearby to find some seeds.
+
+#Better storage
+#name
+tier0.5.quest17.name=Better storage
+#description
+tier0.5.quest17.desc=While standard chests are good for your basic items and goods, they are not ideal for storing a large amount of ore. You should build yourself some barrels in order to keep things organized.
+
+#Sleeping outside
+#name
+tier0.5.quest18.name=Sleeping outside
+#description
+tier0.5.quest18.desc=Carrying the bed with you all the time the looks very funny. Why don't you craft a sleeping bag to stay outside without placing a bed and changing your spawn point. Be warned: If you play on a server then you'd better sleep below Y level 128, as nights are very cold in the mountains...
+
+#Fallen from the sky
+#name
+tier0.5.quest19.name=Fallen from the sky
+#description
+tier0.5.quest19.desc=There are big meteors everywhere and you are wondering why you need to mine them now?%nSkystone is a good source of rare earth metals in the LV age.%nInside the meteor you can find a skystone chest containing some processor press plates. Save them for later, as they are really important.
+
+#Maceration v0.1 Alpha
+#name
+tier0.5.quest20.name=Maceration v0.1 Alpha
+#description
+tier0.5.quest20.desc=This fancy little device works (almost...) like a macerator. Some people say it's even better, since it does not require power, yay! You only need to craft one for this quest, but you probably should make some more if you can...
+
+#Clay: The Gathering
+#name
+tier0.5.quest21.name=Clay: The Gathering
+#description
+tier0.5.quest21.desc=While bored, you thought that it might be a good idea to take up pottery. You should go and find some clay, the riverbanks should have some.
+
+#Gravel: The Gathering
+#name
+tier0.5.quest22.name=Gravel: The Gathering
+#description
+tier0.5.quest22.desc=Your tools will eventually lose durability. You think it would be a good idea to collect more gravel in order to provide yourself with flint for more tools.
+
+#Sand: The Gathering
+#name
+tier0.5.quest23.name=Sand: The Gathering
+#description
+tier0.5.quest23.desc=In a strange vision you saw a big structure which would allow you to make charcoal. Finally some torches! According to your calculations, you will need a lot of sand for that.
+
+#Better lunch bag
+#name
+tier0.5.quest24.name=Better lunch bag
+#description
+tier0.5.quest24.desc=Your lunch bag is now so abused and rather old so it's time to get something better. Let's craft a lunch box which can hold way more food.
+
+#Iron shields
+#name
+tier0.5.quest25.name=Iron shields
+#description
+tier0.5.quest25.desc=You have been using your hide shield long enough. After you make your first tools, grab a bit of iron ore and make a nice iron shield.
+
+#Stone spear
+#name
+tier0.5.quest26.name=Stone spear
+#description
+tier0.5.quest26.desc=Upgrade your wooden spear with a stone arrowhead and iron screws to a stone spear.
+This spear has better durability than the wooden one.
+
+#XP usage?!
+#name
+tier0.5.quest27.name=XP usage?!
+#description
+tier0.5.quest27.desc=Exploring some dungeons or fighting mobs probably gave you a lot of XP. Better use it to get iron, copper, tin or other useful dusts before you die during the next fight.%nPlace your tank on the ground and a drain on top. Now you can fill it with XP.
+
+#Making a better sword
+#name
+tier0.5.quest28.name=Making a better sword
+#description
+tier0.5.quest28.desc=Now it's time to make your first tinkers sword. First you have to make blade, hand guard and tool rod cast forms. Melt some bronze in the smeltery and cast your tool parts. Tadaa... there is your first tinkers sword.
+
+#Don't burn your fingers!
+#name
+tier0.5.quest29.name=Don't burn your fingers!
+#description
+tier0.5.quest29.desc=You have decided it's time to make some tasty pizza, but your fingers got burned badly. Reading an ancient cookbook you discovered a pair of magical items that would allow you to carry anything hot, even lava in a bucket.%n%nThe gloves have to be placed in the Baubles ring slots of Thaumcraft.
+
+#Something to carry liquids
+#name
+tier0.5.quest30.name=Something to carry liquids
+#description
+tier0.5.quest30.desc=You tried to move water with your bare hands, which didn't work at all. Luckily, you remember how to make a bucket out of clay.
+
+#Finite water!?
+#name
+tier0.5.quest31.name=Finite water!?
+#description
+tier0.5.quest31.desc=Finite water is a problem, that's for sure. Last night, you had an idea. If you can drink cacti, you should also be able make water out of 8 cacti and use that for most recipes that require water. How cool is that? So what about another trade? 10 wood for.. 3 cacti so you can setup a farm. Deal?
+
+#Another brick in the wall
+#name
+tier0.5.quest32.name=Another brick in the wall
+#description
+tier0.5.quest32.desc=Your vision becomes more clear, you'll need bricks for your first multiblock structure. You think that 104 bricks should be enough. However, the bricks you'll need are somewhat special. Make sure to craft the correct ones!
+
+#Getting (char)coal
+#name
+tier0.5.quest33.name=Getting (char)coal
+#description
+tier0.5.quest33.desc=It's time to get yourself some charcoal. For that, we're going to build a coke oven. Good that you just collected a lot of resources! (What a coincidence...)
+
+#You need MOOOOOOORE wood
+#name
+tier0.5.quest34.name=You need MOOOOOOORE wood
+#description
+tier0.5.quest34.desc=It's time to feed your new coke oven with some wood to get more charcoal. You are looking for the most efficient way to plant trees. Try to find some spruce saplings and some jungle saplings. Both can be planted in a 2x2 grid to get bigger trees.
+
+#Compact Drawers
+#name
+tier0.5.quest35.name=Compact Drawers
+#description
+tier0.5.quest35.desc=They are very compact and add some fanciness to your glorious dirt base.
+
+#Better than barrels
+#name
+tier0.5.quest36.name=Better than barrels
+#description
+tier0.5.quest36.desc=While barrels offer only a single slot for storage, drawers can go up to 4 slots each, 16 stacks in each slot. they can also be used to make a "ghetto ME storage system (Tec2k17)%nlater in the HV age with some help of ProjectRed Transportation.
+
+#Bronze javelin
+#name
+tier0.5.quest37.name=Bronze javelin
+#description
+tier0.5.quest37.desc=The bronze javelin is a bit expensive and has only 7 throws, yet it is a good mid-range weapon. With one bronze ingot you can replenish your stack of javelins.
+
+#Making better tools
+#name
+tier0.5.quest38.name=Making better tools
+#description
+tier0.5.quest38.desc=With aluminium and copper, you can create a pretty durable material "Aluminum Brass", which can be used to cast better tools. These can be used to mine some more advanced ores.%n%nBut first you need a smeltery. See the Multiblock Goals chapter in this book, or find smeltery blocks in a village nearby.
+
+#Punji Sticks
+#name
+tier0.5.quest39.name=Punji Sticks
+#description
+tier0.5.quest39.desc=A early game protection fence can be made out of punji sticks. It hurts all mobs/players and add give slowness II potion effect. Make a trench around your base and put the punji sticks inside.
+
+#Cotton, cotton and more cotton
+#name
+tier0.5.quest40.name=Cotton, cotton and more cotton
+#description
+tier0.5.quest40.desc=You find out that cotton is very useful, it can be used to make string, wool, and some other useful items too. Make a small cotton plantation to get tons of it.
+
+#Book parts
+#name
+tier0.5.quest41.name=Book parts
+#description
+tier0.5.quest41.desc=After you found a way to move water around, you had another brilliant idea: Paper! Paper is no longer made with sugarcane, you will now need wood pulp. You will need a lot of wood to craft wood pulp, so better grab your axe and go chop some trees.
+
+#Forming press v0.1
+#name
+tier0.5.quest42.name=Forming press v0.1
+#description
+tier0.5.quest42.desc=As you may have noticed, you cannot turn clay into bricks directly. Well, to be fair, it wasn't a good recipe anyway. You'll probably end up with something bread-shaped. So in order to make bricks, you need a form. Get yourself a knife and a blank pattern, and cut a brick sized piece out. It's as easy as that.
+
+#Creosote oil
+#name
+tier0.5.quest43.name=Creosote oil
+#description
+tier0.5.quest43.desc=I guess you already processed a bit of wood into charcoal and wonder what you can do with all this creosote oil?%nWell you can burn it in the normal furnace to cook your food or you can make more torches with it. Later in the LV age you probably should run combustion generators with it.
+
+#Framing Drawers
+#name
+tier0.5.quest44.name=Framing Drawers
+#description
+tier0.5.quest44.desc=Now you can really make some swaggy and even FANCIER drawers using this table, all you have to do is place some decorative blocks (works with almost ALL decorative blocks) and it will take their texture, the TOP left is the outer Square bottom left is for the front face and top right is for the borders.
+
+#Getting iron
+#name
+tier0.5.quest45.name=Getting iron
+#description
+tier0.5.quest45.desc=Iron can be found in multiple veins. Magnetite veins (y 30-180), chalcopyrite veins (y 5-60), and limonite veins (y 10-40) all contain iron ore.
+
+#Aluminini...um...?
+#name
+tier0.5.quest46.name=Aluminini...um...?
+#description
+tier0.5.quest46.desc=However it is spelled, you will need it. You can find it in chunks of gravel on the surface. Try searching in rivers. (This quest is optional, but recommended.)
+
+#Copper
+#name
+tier0.5.quest47.name=Copper
+#description
+tier0.5.quest47.desc=Copper ingots can be created by smelting copper, chalcopyrite, or malachite ore.
+
+#Tin
+#name
+tier0.5.quest48.name=Tin
+#description
+tier0.5.quest48.desc=Tin ingots can be created by smelting tin and cassiterite ore.
+
+#Cow Tipper
+#name
+tier0.5.quest49.name=Cow Tipper
+#description
+tier0.5.quest49.desc=Before you had to kill some pigs and sheep to complete quests. Now it's time to kill some cows and hopefully get some leather. If you are lucky and get a cow trophy you may never need to kill another cow in the future.
+
+#Tinker-time
+#name
+tier0.5.quest50.name=Tinker-time
+#description
+tier0.5.quest50.desc=While using your flint tools is fun in terms of burning pigs and cows, they are not very good, and can't be repaired. You discovered how to craft tools that could be repaired and upgraded, but for that you definitely need a more advanced crafting technique.
+
+#Your first bow
+#name
+tier0.5.quest51.name=Your first bow
+#description
+tier0.5.quest51.desc=Since vanilla bows are only craftable in the assembling machine and mobs do not drop them very often you have to make a Tinkers bow. Wood would be the best material for now.  So craft the bow limbs out of wood and the bow string out of strings. The arrow that has the most durability is bone, so craft the stick out of bone. It is much lighter but less durable than a regular arrow. Use a flint tip to make it repairable with flint.%n%nYou can repair your bow the same way as all the other Tinkers tools. Arrows can be regained by repairing them or picking them up from the floor.
+
+#Another fuel source
+#name
+tier0.5.quest52.name=Another fuel source
+#description
+tier0.5.quest52.desc=Lignite and regular coal are the fuel sources you'll definitely need. The latter can be turned into coal coke, which is a superior fuel source to smelt your first large batch of ore.
+
+#Upgrade 2.0
+#name
+tier0.5.quest53.name=Upgrade 2.0
+#description
+tier0.5.quest53.desc=Find iron, copper and tin ore. Very funny... How can you mine these with just a flint pickaxe?%nI have an idea. Bring me all the stone you mined with your flint pickaxe and I will give you a better tool head in exchange.
+
+#Your first tool
+#name
+tier0.5.quest54.name=Your first tool
+#description
+tier0.5.quest54.desc=When your tinkers tables are ready you can craft your first tool. If you did not find a village yet you can only craft flint tools. Let's start with a pickaxe, an axe and a shovel. At this point swords are unobtainable since they need metals like iron or bronze which you will get at a later stage. In the meantime use your gregtech swords. Your new tools are weak at first but the more you use them the better they will get. They will level up to level 99 if you play long enough. Tool parts can be replaced for a bit of level XP, however the tool must be fully repaired first.
+
+#Your first flint throwing knife
+#name
+tier0.5.quest55.name=Your first flint throwing knife
+#description
+tier0.5.quest55.desc=Is the bone bow too expensive for your taste? Then make a flint throwing knife instead. You need flint and a stick to get 12 knives. The durability and the attack damage are very low but it still helps with killing mobs from a safe distance.
+
+#Copper Ore
+#name
+tier0.5.quest56.name=Copper Ore
+#description
+tier0.5.quest56.desc=Can be found between y levels 5 and 60 either as "Copper Ore" or "Chalcopyrite". Most of the time you'll find it together with  "Iron" and "Pyrite".
+
+#Malachite
+#name
+tier0.5.quest57.name=Malachite
+#description
+tier0.5.quest57.desc=Another copper source  is "malachite" which can be found between Y level 10 and 40. This vein contains more iron ore variants like "brown limonite", "yellow limonite" and "banded iron ore".
+
+#Iron Ore
+#name
+tier0.5.quest58.name=Iron Ore
+#description
+tier0.5.quest58.desc=With iron tools, you are able to mine most of the Overworld ores. I think you already found iron or magnetite. So bring me some ores and make some iron ingots out of them.
+
+#Copper sky, Iron curtain
+#name
+tier0.5.quest59.name=Copper sky, Iron curtain
+#description
+tier0.5.quest59.desc=With your newly acquired fuel source, you are now ready to process more advanced materials than stone or clay. Iron or copper, for example. Just in case you don't know, they spawn in rather large veins. Use the following quests to locate the most important veins.
+
+#Finally, some power
+#name
+tier0.5.quest60.name=Finally, some power
+#description
+tier0.5.quest60.desc=Now that you have a coke oven, you should start producing charcoal. The more, the better. Don't worry about the creosote oil. I have another deal for you...
+
+#################
+#End Of Tier 0.5#
+#################
+
+
+########
+#Tier 1#
+########
+
+#Tier 1 - Steam
+#name
+tier1.name=Tier 1 - Steam
+#description
+tier1.desc=Quest set for all steam-based machines.
+
+########
+#Quests#
+########
+
+#Hoppers
+#name
+tier1.quest1.name=Hoppers
+#description
+tier1.quest1.desc=Hoppers come in handy when you want to automate your machines.%nYou can input items via hoppers directly into GT pipes and you don't have to use a conveyor belt.%nHowever, the input rate is much slower, and the hopper must be beneath its source inventory.
+
+#Upgrade: High speed alloys
+#name
+tier1.quest2.name=Upgrade: High speed alloys
+#description
+tier1.quest2.desc=Like most machines, there is a more advanced version of the alloy smelter. Keep in mind that this machine uses a lot of steam, so you better get some more boilers first. (This quest is optional)
+
+#Upgrade: Better furnace
+#name
+tier1.quest3.name=Upgrade: Better furnace
+#description
+tier1.quest3.desc=An updated version of the steam furnace. Uses more steam, but is almost twice as fast. (This quest is optional)
+
+#Using steam to cook things
+#name
+tier1.quest4.name=Using steam to cook things
+#description
+tier1.quest4.desc=A rather slow process, but it's more efficient than using a regular furnace.
+
+#Welcome to Tier 1
+#name
+tier1.quest5.name=Welcome to Tier 1
+#description
+tier1.quest5.desc=Welcome, and well done so far! This tier is all about your first machines, getting more stuff from your ores and making bronze ingots in a more efficient manner.
+
+#More advanced alloys
+#name
+tier1.quest6.name=More advanced alloys
+#description
+tier1.quest6.desc=Your smeltery does a great job mixing metals into alloys, but it's not very efficient, and limited in its complexity. You need something new, so why not put your steam to some use? It might also come in handy when processing raw rubber.
+
+#A very important alloy
+#name
+tier1.quest7.name=A very important alloy
+#description
+tier1.quest7.desc=The most important alloy (until you reach a higher tier) is undoubtedly red alloy. Fortunately, you have an alloy smelter, so grab some redstone and combine it with copper to get yourself a handful of that.
+
+#Wire Cutter v.0.2alpha
+#name
+tier1.quest8.name=Wire Cutter v.0.2alpha
+#description
+tier1.quest8.desc=Small gears require a wire cutter to be made, so let's craft one.
+
+#The hell is that?
+#name
+tier1.quest9.name=The hell is that?
+#description
+tier1.quest9.desc=In order to get more machines, you'll need pistons. But not those amateurish ones, you need special ones, and I shall guide you in the making of them.
+
+#Macerator v1.0!
+#name
+tier1.quest10.name=Macerator v1.0!
+#description
+tier1.quest10.desc=Finally you are able to make a device that will replace your mortar. However, the "no-durability" feature of this device comes with a cost: You need 2 diamonds for the grinding heads.
+
+#Upgrade: Better macerator
+#name
+tier1.quest11.name=Upgrade: Better macerator
+#description
+tier1.quest11.desc=An updated version of the steam macerator. Uses more steam, but is almost twice as fast. (This quest is optional)
+
+#The power of the sun
+#name
+tier1.quest12.name=The power of the sun
+#description
+tier1.quest12.desc=The sun has quite a bit of power, so why not use it to produce steam?%n%nHint: Just remember that the solar boiler calcifies and becomes less efficient over time.
+
+#Steam alternatives
+#name
+tier1.quest13.name=Steam alternatives
+#description
+tier1.quest13.desc=There is more than one way to get steam for your machines. This completely optional quest shows you some alternative methods for producing steam.
+
+#Redstone
+#name
+tier1.quest14.name=Redstone
+#description
+tier1.quest14.desc=If you didnt't find any Redstone veins, it is quite important to look for one now. Try your luck at Y level 5-40.
+
+#Redstone, early game processing
+#name
+tier1.quest15.name=Redstone, early game processing
+#description
+tier1.quest15.desc=Are you wondering how to process redstone without any macerator? Well you can mine it with a gregtech hammer and get the crushed ore. Then use with the hammer in the crafting table to get some impure redstone dust. After this, fill a cauldron with water and drop the dust in it. You will get pure redstone dust for your red alloy ingots.
+
+#Upgrade: A better compressor
+#name
+tier1.quest16.name=Upgrade: A better compressor
+#description
+tier1.quest16.desc=An updated version of the steam compressor. Uses more steam, but is almost twice as fast. (This quest is optional)
+
+#Compressing stuff
+#name
+tier1.quest17.name=Compressing stuff
+#description
+tier1.quest17.desc=This rather simple device does a very important job: compression. It's main function is to press 9 ingots into a block, but it's also useful for a variety of recipes, for example making firm tofu.
+
+#Extra Modifier
+#name
+tier1.quest18.name=Extra Modifier
+#description
+tier1.quest18.desc=If you don't have an extra modifier on your tool you can easily add one.%nA gold block and a diamond are all you need.
+
+#Oh, shiny! (Not platinum!)
+#name
+tier1.quest19.name=Oh, shiny! (Not platinum!)
+#description
+tier1.quest19.desc=To make your first macerator you need two diamonds, and to enter the Twilight Forest you need one. Finding a diamond vein would help you a lot. Go and look for one at Y level 5-20.
+
+#A clear view
+#name
+tier1.quest20.name=A clear view
+#description
+tier1.quest20.desc=Are you still living in your dirt/cobblestone bunker? How about letting in some sunlight? Grind up some sand and flint and craft some glass dust. Put it in your smeltery and pour it into a casting basin to make clear glass.%n%nHint: In order to use it for recipes, you have to chisel it.
+
+#Lapis, Lazurite, Sodalite, Calcite
+#name
+tier1.quest21.name=Lapis, Lazurite, Sodalite, Calcite
+#description
+tier1.quest21.desc=In order to make your bricked blast furnace you need to find a lapis vine containing calcite.%nYou can find the vein in the overworld or the Twilight Forest at Y 20-50.
+
+#Gypsum
+#name
+tier1.quest22.name=Gypsum
+#description
+tier1.quest22.desc=To make bricks for the blast furnace you need concrete and gypsum. Gypsum can be found in a vein together with basaltic and granitic mineral sand, and fullers earth. Y 50-60 and only in the overworld.
+
+#Upgrade: Coal boiler
+#name
+tier1.quest23.name=Upgrade: Coal boiler
+#description
+tier1.quest23.desc=This is basically just an upgrade to your current coal boiler, however it produces more than twice as much steam. Something you should consider building if you're planning to get some of the upgraded machines.
+
+#Another use for Java, I mean Lava
+#name
+tier1.quest24.name=Another use for Java, I mean Lava
+#description
+tier1.quest24.desc=With a more durable steel casing, you can use lava to make steam.
+
+#Reinforced X? Unbreakable
+#name
+tier1.quest25.name=Reinforced X? Unbreakable
+#description
+tier1.quest25.desc=With your steel tool you are able to mine obsidian. Large obsidian plates give a reinforced modifier which increases the durability of your tool.%nReinforced level X makes a tool unbreakable.
+
+#Redstone? Haste!
+#name
+tier1.quest26.name=Redstone? Haste!
+#description
+tier1.quest26.desc=Mining and digging can be soooo slow. Get some redstone on your pick, shovel or axe to make it faster.
+
+#Upgrade: Forge hammer
+#name
+tier1.quest27.name=Upgrade: Forge hammer
+#description
+tier1.quest27.desc=An updated version of the steam forge hammer. Uses more steam, but is almost twice as fast. (This quest is optional)
+
+#The Iron Guy
+#name
+tier1.quest28.name=The Iron Guy
+#description
+tier1.quest28.desc=Do you feel lonely? Need some extra protection in your base?%nCraft some Iron Golems and the monster problem inside your base will be gone.
+
+#The Cool Guy
+#name
+tier1.quest29.name=The Cool Guy
+#description
+tier1.quest29.desc=Feeling lonely? Located far away from a snow biome?%nCraft a Snow Golem, and perhaps challenge him to a snow ball fight.
+
+#Lapis? Lucky!
+#name
+tier1.quest30.name=Lapis? Lucky!
+#description
+tier1.quest30.desc=Maybe you were lucky and received the luck modifier on your pickaxe. If not, you may still have an unused modifier on your pick so you can add some lapis lazuli. Or you can perhaps add another modifier by adding a diamond and a gold block to your pick and then add some lapis.
+
+#Iron Bolts
+#name
+tier1.quest31.name=Iron Bolts
+#description
+tier1.quest31.desc=Your crossbow need some ammo to shoot with. Let's craft some wooden bolts with an iron tip.
+
+#Wooden Crosbow
+#name
+tier1.quest32.name=Wooden Crosbow
+#description
+tier1.quest32.desc=Now you are able to make a better long range weapon; a crossbow. Use wood for the the crossbow limb and the body and use obsidian (Reinforced III) for the tough binding. Normal strings for the bowstrings would be enough for now.
+
+#Alumite
+#name
+tier1.quest33.name=Alumite
+#description
+tier1.quest33.desc=It's upgrade time again. You can make alumite by mixing obsidian, steel and auluminu(i)m in the smeltery. Alumite pickaxes are able to mine ardite and cobalt in the Nether.
+
+#Upgrade of the upgrade of the...
+#name
+tier1.quest34.name=Upgrade of the upgrade of the...
+#description
+tier1.quest34.desc=It's upgrade time. Unlock redstone and obsidian level for your different tools.
+
+#Submission Station
+#name
+tier1.quest35.name=Submission Station
+#description
+tier1.quest35.desc=Although many of the questing tasks can be submitted directly through your inventory (including liquids) sometimes you need a more automated solution. This is where the Object Submission Station (OSS) comes in handy.%nTasks supporting the OSS can be selected through the built in interface to enable its use. Once setup, liquids and items can be either piped in or dropped into the interface's input slot. It will not void items or liquids if no task is selected or if it has already been completed, however, making it relatively safe from accidental item/fluid deletion. Multiple OSS are also capable of taking on separate sub-tasks under the same quest simultaneously!
+
+#Hammer time v2
+#name
+tier1.quest36.name=Hammer time v2
+#description
+tier1.quest36.desc=Using 6 ingots to craft a hammer seems pretty wasteful, as this tool has durability. How nice would it be to have a machine that does the same but without having durability and using three ingots to make two plates? Guess what, there is one! And you should totally get one.
+
+#One Anvil... Better make that two!
+#name
+tier1.quest37.name=One Anvil... Better make that two!
+#description
+tier1.quest37.desc=With your brand-new Compressor you are able to make some metal blocks for your new anvil. Better craft two anvils, one will be required for the forge hammer.%n%nWith the anvil you can repair, rename and enchant armor and tools.
+
+#Better than iron
+#name
+tier1.quest38.name=Better than iron
+#description
+tier1.quest38.desc=Wrought Iron will become very soon more important when you have a bit steel and able to build high pressure steam machines. The material is much harder then iron and you can make better tools with it too.%nTo make wrought Iron you need a furnace to smelt iron ingots down to wrough iron nuggets. With the compressor you can compress the nuggets to ingots.%n%nHint: Crushed or purified oredust can be smelt to iron nuggets directly.
+
+#Bookshelves...? Ah forestry... Multiblock farms!
+#name
+tier1.quest39.name=Bookshelves...? Ah forestry... Multiblock farms!
+#description
+tier1.quest39.desc=The bookshelf can only be made with wood planks, which are made in a compressor. Perhaps someone thinks this is a bit crazy...
+
+#Books
+#name
+tier1.quest40.name=Books
+#description
+tier1.quest40.desc=Books can be found easily enough in villages or in the roguelike dungeons surface brick house.%nI'm sure they have a recipe too.
+
+#Extracting stuff
+#name
+tier1.quest41.name=Extracting stuff
+#description
+tier1.quest41.desc=As you'll need rubber later to make cables from wires, you should get yourself a steam extractor. You can also use this machine to get more dyes from flowers, or process different fruits into juice.
+
+#Upgrade: Extractor
+#name
+tier1.quest42.name=Upgrade: Extractor
+#description
+tier1.quest42.desc=An updated version of the steam extractor. Uses more steam, but is almost twice as fast. You most probably want to craft this, as the extractor does also extract your nerves... (This quest is optional)
+
+#Mining Dirt Block by Block is so Old School
+#name
+tier1.quest43.name=Mining Dirt Block by Block is so Old School
+#description
+tier1.quest43.desc=By making a steel excavator you are now able to mine dirt in a 3x3 area. Don't destroy your whole garden.
+
+#Tool Forge
+#name
+tier1.quest44.name=Tool Forge
+#description
+tier1.quest44.desc=Finally you get your first alumite. Now it's time to craft a tool forge for making bigger Tinkers tools. 
+
+#Barrel Upgrades Tier 2
+#name
+tier1.quest45.name=Barrel Upgrades Tier 2
+#description
+tier1.quest45.desc=Are your upgraded cobblestone or dirt barrels full again?%nNo problem, upgrade them some more!
+
+#Barrel Upgrades
+#name
+tier1.quest46.name=Barrel Upgrades
+#description
+tier1.quest46.desc=Are your cobblestone or dirt barrels filled to the brim?%nNo problem, upgrade them!
+
+#Blastoff!
+#name
+tier1.quest47.name=Blastoff!
+#description
+tier1.quest47.desc=It's about time to make some steel. Look in the Multiblock Goals quest set and build a bricked blast furnace. Return here when you made at least 8 steel ingots.
+
+#Flint and steel
+#name
+tier1.quest48.name=Flint and steel
+#description
+tier1.quest48.desc=After you make steel you are able to craft flint and steel. I guess you want to travel to the Nether as soon as possible but be aware the Nether is a very dangerous place.
+
+#THE NETHER
+#name
+tier1.quest49.name=THE NETHER
+#description
+tier1.quest49.desc=Now more dangerous with extra hardcore infernal mobs. Have fun and take care.
+
+#How to make rubber
+#name
+tier1.quest50.name=How to make rubber
+#description
+tier1.quest50.desc=Making rubber is now more complicated, you need raw rubber and sulfur. Finding a sulfur vein in the Nether seems like a good idea, doesn't it? Found on Y level 5-20.
+
+#Slime Island Journey
+#name
+tier1.quest51.name=Slime Island Journey
+#description
+tier1.quest51.desc=Rubber trees are not the only source for raw rubber. Go and find a slimy island high in the sky. Slime balls and slime leaves give raw rubber too.%nMake some slime tree farms beside your rubber farm.
+
+#Cutting a Tree log by log is so Old School
+#name
+tier1.quest52.name=Cutting a Tree log by log is so Old School
+#description
+tier1.quest52.desc=By making a steel lumber axe you are now able to cut down the entire tree in one hit. Don't forget your backpack when you are cutting a sacred oak tree down.
+
+#One Block mining is so Old School
+#name
+tier1.quest53.name=One Block mining is so Old School
+#description
+tier1.quest53.desc=By making a steel hammer you are now able to mine a shaft of 3x3 blocks. Be careful in the Nether or you could be boiled in lava very quickly.
+
+#Iron spear
+#name
+tier1.quest54.name=Iron spear
+#description
+tier1.quest54.desc=Upgrade your wooden spear with an iron arrowhead and two steel screws to an iron spear.%nThe iron spear has better durability than the stone variant.
+
+#More charcoal
+#name
+tier1.quest55.name=More charcoal
+#description
+tier1.quest55.desc=You have found an alternative way of making charcoal with a "charcoal pile igniter".%nGo and start getting massive amounts of charcoal.
+
+#Ardite and Cobalt
+#name
+tier1.quest56.name=Ardite and Cobalt
+#description
+tier1.quest56.desc=If you are done with all quests you can look for cobalt and ardite in the Nether. Remember, you need an electric blast furnace to process these materials before you can make tools with them.
+
+#Netherquartz? Sharpness
+#name
+tier1.quest57.name=Netherquartz? Sharpness
+#description
+tier1.quest57.desc=Your sword is too dull? Get some nether quartz to sharpen it again.
+
+#Tetrahedrite, stibnite and copper
+#name
+tier1.quest58.name=Tetrahedrite, stibnite and copper
+#description
+tier1.quest58.desc=Maybe you are wondering why you need tetrahedrite or stibnite. Well, antimony can be centrifuged out of it which is very useful for batteries in the LV Age.%nThe veins can be found between Y level 80-120.
+
+#Accelerated plant growth
+#name
+tier1.quest59.name=Accelerated plant growth
+#description
+tier1.quest59.desc=Plants grow very slowly, you might've discovered that by now. So why you don't counter that? A watering can will come in handy very soon.
+
+#Basic crafting: Casings
+#name
+tier1.quest60.name=Basic crafting: Casings
+#description
+tier1.quest60.desc=All machines need a hull to keep their private parts together. Good news is: They are crafted in the same way for every tier, only the materials change.
+
+#Where can I put all the items in?
+#name
+tier1.quest61.name=Where can I put all the items in?
+#description
+tier1.quest61.desc=After you make your first steel you're able to craft the small backpack. In this bag you can put a lot of the stuff you want to carry around. With 36 slots it's a bit bigger than a small chest.
+
+#Molds, molds, molds
+#name
+tier1.quest62.name=Molds, molds, molds
+#description
+tier1.quest62.desc=After you can make steel and have a tinkers smelter you have to make molds. Molds can be used in the alloy smelter and the fluid solidifier. You need them to make vacuum tubes, ingots, gears and more.
+
+#Pollution what....?
+#name
+tier1.quest63.name=Pollution what....?
+#description
+tier1.quest63.desc=If you are running your bricked blast furnace for a long time you will sometimes get headaches, nausea and other weird effects. Yes this is pollution... from making so much steel. If you can collect some rubber sheets, I will trade you a complete hazmat suit.
+
+#Wire-Wrap
+#name
+tier1.quest64.name=Wire-Wrap
+#description
+tier1.quest64.desc=Placing wires without insulation seems to be a bad idea. Now that you have an extractor to extract raw rubber out of sticky resin and an alloy smelter to further process it using sulphur, you should work on getting some insulating rubber sheets.
+
+#Low tier wires
+#name
+tier1.quest65.name=Low tier wires
+#description
+tier1.quest65.desc=Low tier wires like red alloy and tin can be made in a crafting table. Copper wire requires an alloy smelter. So let's make a mold for the rubber plates.
+
+#The Plunger
+#name
+tier1.quest66.name=The Plunger
+#description
+tier1.quest66.desc=The Plunger can be used to clear liquids from pipes. It can also be used on a machine to remove up to 1000mb of fluid from its internal buffer. You don't have to wrench your machine and replace it. It can be crafted from a rod of the desired material and rubber sheets.%n%nHint: Plunger deals 2.75 - 7.75 damage depending on the materials used.
+
+#A quite different storage
+#name
+tier1.quest67.name=A quite different storage
+#description
+tier1.quest67.desc=Regular chests can fill up rather quickly if you happen to collect mob drops like swords and/or armor. By using a cabinet, you can store up to 270 items of the same type.
+
+#Where I can put all the liquids?
+#name
+tier1.quest68.name=Where I can put all the liquids?
+#description
+tier1.quest68.desc=With your brand new alloy smelter you are able to combine two materials. What happens if you mix some obsidian dust and glass? Obsidian glass, great. Your first tank that you can make would be a Buildcraft tank. This tank can carry up 16 buckets of a single fluid. It's possible to upgrade those tanks so they can hold up to 64 buckets.
+
+#Packing your tanks chests and barrels
+#name
+tier1.quest69.name=Packing your tanks, chests and barrels
+#description
+tier1.quest69.desc=Packing your chests and barrels without spilling all the things (buildcraft(tm))?%nNo problem! Make a dolly and you can carry your full chests, barrels or storage drawers anywhere you want. But be warned, you will get a slowness debuff so hopefully you don't have to travel very far. Not portable buildcraft and iron tanks can moved so too without loosing fluids.
+
+#Time for some logic
+#name
+tier1.quest70.name=Time for some logic
+#description
+tier1.quest70.desc=Good news! You are now able to advance to the next tier! Bad news is: You still have to craft a lot of things before you can begin. Fear not mortal, I shall guide you!
+
+#Wired, weird?!
+#name
+tier1.quest71.name=Wired, weird?!
+#description
+tier1.quest71.desc=One of the very basic materials which you should memorize how to craft are wires and cables. Basically you just cut a plate into a wire with your wire cutter. Not very efficient, but there will be a better way later.
+
+#Basic crafting: Motors
+#name
+tier1.quest72.name=Basic crafting: Motors
+#description
+tier1.quest72.desc=Motors are little devices that can turn electrical power into rotational energy. Very useful for all kind of machines, and not that difficult to craft. The pattern is always the same, only the materials change with tiers. For now you can use restone to magnetize your iron rod.%nLater one you are able to build a Electromagnetic Polarizer.
+
+#GT 6 styled Wires and Cables
+#name
+tier1.quest73.name=GT 6 styled Wires and Cables
+#description
+tier1.quest73.desc=Maybe you are wondering why the new wires and cables don't auto-connect anymore? This was changed to make the wires and cables smarter. You have to use a wirecutter to connect the wires and cables on the side you want. No more burnt cables or wrongly connected wires and cables from now on.%n%nHint: If you click one wire or cable on the other it will auto-connect. 
+
+#Rubber Soft Mallet
+#name
+tier1.quest74.name=Rubber Soft Mallet
+#description
+tier1.quest74.desc=Your wooden soft mallet breaks after a few uses. Now you can make a rubber mallet which is much more durable.
+
+#Better Tank... Iron Tank
+#name
+tier1.quest75.name=Better Tank... Iron Tank
+#description
+tier1.quest75.desc=Storing more than 16 buckets of fluid in one tank? Sure! Just make an iron tank or upgrade the Buildcraft tank.%nDiamond tanks carry up to 64 buckets and obsidian ones are blast proof.
+
+#Circuit Boards
+#name
+tier1.quest76.name=Circuit Boards
+#description
+tier1.quest76.desc=For every circuit you need a basic circuit board. Craft a coated circuit board and use copper wire to finish it.
+
+#Your first logic circuit
+#name
+tier1.quest77.name=Your first logic circuit
+#description
+tier1.quest77.desc=Steam machines are quite stupid, they just do one thing over and over again. As you advance into the electrical age, you've decided that you want the machines to have more features, like automatic output in order to create some automation. For that, you need logic circuits.
+
+#Resistor
+#name
+tier1.quest78.name=Resistor
+#description
+tier1.quest78.desc=Every basic circuit needs two resistors to work
+
+#Better Tank... ULV Tank
+#name
+tier1.quest79.name=Better Tank... ULV Tank
+#description
+tier1.quest79.desc=Next step is to store 32 buckets in a tank. The ULV Tank from Gt++ needs steel plates, iron plates, tin plates a clay pipe and a water bucket.
+
+#Basic crafting: Rotors
+#name
+tier1.quest80.name=Basic crafting: Rotors
+#description
+tier1.quest80.desc=Rotors are also crafted using an identical pattern with different materials. A bit annoying to craft at the moment, but you don't need a lot of them anyway.
+
+#Steam-a-licious!
+#name
+tier1.quest81.name=Steam-a-licious!
+#description
+tier1.quest81.desc=You almost made it. One last crafting step is required in order to advance to Tier 2. Keep going!
+
+###############
+#End Of Tier 1#
+###############
+
+
+########
+#Tier 2#
+########
+
+#Tier 2 - 32 EU (LV)
+#name
+tier2.name=Tier 2 - 32 EU (LV)
+#description
+tier2.desc=The first "voltage" tier of this pack. Things are getting easier...
+
+########
+#Quests#
+########
+
+#Protect your base; Tier 1
+#name
+tier2.quest1.name=Protect your base; Tier 1
+#description
+tier2.quest1.desc=One needs proper protection for ones home. So why not get some turrets for safety? At the moment, 2 Turrets are available: "Potato" and "disposable item". I assume you can guess what they do and how they work...
+
+#Turret base
+#name
+tier2.quest2.name=Turret base
+#description
+tier2.quest2.desc=Turrets must be placed on top of a turret base. Only the player who initially placed the base can access and configure the turret. So don't worry about people taking your ammunition.
+
+#Don't play with your food!
+#name
+tier2.quest3.name=Don't play with your food!
+#description
+tier2.quest3.desc=Use it to kill zombies instead. Does only a little damage, but hey, who cares?
+
+#Magnetize your rods
+#name
+tier2.quest4.name=Magnetize your rods
+#description
+tier2.quest4.desc=Magnetic steel rods need a polariser to craft. Make a few for your coils.
+
+#Saving redstone
+#name
+tier2.quest5.name=Saving redstone
+#description
+tier2.quest5.desc=Tired of using 4 redstone for one magnetic iron rod? Well, good news for you! The polarizer doesn't need redstone, just a little bit of power. You don't need to attach this machine to a permanent power source, it runs fine on battery power.
+
+#Basic transport: Fluids
+#name
+tier2.quest6.name=Basic transport: Fluids
+#description
+tier2.quest6.desc=Just like item nodes, liquid nodes transfer... liquids. But probably the best thing: They can all utilize the same transfer pipe!
+
+#Basic transport: Items
+#name
+tier2.quest7.name=Basic transport: Items
+#description
+tier2.quest7.desc=In order to transfer items, you need so called "nodes". There are some for pushing items into a pipe system, and later you'll have access to nodes that are able to pull items from attached inventories.
+
+#Who needs that dirt anyway
+#name
+tier2.quest8.name=Who needs that dirt anyway
+#description
+tier2.quest8.desc=You probably have a ton of items floating around in your base. So why not use them to kill your enemies?
+
+#Upgrading intensifies
+#name
+tier2.quest9.name=Upgrading intensifies
+#description
+tier2.quest9.desc=Your turrets probably need more space to hold more ammunition, so why not get an upgrade for that?
+
+#Transformer LV-MV
+#name
+tier2.quest10.name=Transformer LV-MV
+#description
+tier2.quest10.desc=It's possible to run MV machines while still in LV age. Build a transformer and use 4 power sources 32 eu/t to power one 128 eu/t machine. You can change the mode of a transformer with a soft mallet. If the transformer is wired and loaded then do NOT! change the mode otherwise there probably will be a big explosion.
+
+#Hey DJ, Mix it!
+#name
+tier2.quest11.name=Hey DJ, Mix it!
+#description
+tier2.quest11.desc=The mixer is a very useful device. You can mix all kind of fluid and items. (Useful to prevent dust from falling to the ground when crafting.)
+
+#Damn you, wire cutter!
+#name
+tier2.quest12.name=Damn you, wire cutter!
+#description
+tier2.quest12.desc=Enough is enough. No more wasting gazillions of ingots just for a couple of wires. Now that you have power, you should go for a wiremill!
+
+#Alloy smelter
+#name
+tier2.quest13.name=Alloy smelter
+#description
+tier2.quest13.desc=Upgrade your steam alloy smelter to an LV one.
+
+#Basic transport pipe
+#name
+tier2.quest14.name=Basic transport pipe
+#description
+tier2.quest14.desc=These pipes are rather simple and won't do anything on their own. But in combination with transfer nodes, you'll soon find out how great they are. Also, given the correct upgrades, they even surpass most other transfer systems.
+
+#Passive defence
+#name
+tier2.quest15.name=Passive defence
+#description
+tier2.quest15.desc=A more "passive" approach to base defence are walls and fences. But seriously, where is the fun in that?
+
+#Your magic progression
+#name
+tier2.quest16.name=Your magic progression
+#description
+tier2.quest16.desc=Now that you are able to produce aluminium, you may dig into magic. If you haven't unlocked basic thaumaturgy, try to find a silverwood and a greatwood sapling.
+
+#Get ready for Tier 3
+#name
+tier2.quest17.name=Get ready for Tier 3
+#description
+tier2.quest17.desc=In order to proceed forward, you need to get aluminium. A lot of it. But for now, one is enough to unlock this quest. Probably the best source for aluminium is clay, however you need an MV machine for that. So you need to find an alternative until you have enough dusts for your initial setup.
+
+#Welcome to Tier 2
+#name
+tier2.quest18.name=Welcome to Tier 2
+#description
+tier2.quest18.desc=Why, hello there! Seems you've made it into the electrical age. Don't be so quick to throw away your steam machines, you'll probably want to use them until you reach tier 3.
+
+#Thermal centrifuge
+#name
+tier2.quest19.name=Thermal centrifuge
+#description
+tier2.quest19.desc=A optional machine to get different byproducts out of your crushed and purified ore dust. This machine becomes very useful when you have reactors and want to recycle your depleted fuel rods.
+
+#A new alloy Cobalt Brass
+#name
+tier2.quest20.name=A new alloy Cobalt Brass
+#description
+tier2.quest20.desc=If you want to cut diamond blocks into plates, it's time to get a new alloy 'cobalt brass'.%nFirst you need to make brass out of zinc (only found in small ores or as a centrifuge byproduct from tin or tetrahedrite) and copper. Mix it with aluminium and cobalt dust (can be centrifuged from various materials) to get the cobalt brass dust.%n%nNow that you have come this far, we think that you are able to look up the ores that you need by yourself with the help of NEI and the ore mix spreadsheet.
+
+#You're gonna hate this #1
+#name
+tier2.quest21.name=You're gonna hate this #1
+#description
+tier2.quest21.desc=The first item you'll need a lot of. If you want to pull items out of chests or barrels you'll need one.%n%nHint: Goes pretty well with item pipes or GT machines, adjust with a screwdriver.
+
+#Mjolnir!!! (electric forge hammer)
+#name
+tier2.quest22.name=Mjolnir!!! (electric forge hammer)
+#description
+tier2.quest22.desc=Not really required, but it is a lot faster than the steam one and it can be automated. If you feel like ore washing is too slow use this hammer. There are no recipes that require anything more than steam level to hammer something.
+
+#Sifting Machine
+#name
+tier2.quest23.name=Sifting Machine
+#description
+tier2.quest23.desc=You need flawless or exquisite diamonds, emeralds, rubies or other gems? Well then it's time for you to make a Sifting Machine.
+
+#Electric macerator
+#name
+tier2.quest24.name=Electric macerator
+#description
+tier2.quest24.desc=It is highly recommended to get one of these, as the efficiency in terms of coal/steam used to macerate something is a lot better when using EU.
+
+#Find some Certus Quartz
+#name
+tier2.quest25.name=Find some Certus Quartz
+#description
+tier2.quest25.desc=The Nether is full of different kinds of quartz. For the emitter and the sensor you will need to find some certus quartz.
+
+#Quartz and Quartzite Veins
+#name
+tier2.quest26.name=Quartz and Quartzite Veins
+#description
+tier2.quest26.desc=The Nether is full of different kinds of quartz. Go and find a quartzite and certus quartz vein. They are located between Y levels 40-80.
+
+#Hello Baron, how is your black gold today?
+#name
+tier2.quest27.name=Hello Baron, how is your black gold today?
+#description
+tier2.quest27.desc=During your travels you may have seen some of these huge oil wells. Now it's time to go make a pump and put this black gold into tanks. Oil can be burned in a combustion generator or be refined.%nMining pipes are needed for pumping the oil.%n%nBring a combustion generator with you to power the pump. (Thanks to the advancement of technology the pumping machine can auto output on top.)
+
+#You're gonna hate this #2
+#name
+tier2.quest28.name=You're gonna hate this #2
+#description
+tier2.quest28.desc=The second item you'll need a lot of. When you want to get fluid out of tanks you'll need one.%n%nHint: Goes pretty well with fluid pipes or GT machines, adjust with a screwdriver. It can also be further upgraded into a fluid regulator that allows precise control of fluid transfer speed.
+
+#Suction device... nice
+#name
+tier2.quest29.name=Suction device... nice
+#description
+tier2.quest29.desc=I hope you are not thinking about what I am thinking you are thinking about...%n%nHint:%nIt is highly recommended to get one of these, as the efficiency in terms of coal/steam used to extracting something is a lot better when using EU.
+
+#Compact? Or is it?
+#name
+tier2.quest30.name=Compact? Or is it?
+#description
+tier2.quest30.desc=It is a compressor but that doesn't mean it is compact...%n%nHint:%nIt is highly recommended to get one of these electric compressors, as the efficiency in terms of coal/steam used to compress something is a lot better when using EU.
+
+#Press all the things
+#name
+tier2.quest31.name=Press all the things
+#description
+tier2.quest31.desc=With the basic forming press you can make different food items, glass arrows and some project red components. At MV/HV stage you can make rotors, various AE components and make copies of your molds and extruder shapes.
+
+#Lossless LV Cables
+#name
+tier2.quest32.name=Lossless LV Cables
+#description
+tier2.quest32.desc=How about losless 32 EU LV Cables ? Redstone alloy is a superconductor wire and will transfer your energy without any loss.
+Redalloy is a new alloy which requires an EBF. Mix redstone, silicon and coal by hand, or in the mixer for a better result.
+
+#Basic monster protection
+#name
+tier2.quest33.name=Basic monster protection
+#description
+tier2.quest33.desc=Spawning monsters in or near your base can be annoying. Especially if you happen to get infernal creepers. Luckily, there is a good way to prevent them from spawning at all.
+
+#Gotta catch 'em all
+#name
+tier2.quest34.name=Gotta catch 'em all
+#description
+tier2.quest34.desc=Sure, you can use wheat/potatoes/carrots to make animals follow you back to your base, but that can be tedious. A golden lasso is a proper solution for animal transportation.
+
+#Try to dry out the Nether
+#name
+tier2.quest35.name=Try to dry out the Nether
+#description
+tier2.quest35.desc=Pumps can do more than pump oil and water. You can go to the nether and pump lava from the huge lava lakes too.%nDon't forget to bring some tanks with you.
+
+#New source of Glowstone
+#name
+tier2.quest36.name=New source of Glowstone
+#description
+tier2.quest36.desc=Find some glowflowers in the Nether and plant them in the Overworld. You will never need to go to the Nether and harvest glowstone lamps again.
+
+#Better Tank... LV Tank
+#name
+tier2.quest37.name=Better Tank... LV Tank
+#description
+tier2.quest37.desc=Next step is to store 64 buckets in a tank. The LV Tank from Gt++ needs steel plates, iron plates, bronze plates a huge clay pipe and an LV pump.
+
+#Dust to crystals
+#name
+tier2.quest38.name=Dust to crystals
+#description
+tier2.quest38.desc=Use the autoclave to crystallize your dust. You can make raw carbon mesh out of carbon dust.
+
+#Simple Ore Washer
+#name
+tier2.quest39.name=Simple Ore Washer
+#description
+tier2.quest39.desc=Too lazy to make an ore washer, yet bored with your non-automatable cauldron? Then the simple washer is the machine for you! It work reasonably fast and uses 8eu max. Ok, you do not get any byproducts, but who cares!
+
+#Basic ore washer
+#name
+tier2.quest40.name=Basic ore washer
+#description
+tier2.quest40.desc=Macerating ores usually doubles the output. If you want MOOOOOOORE, craft an ore washer and wash out some rare materials.
+
+#LV extruder
+#name
+tier2.quest41.name=LV extruder
+#description
+tier2.quest41.desc=The extruder is not very useful in the LV age. But it will extrude your next tier of boat or make some Tinkers Construct tool parts.
+
+#You're gonna hate this #3
+#name
+tier2.quest42.name=You're gonna hate this #3
+#description
+tier2.quest42.desc=A piston, but more .. "electrical". The third item you are going to craft a lot of in the future.
+
+#You're gonna hate this #4
+#name
+tier2.quest43.name=You're gonna hate this #4
+#description
+tier2.quest43.desc=The fourth item you'll need a lot of, and is also a pain to craft. Arguably the most painful item ever.%n%nHint: Works like a conveyor but can work with selected item slots, adjust with a screwdriver.
+
+#Avengers, assemble!
+#name
+tier2.quest44.name=Avengers, assemble!
+#description
+tier2.quest44.desc=An absolute must have for fans of the movie. Oh, and to make all the things, of course.
+
+#Bzzz... Whoom...
+#name
+tier2.quest45.name=Bzzz... Whoom...
+#description
+tier2.quest45.desc=Making some flawless crystals requires a precision laser engraver.%nAt MV level the precision laser engraver becomes more important.
+
+#Better Tank... MV Tank
+#name
+tier2.quest46.name=Better Tank... MV Tank
+#description
+tier2.quest46.desc=Next step is to store 128 buckets in a tank. The MV Tank from Gt++ needs steel plates, darksteel plates, bronze plates a  bronze pipe and an LV pump.
+
+#ULV Transformer
+#name
+tier2.quest47.name=ULV Transformer
+#description
+tier2.quest47.desc=To get your simple ore washer working you need a ULV Transformer. The Washer can only work with 8 EU. If you put more into energy into it you get a big hole in your base.
+
+#A new alloy Magnalium
+#name
+tier2.quest48.name=A new alloy Magnalium
+#description
+tier2.quest48.desc=You wonder why you need magnalium now? It's not for GT machines right now but for a material update for your crossbow.%nIt's a very good material in LV Tier. Go to the Twilight Forest and find an Olivine/Glauconite vein located at Y 10-40 or in the Overworld a Glauconite Soapstone mix located at Y 20-50 and a Granitic Mineral Vein in the Overworld Located at Y 50-60 (The Gypsum vein you will need for the Bricked Blast Furnace).%nWith your Ore Washer you can get Magnesium and Aluminium out of the Ores (Magnesite for Magnesium and Fullers Earth for Aluminium) and mix it in the Alloy smelter to Magnalium.%nMagnesite gives 10 tiny piles of Magnesium each dust but fullers earth gives only a tiny pile of Aluminium.
+
+#Hydrogen, methane or some farts... (Natural gas) 
+#name
+tier2.quest49.name=Hydrogen, methane or some farts... (Natural gas) 
+#description
+tier2.quest49.desc=Some centrifugal processes leave gases behind like hydrogen or methane. Centrifuge some brown and yellow limonite to get hydrogen or dump your unused food in a centrifuge to get methane gas. Wood will even give 60 mb per log. Maybe it's time to build a forestry tree farm.
+
+#Molten redstone?
+#name
+tier2.quest50.name=Molten redstone?
+#description
+tier2.quest50.desc=You heard that the carpenter needs some molten redstone for a few recipes.%nConverting redstone dust into a fluid requires a fluid extractor. Let's build one.
+
+#Diesel, oil or maybe creosote?
+#name
+tier2.quest51.name=Diesel, oil or maybe creosote?
+#description
+tier2.quest51.desc=You probably collected a ton of creosote and maybe even have built your first 'electric' blast furnace. creosote will be a good fuel for the moment. So try to build a few of the combustion generators and use them besides steam as a secondary power source.
+
+#Bow, arrows and quiver
+#name
+tier2.quest52.name=Bow, arrows and quiver
+#description
+tier2.quest52.desc=Wow, your first handmade *ehm* machine made bow. You find out that you can put the bow in the mine and blade battlegears slots. Now it's time to make a quiver and maybe some arrows. You can put up to 4 stacks of arrows in your quiver.%n%nLet's go hunt a bit.
+
+#You're gonna hate this #5
+#name
+tier2.quest53.name=You're gonna hate this #5
+#description
+tier2.quest53.desc=The fifth item you'll need a lot of. For the microwave, the scanner, the precision laser engraver, etc.
+
+#Auto Mining
+#name
+tier2.quest54.name=Auto Mining
+#description
+tier2.quest54.desc=A miner in LV age? Wow! This nifty machine will find ores for you. Place up to two stacks of mining pipes in the right slots. This machine needs 32 EU/t to work; with an 8V Solar panel it works at 25% speed. The miner searches for ores in a 16 block radius.
+
+#Ardite Crossbow Body
+#name
+tier2.quest55.name=Ardite Crossbow Body
+#description
+tier2.quest55.desc=To make your crossbow even better craft an ardite crossbow body. You received a few ardite ingots as reward before.%nWith redstone you can make your bow faster. This requires a free modifier slot on your crossbow.
+
+#Fiery Bowstring
+#name
+tier2.quest56.name=Fiery Bowstring
+#description
+tier2.quest56.desc=Why not upgrade your bowstring too?. If you cannnot find any fiery strings in the Nether you got some from the last quest. Craft some fiery bowstring with it.
+
+#Magnalium Crossbow
+#name
+tier2.quest57.name=Magnalium Crossbow
+#description
+tier2.quest57.desc=Now its time to craft your Crossbow Limb and the Crossbow Body to upgrade your old Wooden Crossbow.
+
+#Magnalium Crossbow Bolts
+#name
+tier2.quest58.name=Magnalium Crossbow Bolts
+#description
+tier2.quest58.desc=Magnalium bolts are much better than your old wooden bolts.%nYou can use nether quartz on the bolts to make them even better.%nThis requires a free modifier slot.
+
+#Basic Fluid Solidifier
+#name
+tier2.quest59.name=Basic Fluid Solidifier
+#description
+tier2.quest59.desc=To get your molten fluids back to a solid state you need a fluid solidifier. It is used for crossbow bolts as well.
+
+#Scanning bees, crops and moooooore!
+#name
+tier2.quest60.name=Scanning bees, crops and moooooore!
+#description
+tier2.quest60.desc=Automate your bee or crop scanning. Later on, this machine gets very useful for scanning high tier machine parts for the assembly line research data or to fill data orbs with data for the UU matter production. Data sticks with raw prospecting data need a scanner too.
+
+#You're gonna hate this #6
+#name
+tier2.quest61.name=You're gonna hate this #6
+#description
+tier2.quest61.desc=The sixth item you'll need a lot of. For the scanner and the seismic prospector.
+
+#Sulfuric gas
+#name
+tier2.quest62.name=Sulfuric gas
+#description
+tier2.quest62.desc=Another distillate for your gas turbine you can make out of oil is sulfuric gas with a burn value of 25,000 EU per cell.
+
+#Glue
+#name
+tier2.quest63.name=Glue
+#description
+tier2.quest63.desc=If you centrifuge sticky resin, you get some glue. Glue is very useful in the creation of good circuit boards.
+
+#Empty Circuit Board
+#name
+tier2.quest64.name=Empty Circuit Board
+#description
+tier2.quest64.desc=Good circuit boards require wooden pulp and refined glue to make phenolic circuit boards. By adding gold wire you can craft a good circuit board.
+
+#Good Circuits
+#name
+tier2.quest65.name=Good Circuits
+#description
+tier2.quest65.desc=Good circuits are an improvement on basic circuits. They are a component of all MV gregtech machines. Be sure you build the electric blast furnace first, so you can process some aluminium dust into ingots.
+
+#Diode
+#name
+tier2.quest66.name=Diode
+#description
+tier2.quest66.desc=Good circuits need diodes. There are two ways to craft them. Using a silicon wafer together with some fine tin wire or gallium arsenide. Molten glass is also needed.
+
+#Gallium Arsenide
+#name
+tier2.quest67.name=Gallium Arsenide
+#description
+tier2.quest67.desc=The diode requires gallium arsenide and you may be wondering how to get gallium or arsenic this early in the game.%nYou can get gallium out of crushed zinc ore by using a thermal centrifuge. You can find the small zinc ores in the Overworld or the in the Nether at Y Level 80 - 210. To get cushed ore, you may need a Tinker's Construct tool with the Luck (Fortune) enchant on it. Sphalerite is another source of gallium.%nYou can get arsenic from realgar small ores in the Nether at Y level 5 - 85. Centrifuge the dusts in a centrifuge. Another source is tinkers construct cobalt ore in the nether.%nMix those two dusts in a mixer to get gallium arsenic dust.
+
+#Your oil is too Crude? Refine it!
+#name
+tier2.quest68.name=Your oil is too Crude? Refine it!
+#description
+tier2.quest68.desc=Burning oil in the combustion generator is a very inefficient way of producing power. Every bucket/cell of oil only gives you 20,000 EU. Time to try and refine it...
+
+#Sulfuric naphtha
+#name
+tier2.quest69.name=Sulfuric naphtha
+#description
+tier2.quest69.desc=Another distillate you can make out of oil is sulfuric naphtha with a burn value of 40,000 EU per cell in the gas turbine.
+
+#Naphtha
+#name
+tier2.quest70.name=Naphtha
+#description
+tier2.quest70.desc=You can process sulfuric naphtha to fluid naphtha which has a burn value of 320,000 EU in the gas turbine.%nNaphtha is also a base product for polyethylene and polycaprolactam.
+
+#Refinery gas
+#name
+tier2.quest71.name=Refinery gas
+#description
+tier2.quest71.desc=Refine your gas in a chemical reactor with hydrogen gas to give it a better burn value of 160,000 EU, and maybe use it to make methane gas.
+
+#Methane
+#name
+tier2.quest72.name=Methane
+#description
+tier2.quest72.desc=Distilling some "refinery gases" gives you some methane gas. There are many more ways to get methane.
+
+#N like nitrogen... Hide, alphabet strikes again!
+#name
+tier2.quest73.name=N like nitrogen... Hide, alphabet strikes again!
+#description
+tier2.quest73.desc=You can get some nitrogen by centrifuging... air. This process takes a long time, especially at the LV tier.
+
+#How to get sodium/lithium
+#name
+tier2.quest74.name=How to get sodium/lithium
+#description
+tier2.quest74.desc=Salt ore mixes can be found in the Overworld between Y level 50-70. Salt isn't only used to get sodium, it's an important ingredient in many pam's harvestcraft food recipes.%n%nHint: Lepidolite and spodumene are good sources of lithium for your batteries.
+
+#Food 2.0
+#name
+tier2.quest75.name=Food 2.0
+#description
+tier2.quest75.desc=Forget everything you know about food and values. With your new canning machine you are able to fill tin cans with very nourishing food. This food can be consumed in milliseconds and makes you full and happy.
+
+#LPG
+#name
+tier2.quest76.name=LPG
+#description
+tier2.quest76.desc=Centrifuging some Butane or Propane gives you LPG with a burn value of 320,000 EU, the same as naphtha. Also it is a way to get methane and eventually epichlorohydrin.
+
+#Butane and Propane
+#name
+tier2.quest77.name=Butane and Propane
+#description
+tier2.quest77.desc=You can distill a lot of different gases out of your "refinery gases".%nMethane, butane, propane, helium and ethane.%n%nHint:%nRefinery gas is not the best source for Propane and Butane. Better refine those out of naphtha.
+
+#H like Hydrogen... rest of the alphabet is too complicated...
+#name
+tier2.quest78.name=H like Hydrogen... rest of the alphabet is too complicated...
+#description
+tier2.quest78.desc=Centrifuge some brown or yellow limonite dust to get some hydrogen, or use an Electrolyser with some water to produce it in a fluid form.
+
+#Round and round and round...
+#name
+tier2.quest79.name=Round and round and round...
+#description
+tier2.quest79.desc=After purification of your ore dust, you can centrifuge it to get even more byproducts out of the dust.
+
+#Water and electricity, sounds fun and safe right?
+#name
+tier2.quest80.name=Water and electricity, sounds fun and safe right?
+#description
+tier2.quest80.desc=Using the power of water and electricity you can get even more out of your dusts.
+
+#IC2 Battery
+#name
+tier2.quest81.name=IC2 Battery
+#description
+tier2.quest81.desc=Some recipes require IC2 batteries. Fill your small battery hull with some molten redstone and you will get your RE-Battery. Molten cells will hurt you, so be careful.
+
+#Lithium
+#name
+tier2.quest82.name=Lithium
+#description
+tier2.quest82.desc=Lithium can be washed out of Lepidolite Ore or centrifuged out of Spodumene Ore.
+
+#Basic canner
+#name
+tier2.quest83.name=Basic canner
+#description
+tier2.quest83.desc=The canning machine is mainly used to fill tin cans with any kind of food, but it is useful for filling and emptying tin cells with other solid items than food, usually in the form of dust. It can also fill batteries with redstone, cadmium, lithium or sodium.
+
+#Reusable battery: Lithium
+#name
+tier2.quest84.name=Reusable battery: Lithium
+#description
+tier2.quest84.desc=Sodium, cadmium, and lithium batteries are rechargeable batteries. They are crafted without stored energy, but can be charged in any gregtech machine. If unneeded, they can be placed in an extractor and converted back into small battery hulls, but their contents are lost.
+
+#Heavy Sulfuric fuel
+#name
+tier2.quest85.name=Heavy Sulfuric fuel
+#description
+tier2.quest85.desc=The second step is to distill your oil into heavy sulfuric fuel, that has a burn value of 40,000 EU.
+
+#Heavy fuel
+#name
+tier2.quest86.name=Heavy fuel
+#description
+tier2.quest86.desc=By adding hydrogen to sulfuric heavy fuel in a chemical reactor you can produce some heavy fuel with the burn value of 200,000 EU.%n%nThe remaining hydrogen sulfide cells can be used later to produce some sulfuric acid for your TNT/iTNT or acid batteries.%n%nIn MV age you can make diesel out of heavy and light fuel.
+
+#The missing one
+#name
+tier2.quest87.name=The missing one
+#description
+tier2.quest87.desc=It was once said... <basdxz> But ffs, add a plate bender to the LV tier book ...and then it popped into existence.
+
+#Antimony
+#name
+tier2.quest88.name=Antimony
+#description
+tier2.quest88.desc=The most efficient way to get antimony for batteries is to centrifuge stibnite dust, the second most efficient way is to use tetrahedrite dust.
+
+#Sodium
+#name
+tier2.quest89.name=Sodium
+#description
+tier2.quest89.desc=Sodium can be washed out of Glauconite Ore and Sand. It can also be electrolyzed out of salt.
+
+#How to get sodium
+#name
+tier2.quest90.name=How to get sodium
+#description
+tier2.quest90.desc=A second source for sodium is glauconite ore or glauconite sand. This type of ore vein can be found at Y level 20-50.
+
+#Reusable battery: Sodium
+#name
+tier2.quest91.name=Reusable battery: Sodium
+#description
+tier2.quest91.desc=Sodium, cadmium, and lithium batteries are rechargeable batteries. They are crafted without stored energy, but can be charged in any gregtech machine. If unneeded, they can be placed in an extractor and converted back into small battery hulls, but their contents are lost.
+
+#Chemical rubber production
+#name
+tier2.quest92.name=Chemical rubber production
+#description
+tier2.quest92.desc=A much more efficient way to make insulated cables is by making molten rubber in a chemical reactor which can be applied to a cable in the assembling machine. When you put both machines next to each other you can output the molten rubber directly to the assembling machine by clicking the fluid auto-output button on the chemical reactor. Make sure to set the correct side of the reactor as output side by wrenching it.
+
+#Empty Cells
+#name
+tier2.quest93.name=Empty Cells
+#description
+tier2.quest93.desc=With your plate bender you are able to make empty cells. The circuit needs to be configured to 12 otherwise you will make foil.
+
+#A lead about lead that leads to lead dust
+#name
+tier2.quest94.name=A lead about lead that leads to lead dust
+#description
+tier2.quest94.desc=The next step of making batteries is to collect some lead. Lead and galena veins can be found in the Twilight Forest at y levels 5 - 45.
+
+#Battery alloy
+#name
+tier2.quest95.name=Battery alloy
+#description
+tier2.quest95.desc=Mixing antimony and lead in the alloy smelter will give you some battery alloy.%nCombine it with some tin cable and voila there is your small battery hull.
+
+#A big meteorite
+#name
+tier2.quest96.name=A big meteorite
+#description
+tier2.quest96.desc=The best way to get rare earth is to find an applied energistics 2 meteorite and grind the blocks into dust. Maybe you completed the quest in the steam age and stored your crushed skystone somewhere? That dust can now be centrifuged into various byproducts like cadmium, neodymium, caesium, lanthanum, and yttrium.%n%nHint: Redstone has rare earth as byproduct. Chalcopyrite (at HV level) and sphalherite (at LV level) have cadmium as byproduct.
+
+#Reusable battery: Cadmium
+#name
+tier2.quest97.name=Reusable battery: Cadmium
+#description
+tier2.quest97.desc=Sodium, cadmium, and lithium batteries are rechargeable batteries. They are crafted without stored energy, but can be charged in any gregtech machine. If unneeded, they can be placed in an extractor and converted back into small battery hulls, but their contents are lost.
+
+#Cheaper Annealed Production
+#name
+tier2.quest98.name=Cheaper Annealed Production
+#description
+tier2.quest98.desc=It' s even faster and cheaper to make annealead copper in the arc furnace than in the electric blast furnace. Annealed copper is a very good material for wires in MV. It only loses 1 EU per block.
+
+#Lubricant
+#name
+tier2.quest99.name=Lubricant
+#description
+tier2.quest99.desc=Using lubricant instead of water or distilled water in your cutting machines will increase the output or speed of the machines.%nYou can make lubricant out of oil, seed oil, fish oil or creosote. If you are able to craft a brewery you can use talk and soapstone to get much more lubricant each cycle.
+
+#Light Sulfuric Fuel
+#name
+tier2.quest100.name=Light Sulfuric Fuel
+#description
+tier2.quest100.desc=The first step is to distill your oil into light sulfuric fuel, that has a burn value of 40,000 EU.
+
+#Light fuel
+#name
+tier2.quest101.name=Light fuel
+#description
+tier2.quest101.desc=By adding hydrogen to sulfuric light fuel in a chemical reactor you can produce some light fuel with the very high burn value of 320,000 EU.%n%nThe remaining hydrogen sulfide cells can be used later to produce some sulfuric acid for your TNT/iTNT or acid batteries.%n%nIn MV age you can make diesel out of light and heavy fuel.
+
+#C9H8O4...NaCl...H2O...
+#name
+tier2.quest102.name=C9H8O4...NaCl...H2O...
+#description
+tier2.quest102.desc=Want to make some cetane-boosted diesel, plastic or some chemical dye? Then it's time to craft a chemical reactor.
+
+#No more filing
+#name
+tier2.quest103.name=No more filing
+#description
+tier2.quest103.desc=Why waste a full ingot to make a rod by using a tool which loses durability and takes even MORE ingots? With this little device, all your rod-needs shall be fulfilled (for now).
+
+#Portable mob spawners..? Cool!
+#name
+tier2.quest104.name=Portable mob spawners..? Cool!
+#description
+tier2.quest104.desc=Do you want to move the spawners around and build some cool mob farms? That will be no problem if you get the diamond dolly.
+
+#Diamond Chests... Oh shiny
+#name
+tier2.quest105.name=Diamond Chests... Oh shiny
+#description
+tier2.quest105.desc=After you build a cutting machine you can make some diamond plates for your new big diamond chests.
+
+#LV Advanced Steam Boiler
+#name
+tier2.quest106.name=LV Advanced Steam Boiler
+#description
+tier2.quest106.desc=The LV Gt++ Steam Boiler is the next machine you can build to produce steam more efficient than with the High Pressure Boiler.
+
+#Electrotine battery
+#name
+tier2.quest107.name=Electrotine battery
+#description
+tier2.quest107.desc=The electrotine battery is exclusively used in project red machines and the jetpack.%nElectrotine is a mixture of redstone and electrum dust.
+
+#Sulfuric acid
+#name
+tier2.quest108.name=Sulfuric acid
+#description
+tier2.quest108.desc=Combining sulfur trioxide and water in the chemical reactor will give you sulfuric acid for your single use acid batteries. If you have made some light or heavy fuel already maybe you have some spare hydrogen sulfide. If not, you can always make sulfuric acid with some sulfur and water in the chemical reactor.
+
+#Fluid canner
+#name
+tier2.quest109.name=Fluid canner
+#description
+tier2.quest109.desc=The fluid canner is a fundamental machine, since it is necessary to move fluids around, as well as for filling tin cells, glass bottles, buckets, and even batteries.%n%nAnother interesting thing about the fluid canner is that it can be transformed into a raintank, by attaching a drain cover on its top (Any machine with tank actually can be...).
+
+#Single use battery: Acid
+#name
+tier2.quest110.name=Single use battery: Acid
+#description
+tier2.quest110.desc=Mercury and acid Batteries are single-use batteries. They are crafted fully charged but cannot be re-charged. Once their stored energy is depleted, they can be placed in an extractor to be converted back into small battery hulls.%n%nThey can be placed in the battery slot in any standard LV gregtech machine, in that case they will be depleted before the machine's internal EU storage. They can also be used in LV battery buffers.
+
+#Battery buffer
+#name
+tier2.quest111.name=Battery buffer
+#description
+tier2.quest111.desc=Batteries can be placed directly in machines. To recharge a battery you need a battery buffer. They come in different sizes: 1, 4, 9 and 16 slots.
+
+#LV battery buffer 9 slots
+#name
+tier2.quest112.name=LV battery buffer 9 slots
+#description
+tier2.quest112.desc=Upgrade your battery buffer to hold 9 batteries which allows max 9 ampere output.%nUseful for your EBF and the arc furnace.
+
+#Basic arc furnace
+#name
+tier2.quest113.name=Basic arc furnace
+#description
+tier2.quest113.desc=The arc furnace is an alternative to smelting stuff back into components and making wrought iron. The recipes use oxygen and 3 amperes of power.
+
+#Faster steel production
+#name
+tier2.quest114.name=Faster steel production
+#description
+tier2.quest114.desc=A faster alternative to steel production is to use the arc furnace and smelt the iron ingots into wrought iron ingots. Then macerate them to dust and smelt them very fast in the EBF to steel. (Some might even dare arc furnacing the dust itself...)
+
+#A truly sharp saw blade
+#name
+tier2.quest115.name=A truly sharp saw blade
+#description
+tier2.quest115.desc=Combining cobalt brass and diamond dust makes a really sharp saw blade for your cutting machine.
+
+#Cutting things apart
+#name
+tier2.quest116.name=Cutting things apart
+#description
+tier2.quest116.desc=An absolutely mandatory machine to have. It will cut rods into bolts, plates into casings, logs into planks, and all of that will be done with the highest possible efficiency. Totally worth it!%n%nHint: Just add water.
+
+#Diamond Tanks... Oh shiny
+#name
+tier2.quest117.name=Diamond Tanks... Oh shiny
+#description
+tier2.quest117.desc=After you build a cutting machine you can make some diamond plates for your new 64 buckets single block tank.
+
+#Mercury
+#name
+tier2.quest118.name=Mercury
+#description
+tier2.quest118.desc=Mercury can be centrifuged out of redstone. If you find some cinnabar ore in the redstone vein you can use that too.
+
+#Single use battery: Mercury
+#name
+tier2.quest119.name=Single use battery: Mercury
+#description
+tier2.quest119.desc=Mercury and acid batteries are single-use batteries. They are crafted fully charged but cannot be re-charged. Once their stored energy is depleted, they can be placed in an extractor to be converted back into small battery hulls.%n%nThey can be placed in the battery slot of any standard LV gregtech machine, in that case they will be depleted before the machine's internal EU storage. They can also be used in LV battery buffers.
+
+###############
+#End Of Tier 2#
+###############
+
+
+##################
+#Multiblock Goals#
+##################
+
+#Multiblock Goals
+#name
+multiblock.goals=Multiblock Goals
+#description
+multiblock.goals.desc=This set is a global tracker for multiblock structure goals. As you can build several parts of many multiblocks way earlier than the respective tier.
+
+########
+#Quests#
+########
+
+#Automation tier 1
+#name
+multiblock.goals.quest1.name=Automation tier 1
+#description
+multiblock.goals.quest1.desc=Do you want to automate your smeltery because you are planning to make stacks of glass blocks?%nNo problem, craft a large bronze pipe and place it under the faucet. Now the molten fluid will flow inside the pipe. Under the pipe you have to place the casting basins or tables.%n%nA hopper and a chest underneath would be good to auto-output products.
+
+#You are not prepared!!!
+#name
+multiblock.goals.quest2.name=You are not prepared!!!
+#description
+multiblock.goals.quest2.desc=It's time for something really big: A smeltery! There's a lot to craft, so better gather some resources...
+
+#The water dilemma
+#name
+multiblock.goals.quest3.name=The water dilemma
+#description
+multiblock.goals.quest3.desc=Finite water is a problem. But fear not, there are solutions! I shall guide you to a steady supply of water.
+
+#Multiblock tanks... Railcraft tanks
+#name
+multiblock.goals.quest4.name=Multiblock tanks... Railcraft tanks
+#description
+multiblock.goals.quest4.desc=576 buckets of fluid, that should be enough to store all the creosote you have accumulated thus far. If that isn't enough you can make this tank bigger. The smallest tanks are 3x3x4 while the biggest are 9x9x8.%n%nHint: Fluid will auto-output (without any pumps) if you place a valve on the bottom side of the tank.%n%nUse only Buckets to move fluids because cells get destroyed.
+
+#Why one coke oven when you can have ten
+#name
+multiblock.goals.quest5.name=Why one coke oven when you can have ten
+#description
+multiblock.goals.quest5.desc=Your bricked blast furnace uses coal like hell and your steam boiler too? Well it's time to make more coke ovens and automate them a bit. Wooden fluid pipes and tin item pipes will help you reach your goal.
+
+#Analyzing the soil
+#name
+multiblock.goals.quest6.name=Analyzing the soil
+#description
+multiblock.goals.quest6.desc=To determine which kind of oil or gas there is in the chunk you need to scan the soil by right clicking a seismic prospector with 8 dynamite, 4 TNT, 2 industrial TNT or 1 glyceryl. Then use a data stick to extract the data by right clicking on it after the animation has finished.%nProTip: you can do it more efficiently by only scanning every 8 chunks.%n%nNow you need to add the analyzed data stick to a scanner. Then place it in the bottom right slot of the printer and add 3 paper in the top left slot and make sure you have atleast 144 mb squid ink in it. (Only gregtech machines will work)%n%nAfter the process is done take the printed page and combine it with a piece of leather in an assembling machine filled with at least 20 mb of refined glue.%n%nTADA now you have a book with info about the chunk you scanned.  
+
+#Railcraft steam power
+#name
+multiblock.goals.quest7.name=Railcraft steam power
+#description
+multiblock.goals.quest7.desc=As an alternative way to steam you can use the railcraft boilers. They require at least one firebox.
+More than one size is possible: (1x1 mentioned above) 2x2 and 3x3. Each boiler needs 1, 2 or 3 layers of tanks on top, depending on the size.
+
+#Liquid fuelled firebox
+#name
+multiblock.goals.quest8.name=Liquid fuelled firebox
+#description
+multiblock.goals.quest8.desc=Cresosote oil into steam! After you make your first steel you are able to craft a liquid fueled firebox.%nDiesel, ethanol, creosote and biofuel all work well here.
+
+#It's time to get more steam
+#name
+multiblock.goals.quest9.name=It's time to get more steam
+#description
+multiblock.goals.quest9.desc=As soon as you have the ability to store energy in large quantities, it would be necessary to have a way to generate energy in large quantities. You need a large bronze boiler. But in order to make this boiler, you will need a mountain of bronze. This boiler produces 800 liters of steam per tick. This is enough to run 10 basic steam turbines.%n%nThe large boiler can uses either water or distilled water. Water is consumed at a rate of 1l of water per 150l of steam.%n%nTo make a large boiler you must make a 3x3x5 structure with pipe casings in the center of the middle 3 levels. The lowest level must contain at least 1 or 2 input hatches, 1 or 2 input buses, 3 or 4 fireboxes, 1 muffler, and one maintenance hatch. The lowest level can not contain any plated bricks. All hatches, buses, and mufflers must have their back side touching a firebox. The output hatch can be placed on any of the upper 4 levels.
+
+#Automation tier 2
+#name
+multiblock.goals.quest10.name=Automation tier 2
+#description
+multiblock.goals.quest10.desc=You want a better automation than using pipes? Sure, craft a comparator and link it with redstone dust placed on the ground. The redstone needs to be adjecent to the faucet to activate the crafting process.
+
+#Time to get some steel
+#name
+multiblock.goals.quest11.name=Time to get some steel
+#description
+multiblock.goals.quest11.desc=You need steel? Uhh... fine. Let's get busy...%n%nHint: The bricked blast furnace can share walls with other ones, just like most GT multi blocks. How will this affect the air quality though...
+
+#The "Waterproblems" are solved
+#name
+multiblock.goals.quest12.name=The "Waterproblems" are solved
+#description
+multiblock.goals.quest12.desc=Entering the HV age you found a way of making a water reservoir wich solves the finite water problem. Craft it with some fused quartz glass, HV pumps and cauldrons.
+
+#Steel multiblock tanks
+#name
+multiblock.goals.quest13.name=Steel multiblock tanks
+#description
+multiblock.goals.quest13.desc=Do you want to have tanks that can hold double the amount than that of the iron ones? Go ahead and make a steel tank. All sizes allowed from 3x3x4 to 9x9x8 blocks.%n%nHint: Fluid will auto-output (without any pumps) if you place a valve on the bottom side of the tank.%n%nOnly use buckets because cells get destroyed.
+
+#Smelt all the things...
+#name
+multiblock.goals.quest14.name=Smelt all the things...
+#description
+multiblock.goals.quest14.desc=Smelting up to nine items at once? With a bit of steel you can make a railcraft Steam Oven. 2x2x2%n%nHint: All furnace recipes work just fine, but you cannot use it to make charcoal from wood.
+
+#Low pressure boiler tank
+#name
+multiblock.goals.quest15.name=Low pressure boiler tank
+#description
+multiblock.goals.quest15.desc=The low pressure boiler tank is the easiest way to store steam. The firebox needs this tank on top to produce steam. The bigger the boiler the slower it heats up, but it will produce more steam when heated up.
+
+#High pressure boiler tank
+#name
+multiblock.goals.quest16.name=High pressure boiler tank
+#description
+multiblock.goals.quest16.desc=After you make steel you are able to craft a high pressure boiler tank. The upgraded version increases the temperature and produces more steam than the low pressure version.
+
+#Steam is never enough
+#name
+multiblock.goals.quest17.name=Steam is never enough
+#description
+multiblock.goals.quest17.desc=Now you can make advanced circuits, which means it's time to build a large steel boiler. This boiler is one and a half times more efficient than a bronze one, and that means we need 5 more steam turbines. Don't forget to monitor the water level!
+
+#We need big toys
+#name
+multiblock.goals.quest18.name=We need big toys
+#description
+multiblock.goals.quest18.desc=All your little turbines take up too much space? Are you running out of water? It is time to solve these problems. This large turbine can help you produce a tremendous amount of energy. . It will also distill water for you, so you can use the same water again inside your large boiler.  Don't forget to make a rotor for the turbine. At the initial stage the most suitable materials for the rotor are: vanadium steel (it has a very high durability, but slowly produces energy), cobalt (good combination of durability and performance) and ultimet (has higher efficiency, durability and performance).
+
+#Better than Duct Tape
+#name
+multiblock.goals.quest19.name=Better than Duct Tape
+#description
+multiblock.goals.quest19.desc=A soldering iron tool to remove the burned out circuits message is better than duct tape.%nThe soldering iron requires one soldering material item and 10,000 EU. Valid soldering materials are fine wires, rods, and ingots made from either tin, lead, or soldering alloy. The soldering iron will consume the first such material it finds in the player's inventory.%n%nFor the other problems other tools are necessary.%n%nPossible problems                  Tool to fix%n"Pipe is loose."                        Wrench%n"Screws are missing."             Screwdriver%n"Something is stuck."               Soft mallet%n"Platings are dented."            Hammer%n"Circuitry burned out."          Soldering Iron%n"That doesn't belong there." Crowbar%n
+
+#EBF-Time
+#name
+multiblock.goals.quest20.name=EBF-Time
+#description
+multiblock.goals.quest20.desc=In order to get alumin(i)um ingots, you need an electric blast furnace. It's another very important step towards victory, so let's get started.%n%nGetting the heating coils might be a little tricky...%n%n(You need 2 LV hatches with 4A of 32V total, or 3 LV hatches with MOOOORE power if the multiblock is not fully repaired)%n%nA few recipes produce CO2/SO2 as fluid. You need to add an additional fluid hatch to the top layer of the EBF to collect it otherwise it gets auto voided. It depends on the muffler hatch how much fluid you can recover. Max muffler recovers = 78%.
+
+#2x steel
+#name
+multiblock.goals.quest21.name=2x steel
+#description
+multiblock.goals.quest21.desc=Steel production is so slow. If you got enough bricks and clay, build a second BBF. Build it attached to the first one, so they can share a wall an you will save some bricks, clay and concrete.
+
+#4x steel
+#name
+multiblock.goals.quest22.name=4x steel
+#description
+multiblock.goals.quest22.desc=Not even two BBFs are fast enough...
+
+#An unexpected Bonus
+#name
+multiblock.goals.quest23.name=An unexpected Bonus
+#description
+multiblock.goals.quest23.desc=Because we're nice developers, we decided to add a little bonus if you happen to compress charcoal. Not only does it allow you to process more than 16 steel at a time (not in the bricked blast furnace), it also yields 10 times the burn time of a piece of charcoal. So one charcoal for free. This bonus only occurs on the first compression step. (But for fanciness, you should definitely get a quintuple one!)
+
+#Smelt all the things stack wise...
+#name
+multiblock.goals.quest24.name=Smelt all the things stack wise...
+#description
+multiblock.goals.quest24.desc=...with this great invention! Uses power to smelt up to 2 stacks of items at once! Can't go any faster!%n%nHint: Parallel smelting depends on coils, consult your local doctor before use.
+
+#Time to drill! 
+#name
+multiblock.goals.quest25.name=Time to drill! 
+#description
+multiblock.goals.quest25.desc=Pumps are nice but you're going to reach a point where you will want MOOOOOOOOOOOOORE oil. This multiblock will help with that but you will need to search for oil using a seismic prospector. You can find raw, light and heavy oil. There's also a chance to find natural gas.%n%nHigher tiers of power will drill faster. You need to upgrade the energy hatch coresponding to the power tier. 
+
+#Moooooore steam
+#name
+multiblock.goals.quest26.name=Moooooore steam
+#description
+multiblock.goals.quest26.desc=Stock up on titanium, it will be fun. A large titanium boiler produces 1600 litres of steam per tick. For this amount you need to choose the right rotors for your turbines. For example, 2 normal cobalt rotors will be just right. Optimal flow for such rotor is 800 liters per tick. If you have more than one boiler, you will need to make calculations in order to select the appropriate rotors.
+
+#Less Power loss
+#name
+multiblock.goals.quest27.name=Less Power loss
+#description
+multiblock.goals.quest27.desc=When you reach MV tier you can make your own duct tape in case you have to move your multiblock machines around. Duct tape will fix all maintenance problems in any multiblock machine.
+
+#EBF Infos
+#name
+multiblock.goals.quest28.name=EBF Infos
+#description
+multiblock.goals.quest28.desc=You can use a scanner to manually check how your EBF works, or you can make an informations panel from nuclear control and always see the status. Make a GT sensor kit and place the sensor card in your info panel. Enable it with a redstone signal.
+
+#Compress all the things
+#name
+multiblock.goals.quest29.name=Compress all the things
+#description
+multiblock.goals.quest29.desc=Martin's (DreamMasterXXL) favourite machine. Compress ALL the things! With explosives, of course.
+
+#Compress all the things
+#name
+multiblock.goals.quest30.name=You smell like a distillery!
+#description
+multiblock.goals.quest30.desc=This bad boy will tremendously boost the by-products of your cracked fuel by multiplying them by 5. This way you can make industrial TNT, polyethylene, polytetrafluoroethylene and other plastics more efficiently.%n%nYou will also need this for your automated setups.
+
+#Even more steam? Are you sure?
+#name
+multiblock.goals.quest31.name=Even more steam? Are you sure?
+#description
+multiblock.goals.quest31.desc=This boiler is the most efficient source of steam. It allows you to produce as much as 2000 litres of steam per tick. If you need more, then build a dual or even quad boiler.
+
+#Still not enough charcoal?
+#name
+multiblock.goals.quest32.name=Still not enough charcoal?
+#description
+multiblock.goals.quest32.desc=This oven is the best way to get charcoal and creosote (x50 faster than Railcraft's coke oven) and other byproducts. You will need tons of bronze, iron and steel to build it, but it's worth it. Finally, it will be possible to dismantle the charcoal pit.%nWith Cupronickel coils the oven is a bit slowlier. Each coil tier speed up the charcoal production.
+
+#Glyceryl trini...... what?
+#name
+multiblock.goals.quest33.name=Glyceryl trini...... what?
+#description
+multiblock.goals.quest33.desc=Kids, today we will make some glyceryl trinitrate with some glycerol.%n%n    - Chemistry 101
+
+#Powderbarrels
+#name
+multiblock.goals.quest34.name=Powderbarrels
+#description
+multiblock.goals.quest34.desc=Powderbarrels are twice as good as dynamite in the implosion compressor. Craft one stack.
+
+#TNT
+#name
+multiblock.goals.quest35.name=TNT
+#description
+multiblock.goals.quest35.desc=TNT is much more powerful than the powderbarrel but much harder to craft. There are LV and HV ways to craft. At LV you need heavy or light fuel to make some toluene wich can be solidified to gelled toluene. Alternatively you can use sugar and plastic dust in a chemical reactor to make toluene more efficient. Mix it with sulfuric acid to make TNT.%n%nThe HV way requires an oil cracking unit to make all kinds of cracked fuel or cracked naphta and a distillation tower to extract toluene from that.
+
+#Let's get it crackin!
+#name
+multiblock.goals.quest36.name=Let's get it crackin!
+#description
+multiblock.goals.quest36.desc=Cracking oil will result in better by-products in the distillation tower. It is a smart idea to get this multiblock since you are going to need TONS of industrial TNT for advanced tier rockets.%n%nIf you add steam the amout of EU/t will be reduced by 50% and if you add hydrogen the output will be increased by 30%
+
+#High speed charcoal
+#name
+multiblock.goals.quest37.name=High speed charcoal
+#description
+multiblock.goals.quest37.desc=Sure, those coke ovens are nice, but they aren't even remotely fast enough to keep up with a large steam boiler. Luckily, there is an upgrade available! The creosote oil will not be produced, but the process will speed up dramatically. Who needs that nasty yellowish flammable stuff anyway...
+
+#Upgrade #1: More heat
+#name
+multiblock.goals.quest38.name=Upgrade #1: More heat
+#description
+multiblock.goals.quest38.desc=Better materials need higher temperatures. You can just exchange the old coils with the new ones. You can even recycle the old coils, how fancy is that!
+
+#At the end of...
+#name
+multiblock.goals.quest39.name=At the end of...
+#description
+multiblock.goals.quest39.desc=...the universe everything freezes eventually. But waiting for the heat death of the universe might take too long. Therefore we present you the vacuum freezer. It should be good enough to cool your hot stuff. You will need a minimum of 16 frost proof machine casings, the rest depends on your setup.
+
+#Dynamite
+#name
+multiblock.goals.quest40.name=Dynamite
+#description
+multiblock.goals.quest40.desc=Dynamite is the most basic explosive you can use in the implosion compressor.%nMix some paper, string and glyceryl trinitrate in a chemical reactor to get dynamite.
+
+#iTNT
+#name
+multiblock.goals.quest41.name=iTNT
+#description
+multiblock.goals.quest41.desc=Industrial TNT is the HV variant of TNT. It explodes with more power, yet does not destroy blocks when it explodes.
+
+#Cleanroom
+#name
+multiblock.goals.quest42.name=Cleanroom
+#description
+multiblock.goals.quest42.desc=If you want to make more advanced circuits you need a cleanroom. The cleanroom is a multiblock between 3x4x3 and 15x15x15 (WxHxDx) blocks. Besides plascrete blocks you need a controller, filter casings on the top, an energy and maintenance hatch , a reinforced door and three machine hulls. For now you can use MV tier.%n%nLet's build a 5x5x5 room.
+
+#A very useful Scanner
+#name
+multiblock.goals.quest43.name=A very useful Scanner
+#description
+multiblock.goals.quest43.desc=The portable scanner is a tool capable of showing advanced information about almost every block in the game.%nIn order to function, the tool needs to be charged first. It can hold up to 400k EU and accept 128 EU/t or less. This is MV tier.%n%nIt can scan crops, which shows more information than the cropnalyzer does. The crop, which was scanned in the world, will drop a scanned seed bag.%nIt can scan machines from GregTech, giving information about current progress, the stored energy, efficiency, problems and CPU-load.%nFor any block in the game it scans, it gives information about its ID, Metadata, position in the world and hardness value.%nIt also gives information about pollution level in the chunk the scanned block belongs to.%nAdditional to that it shows when the clenroom has reached his 100% efficeny level.
+
+#Upgrade #2: Higher tier
+#name
+multiblock.goals.quest44.name=Upgrade #2: Higher tier
+#description
+multiblock.goals.quest44.desc=To reach the 3600k heat capacity of your EBF, so you can process high-tier materials like tungsten, you need nichrome heating coils.
+
+#Upgrade #3: Upgrade tier 4
+#name
+multiblock.goals.quest45.name=Upgrade #3: Upgrade tier 4
+#description
+multiblock.goals.quest45.desc=To process more advanced materials like enderium, enriched naquadah or niobium-titanium you need more than 3600K. Time to upgrade your EBF... again.
+
+#Upgrade #4: Upgrade tier 5
+#name
+multiblock.goals.quest46.name=Upgrade #4: Upgrade tier 5
+#description
+multiblock.goals.quest46.desc=To process more advanced materials like HSS-E, HSS-S, naquadah or draconium you need more than 4500K. Time to upgrade your EBF to 5400k.
+
+#Upgrade #6: Upgrade tier 7
+#name
+multiblock.goals.quest47.name=Upgrade #6: Upgrade tier 7
+#description
+multiblock.goals.quest47.desc=To process the most advanced materials like neutronium, fluxed-electrum or awakened draconium you need more than 7200K. Upgrade your EBF to 9001k. (OVER 9000!!!)
+
+#Upgrade #3: Upgrade tier 6
+#name
+multiblock.goals.quest48.name=Upgrade #3: Upgrade tier 6
+#description
+multiblock.goals.quest48.desc=To process more advanced materials like naquadah-alloy you need more than 5400K. Upgrade your EBF to 7200k to increase the heat.
+
+#########################
+#End Of Multiblock Goals#
+#########################
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/config/betterquesting/resources/gtnh/lang/ru_RU.lang
+++ b/config/betterquesting/resources/gtnh/lang/ru_RU.lang
@@ -1,0 +1,2301 @@
+betterquesting.title.quest_lines=§rЦепочка Заданий
+betterquesting.title.edit_line1=Edit Quest Lines
+betterquesting.title.edit_line2=Edit Quest Line - %s
+betterquesting.title.edit_quest=Edit Quest
+betterquesting.title.edit_tasks=Edit Tasks
+betterquesting.title.edit_rewards=Редактировать Награды
+betterquesting.title.edit_text=Редактировать Текст
+betterquesting.title.pre_requisites=Edit Pre-Requisites
+betterquesting.title.json_object=Object
+betterquesting.title.json_array=Список
+betterquesting.title.json_add=New Type
+betterquesting.title.select_item=Выбрать Предмет
+betterquesting.title.select_fluid=Выбрать Жидкость
+betterquesting.title.select_entity=Выбрать Существо
+betterquesting.title.party_none=Группа
+betterquesting.title.party=Управление Группой - %s
+betterquesting.title.party_invite=Пригласить Игроков
+betterquesting.title.select_theme=Выбрать Оформление
+betterquesting.title.importers=Importers
+betterquesting.title.submit_station=Submit Station
+
+betterquesting.btn.rewards=Награды
+betterquesting.btn.tasks=Задания
+betterquesting.btn.advanced=Advanced
+betterquesting.btn.is_main=Is Main
+betterquesting.btn.requirements=Требования
+betterquesting.btn.edit=Редактировать
+betterquesting.btn.new=Добавить Новый
+betterquesting.btn.import=Импорт
+betterquesting.btn.logic=Логика
+betterquesting.btn.show=Show
+betterquesting.btn.claim=Забрать
+betterquesting.btn.detect_submit=Подтвердить
+betterquesting.btn.add_remove_quests=Add/Remove Quests
+betterquesting.btn.designer=Designer
+betterquesting.btn.item=Предмет
+betterquesting.btn.list=Список
+betterquesting.btn.fluid=Жидкость
+betterquesting.btn.entity=Существо
+betterquesting.btn.text=Текст
+betterquesting.btn.number=Число
+betterquesting.btn.object=Объект
+betterquesting.btn.raw_nbt=Raw NBT
+betterquesting.btn.party_new=Создать Группу
+betterquesting.btn.party_leave=Покинуть
+betterquesting.btn.party_invite=Пригласить
+betterquesting.btn.party_kick=Выгнать
+betterquesting.btn.party_join=Присоединиться
+betterquesting.btn.party_share_lives=Общие Жизни
+betterquesting.btn.party_share_loot=Общие Награды
+
+betterquesting.home.exit=Выход
+betterquesting.home.quests=Задания
+betterquesting.home.party=Группа
+betterquesting.home.theme=Оформление
+
+betterquesting.gui.name=Название
+betterquesting.gui.description=Описание
+betterquesting.gui.quest_line=§rЦепочка Заданий
+betterquesting.gui.database=Database
+betterquesting.gui.selection=Ваш Выбор
+betterquesting.gui.search=Поиск
+betterquesting.gui.folder=Folder
+betterquesting.gui.party_invites=Приглашения
+betterquesting.gui.party_members=Участники
+betterquesting.gui.remaining_lives=Осталось Жизней: %s
+betterquesting.gui.full_lives=Максимальное Количество Жизней
+betterquesting.gui.closing_warning=Вы уверены, что хотите закрыть редактор?
+betterquesting.gui.closing_confirm=Изменения могут быть утеряны!
+
+betterquesting.tooltip.tasks_complete=%s/%s Заданий Выполнено
+betterquesting.tooltip.complete=ЗАВЕРШЁН
+betterquesting.tooltip.incomplete=НЕ ЗАВЕРШЁН
+betterquesting.tooltip.rewards_pending=ЗАБЕРИТЕ НАГРАДУ
+betterquesting.tooltip.requires=Требования:
+betterquesting.tooltip.shift_advanced=Hold SHIFT for advanced info
+betterquesting.tooltip.reset_time=Время Восстановления: %s
+betterquesting.tooltip.main_quest=Основное Задание: %s
+betterquesting.tooltip.global_quest=Global Quest: %s
+betterquesting.tooltip.global_share=Global Share: %s
+betterquesting.tooltip.task_logic=Логика Задания: %s
+betterquesting.tooltip.simultaneous=Simultaneos Tasks: %s
+betterquesting.tooltip.auto_claim=Auto Claim: %s
+betterquesting.tooltip.repeat=Время Восстановления: %s
+
+betterquesting.notice.complete=Задание Завершено
+betterquesting.notice.update=Задание Обновлено
+betterquesting.notice.unlock=Задание Разблокировано
+
+betterquesting.msg.heart_disabled=Хардкорные жизни не активированы. Используй "/bq_admin hardcore" чтобы активировать
+
+key.betterquesting.quests=Открыть Задания
+key.betterquesting.party=Управление Группой
+key.betterquesting.themes=Поменять Оформление
+
+itemGroup.betterquesting=Better Questing
+
+fluid.betterquesting.placeholder=Placeholder
+
+item.betterquesting.placeholder.name=Item Placeholder
+item.betterquesting.extra_life.full.name=Extra Life
+item.betterquesting.extra_life.half.name=Half Heart
+item.betterquesting.extra_life.quarter.name=Quarter Heart
+item.betterquesting.guide.name=Better Questing Starter Guide
+
+tile.betterquesting.submit_station.name=Object Submission Station (OSS)
+
+betterquesting.btn.help1=Navigation
+betterquesting.btn.help2=OSS Block
+betterquesting.btn.help3=Making Quests
+betterquesting.btn.help4=Commands
+betterquesting.btn.help5=Importing
+betterquesting.btn.help6=Themes
+betterquesting.btn.help7=Localization
+betterquesting.btn.help8=Resources
+
+betterquesting.help.page1=§l§nGeneral Navigation%n§r%nBetter Questing's main questing GUIs do not rely on an item or block that could be easily lost but instead through a single keybinding which can be found and changed through the controls menu.%n%nIn the Quest Lines screen you can select any of your active lines from the list and drag around the box to navigate to the quest of your choosing to begin completing tasks.%n%nQuesting parties can be created or edited via the Party Management screens. Here you can also toggle options for sharing hardcore lives or quest rewards.%n%nIf you'd like to change the look of your questing UIs you can choose from the currently installed themes in the Theme selection screen.
+betterquesting.help.page2=§l§nSubmission Station%n§r%nAlthough many of the questing tasks can be submitted directly through your inventory (including liquids) sometimes you need a more automated solution. This is where the Object Submission Station (OSS) comes in handy. Tasks supporting the OSS can be selected through the built in interface to enable its use. Once setup, liquids and items can be either piped in or dropped into the interface's input slot however it will not void items or liquids if no task is selected or if it has already been completed making it relatively safe from accidental item/fluid deletion. Multiple OSS are also capable of taking on separate sub-tasks under the same quest simultaneously!
+betterquesting.help.page3=§l§nMaking Quests%n§r%nTo begin making quests and quest lines you will first have to enable edit mode by running the edit command (See commands for more info). You will then be able to add or remove quest lines however you do not require one to begin making quests. This is especially handy if you'd like to make secret quests that unlock other quests or quest lines.%n%nThere are several menus you will need to become familiar with while editing. These will be a little overwhelming at first compared to most other mods but over time it will get easier. Some advanced editing screens will edit raw questing data so you'd want to be very careful what you change as it could have adverse side effects however this should never result in corruption or a crash. If either occurs than you should immediately report it to a developer.
+betterquesting.help.page4=§l§nCommands%n§r%nThere are only a handful of commands you need to know when working with Better Questing. They are separated into user commands that anyone can run and admin commands which are restricted to server operators.%n%n§o/bq_user refresh%n§r%nManually resyncs the local questing database with the server in case of potential desync issues.%n%n§o/bq_user help%n§r%nGives the player a copy of this guide%n%n§o/bq_admin edit%n§r%nToggles quest editing mode on and off. When enabled, operators will be able to access the editing menus for quests and quest lines. Remember to disable this before publishing packs or quests.%n%n§o/bq_admin hardcore%n§r%nToggles on and off the use of hardcore lives. When all lives have been depleted, players will be banned from the server or have their world deleted as per standard vanilla hardcore.%n%n§o/bq_admin reset [all|<quest_id>] [username|uuid]%n§r%nErases quest completion data for the given user. Handy to use before publishing packs.%n%n§o/bq_admin default [save|load]%n§r%nSaves/loads the current quest database to/from the global default directory. Setting defaults means any newly created worlds will start with that particular set of quests. Saving will also preserve completion data, hardcore state and edit mode so be sure to use the various other command as necessary before running this one.%n%n§o/bq_admin complete <quest_id> [username|uuid]%n§r%nForce completes a quest for the given user%n%n§o/bq_admin delete [all|<quest_id>]%n§r%nDeletes given quest(s) and progression data however it does not delete new world defaults.%n%n§o/bq_admin lives [add|set|max|default] <value> [username]%n§r%nThese commands change the amount of lives players have or the starting and max values.
+betterquesting.help.page5=§l§nImporting%n§r%nSome expansion packs may include importers for other questing mods or allow pack makers to download online quest lines. To access these importers you can click on the 'Import' button in the main quest line editor. By default Better Questing does not have any importers so if you require a specific importer you'll need to either find an expansion with one or make it yourself.
+betterquesting.help.page6=§l§nThemes%n§r%nIf you're someone who prefers a certain color pallet in their UIs or are just a pack maker wanting to give it that more authentic look and feel then themes are your best friend. Themes can change the look of the questing UIs to suit whatever your needs may be whether it be futuristic, magical or just classic Minecraft. They can be installed either through resource packs, resource directory or via expansions packs.
+betterquesting.help.page7=§l§nLocalization%n§r%nBetter Questing supports full localization of quest names and descriptions so that if you wanted to release your pack to users of all nationalities now you now can! In order to begin localizing your quests you'll need to use unique keys such as "§omypack.quest1.name§r" instead of plain text. You can then create a resource pack containing only .lang files for all the language specific translations. These files can alternatively be stored in Better Questing's resource directory for better bundling in packs
+betterquesting.help.page8=§l§nResources%n§r%nIf you want to customise the home screen, bundle themes or add localization files then you can do so through: %n%n"§o/config/betterquesting/resources/<pack_name>/§r"%n%nAny folders here can be treated as unlisted resource packs containing everything required to personalize your pack.
+
+betterquesting.design.tree=Tree Design
+
+betterquesting.toolbox.tab.main=Main
+
+betterquesting.toolbox.tool.open.name=Open
+betterquesting.toolbox.tool.open.desc=Opens a quest for futher editing
+betterquesting.toolbox.tool.grab.name=Grab
+betterquesting.toolbox.tool.grab.desc=Picks up and moves quests elsewhere in the quest line
+betterquesting.toolbox.tool.link.name=Link
+betterquesting.toolbox.tool.link.desc=Sets a quest as prerequisites for others. If a link is already present then it is removed
+betterquesting.toolbox.tool.snap.name=Grid Snap
+betterquesting.toolbox.tool.snap.desc=Changes the grid snap resolution for various other tools
+betterquesting.toolbox.tool.copy.name=Copy
+betterquesting.toolbox.tool.copy.desc=Copies the given quest including prerequisites, tasks and rewards but not progression data
+betterquesting.toolbox.tool.new.name=New Quest
+betterquesting.toolbox.tool.new.desc=Creates a new empty quest
+betterquesting.toolbox.tool.delete.name=Delete Quest
+betterquesting.toolbox.tool.delete.desc=Deletes the given quest from the quest line and database
+betterquesting.toolbox.tool.remove.name=Remove Quest
+betterquesting.toolbox.tool.remove.desc=Removes the given quest only from the quest line. The quest will still be accessible through the database
+betterquesting.toolbox.tool.complete.name=Manual Complete
+betterquesting.toolbox.tool.complete.desc=Forcibly completes the selected quest
+betterquesting.toolbox.tool.reset.name=Reset Quest
+betterquesting.toolbox.tool.reset.desc=Resets completion status and all task progress
+betterquesting.toolbox.tool.icon.name=Select Icon
+betterquesting.toolbox.tool.icon.desc=Changes the quest's icon
+
+betterquesting.cmd.complete=Completed quest %s for %s
+betterquesting.cmd.default.save=Quest database saved as default
+betterquesting.cmd.default.load=Reloaded default quest database
+betterquesting.cmd.default.none=No default currently set
+betterquesting.cmd.delete.single=Deleted quest %s
+betterquesting.cmd.delete.all=Deleted all quests
+betterquesting.cmd.edit=Edit mode %s
+betterquesting.cmd.hardcore=Hardcore mode %s
+
+betterquesting.cmd.lives.add_player=Added %s lives to %s (Total: %s)
+betterquesting.cmd.lives.add_all=Added %s lives to all players
+betterquesting.cmd.lives.remove_player=Removed %s lives from %s (Total: %s)
+betterquesting.cmd.lives.remove_all=Removed %s lives from all players
+betterquesting.cmd.lives.set_player=Set %s's lives to %s
+betterquesting.cmd.lives.set_all=Set all player's lives to %s
+betterquesting.cmd.lives.max=Set max lives to %s
+betterquesting.cmd.lives.default=Set default lives to %s
+
+betterquesting.cmd.reset.player_single=Reset quest '%s' for %s
+betterquesting.cmd.reset.player_all=Reset all quests for %s
+betterquesting.cmd.reset.all_single=Reset quest '%s' for everyone
+betterquesting.cmd.reset.all_all=Reset all quests for everyone
+betterquesting.cmd.refresh=Refreshing local database...
+
+####################
+#Quest Localisation#
+####################
+
+########
+#Tier 0#
+########
+
+#Tier 0 - It begins
+#name
+tier0.name=Тир 0 - Самое Начало
+#description
+tier0.desc=Самый первый тир, нулевой. Эта глава проведет тебя по простым механикам этой сборки. Затронутые моды: Vanilla, Pam's Harvestcraft.
+
+########
+#Quests#
+########
+
+#Your first night
+#name
+tier0.quest1.name=§rТвоя первая ночь
+#description
+tier0.quest1.desc=Перво-наперво тебе следует найти еду и убежище на ночь. Местные ночи жестоки, поскольку в этой сборке присутствует хардкорная темнота. А теперь ступай, набери еды...%n%n§aОт переводчика:%nЗдравствуй! Меня зовут Баш, и я являюсь русским локализатором данной сборки.%nПеревод может содержать ошибки.%nТы можешь помочь автору переводов, указав на эти ошибки.%nСообщать об ошибке следует здесь:  https://discord.gg/aGymCPY %n%nЯ также выкладываю свои похождения в данной сборке.%nПлейлист с прохождением: https://goo.gl/AQXS1R %n%nМой Вк: https://vk.com/id353009539 %nМой Твитч: https://www.twitch.tv/bashduude
+
+#Sticks 'n Stones
+#name
+tier0.quest2.name=§rПалки да Камни
+#description
+tier0.quest2.desc=Эта книжка имеет встроенный светильник, вот везунчик! Наверняка ты читаешь этот текст, пока простаиваешь ночь. С рассветом ступай собери немного гравия и дерева. И не забывай, что тебе нужна еда. Так что поглядывай на сады из Pam's Harvestcraft.(Сохрани некоторые овощи для семян!)
+
+#Where is the flint?
+#name
+tier0.quest3.name=§rГде же кремень?
+#description
+tier0.quest3.desc=Скорее всего, собирая гравий, ты обратил внимание, что тебе не выпало ни единого кремня. Дело в том что... для него есть рецепт. Поищи кремень в NEI и скрафти немного!
+
+#Crafting time
+#name
+tier0.quest4.name=§rВремя крафта
+#description
+tier0.quest4.desc=Самое время собрать 3х3 крафтинг зону. Используя кремень и дерево скрафти верстак!
+
+#Main Quests and Secondary Quests
+#name
+tier0.quest5.name=§rОсновные и Второстепенные Задания
+#description
+tier0.quest5.desc=Теперь, когда ты забрался так далеко, обрати внимание на два новых задания. Видишь разницу? Задание с резкой кромкой это основное задание, и оно ведет к другим основным заданиям толстой линией. Чтобы разблокировать следующий тир заданий, тебе следует завершать основные задания. Другое задание - опциональное, и не требуется для разблокировки следующих тиров. Несмотря на это, опциональные задания частенько дают тебе представление о полезных предметах или процессах.%n%nНе все основные задания соединены линией из-за количества квестов в этой книжке. Если нет очивидной толстой линии от основного квеста к основному - попробуй завершить другие основные задания, доступные тебе.
+
+#Storage for days
+#name
+tier0.quest6.name=§rВместительное хранилище
+#description
+tier0.quest6.desc=Разблокировав 3х3 крафтинг зону, самое время позаботиться о хранении твоего добра. Возьми немного дерева и скрафти сундук. Тебе понадобиться 4 дерева, 4 доски и 1 кремень.
+
+#Bamboo fence
+#name
+tier0.quest7.name=§rБамбуковый забор
+#description
+tier0.quest7.desc=Возможно тебе повезло начать в бамбуковом лесу.%nБамбук - очень полезное дерево, посколько оно растет очень быстро. Установленные бамбуковые палки вырастают в забор, высотой в 3 блока, который будет служить неплохой защитой для твоей базы.%nАльтернативой могут служить ягодные кусты.
+
+#Tools
+#name
+tier0.quest8.name=§rИнструменты
+#description
+tier0.quest8.desc=Теперь, когда у тебя есть укрытие, верстак и хранилище предметов, тебе следует собрать инструменты.(Если ты, конечно, не хочешь продолжать толкать деревья голыми руками...)
+
+
+#You reap...
+#name
+tier0.quest9.name=§rЧто посеешь...
+#description
+tier0.quest9.desc=Ты не всегда будешь получать съедобные награды из этой книги, так что, возможно, следует позаботиться об этой проблеме. Поскольку, ты уже скрафтил мотыгу, ступай найди воду и возделай поле. Совершим обмен: я тебе морковь, а ты мне палки. Так ты сможешь начать свой огород.
+
+#Collecting some berries
+#name
+tier0.quest10.name=§rСобирая ягоды
+#description
+tier0.quest10.desc=Ждешь пока твои морковки взойдут? Ступай собери ягод да ягодных кустов. Ягоды - хороший источник продовольствия, а кусты ты можешь посадить вокруг своего дома, чтобы возвести стену. Она будет снабжать тебя и едой, и защитой против всех монстров, что захотят посетить твой дом и убить тебя.
+
+#Berry medley
+#name
+tier0.quest11.name=§rЯгодная смесь
+#description
+tier0.quest11.desc=Хммм... что бы тебе сделать со всеми этими ягодами? Просто схавать? Ими сильно не насытишься. Давай посадим новых кустов и смешаем ягоды, чтобы получить более насыщенное блюдо.
+
+#Oak trees are not apple trees
+#name
+tier0.quest12.name=§rДубовые деревья - это не яблони
+#description
+tier0.quest12.desc=Дуб, который дает яблоки? Кто чёрт возьми добавил это в minecraft? Найди способ соеденить дубовый саженец с яблоком, чтобы получить саженец яблочного дерева. Посади его, он станет еще одним безлимитным источником продовольствия.
+
+#Monster trap
+#name
+tier0.quest13.name=§rЛовушка для монстров
+#description
+tier0.quest13.desc=Если ты везунчик, то ты появился в биоме пустыни или дождливого леса и уже наткнулся на некоторые залежи зыбучего песка. Собери стак этого песка, вырой небольшую яму и засыпь ее им. Это защитит твое грязевое поместье.
+
+#Get that stone
+#name
+tier0.quest14.name=§rДобудь булыжника
+#description
+tier0.quest14.desc=Взгляни на себя с этой блестящей кремниевой киркой! Время добыть немного булыжника. Юху!(Заодно сможешь улучшить это грязевое нечто...)
+
+#Can you hear the carrots grow?
+#name
+tier0.quest15.name=§rСлышишь? Морковки растут.
+#description
+tier0.quest15.desc=Устал ждать, так как твои морковки растут цеееелую вечность...?%nУ меня есть идея. Костная мука позволит вырастить еду за считанные секунды. Ступай, наруби немного дерева, и я обменяю тебе немного костной муки.
+
+#Your first long range weapon
+#name
+tier0.quest16.name=§rТвоё первое оружие дальнего боя
+#description
+tier0.quest16.desc=Поскольку ты не сможешь сделать ванильный лук до LV тира и оружие из Tinkers тоже не в этом тире, ты находишь способ сделать копье из палок, кожи и нити. Скрафти его, потому что справиться с инфернал монстрами куда легче, находясь, как можно дальше от них.
+
+#Sharpness: Over... 5...
+#name
+tier0.quest17.name=§rОстрота: Свыше... 5...
+#description
+tier0.quest17.desc=Самое время скрафтить что-то более полезное: Меч!
+
+#Fire, fire, Grandpa!
+#name
+tier0.quest18.name=§rЖги, жги, Бабуля!
+#description
+tier0.quest18.desc=Самое время сжечь кое-что, не так ли? У тебя пока нет возможности сделать древесный уголь, но ты наверняка скоро найдешь ей применение.
+
+#"Backed" potatoes
+#name
+tier0.quest19.name=§r"Припечёная" картошка
+#description
+tier0.quest19.desc=Есть сырую картошку, не особо-то полезно, как ты мог убедиться. Некоторый картофель изначально зеленый и испорченный. Приобретя печку, ты сможешь готовить вкуснейшую печёную картошку, как альтернативу к уже имеющейся пище.
+
+#Food variants
+#name
+tier0.quest20.name=§rПродуктовое разнообразие
+#description
+tier0.quest20.desc=Наверное, ты обратил внимание, что поедание одной и той же еды слишком часто - это очень скучно и совсем не здорово. Некоторые продукты питания, такие как чайный лист, могут быть приготовлены в печке. Так что сделай перерыв и выпей чашечку чая. Можешь пожевать вкусного изюма, он ничего такой.
+
+#...what you sow
+#name
+tier0.quest21.name=§r...то и пожнёшь
+#description
+tier0.quest21.desc=Если ты прочел предыдущий квест и посадил морковки, что я дал тебе, значит ты в порядке. Между тем, тебе следует посадить больше фруктов и овощей, и увеличить границы своего огорода для стабильного получения продуктов питания.
+
+#Shield update
+#name
+tier0.quest22.name=§rПатч для щита
+#description
+tier0.quest22.desc=Твой деревянный щит никуда не годится. Тебе следует улучшить его. Похоже тебе понадобится кожа, ступай найди коров.
+
+#Shields UP
+#name
+tier0.quest23.name=§rПоднять Щиты
+#description
+tier0.quest23.desc=Держа меч в одной руке, куда деть вторую? Верно, тебе нужен щит. Скрафти его.
+
+#Soft mallet adventure
+#name
+tier0.quest24.name=§rПриключения мягкого молота
+#description
+tier0.quest24.desc=Что тебе делать с тыквами или арбузными дольками? Ну, ты можешь просто съесть их или... использовать молот и получить семена... Давай скрафтим его. Возможно он тебе еще в чем-нибудь пригодится.
+
+#Rest in pieces
+#name
+tier0.quest25.name=§rПокойся кусочками
+#description
+tier0.quest25.desc=Время пришло! Ступай заруби пару свиней, и нарежь мяса.(И да, они будут дропать приготовленную свинину. Разве это не полезно...)
+
+#Fluffy and red
+#name
+tier0.quest26.name=§rМягкая и красная
+#description
+tier0.quest26.desc=Эпическое задание: Убей овец! (А еще попробуй достать шерсти, на кровать, очевидно...)
+
+#What is that...?
+#name
+tier0.quest27.name=§rЭто что ещё за...?
+#description
+tier0.quest27.desc=Ты повидал достаточно деревьев, но некоторые из них выглядят действительно особенно. Ты уверен, что эти деревья не просто строительный материал или средство получения древесного угля.
+
+#SO...TIRED...MUST...SLEEP...
+#name
+tier0.quest28.name=§rТАК...УСТАЛ...ДОЛЖЕН...ОТДОХНУТЬ...
+#description
+tier0.quest28.desc=Время отдохнуть и закончить тир 0. Прими мои поздравления, ты построил свое первое убежище и уже должен иметь стабильный источник питания. Увидимся в 1 тире!
+
+###############
+#End Of Tier 0#
+###############
+
+
+##########
+#Tier 0.5#
+##########
+
+#Tier 0.5 - Stone Age
+#name
+tier0.5.name=Тир 0.5 - Каменная Эпоха
+#description
+tier0.5.desc=По сути - это "Тир 0" твоего развития. Этот раздел проведёт тебя до твоего первого парового механизма.
+
+########
+#Quests#
+########
+
+#Even More Compact Storage
+#name
+tier0.5.quest1.name=§rЕщё Более Компактное Хранение
+#description
+tier0.5.quest1.desc=Если ты добыл достаточное количество золота, ты можешь улучшить свои сундуки в золото, с внутренним хранилищем 9х9 слотов. Ты можешь скрафтить золотой сундук с нуля или улучшить текущий железный, используя "улучшение из железного в золотой сундук".
+
+#GT 6 styled Pipes
+#name
+tier0.5.quest2.name=§rМеханика Труб из GT 6
+#description
+tier0.5.quest2.desc=Наверное, ты гадаешь, почему новые трубы больше не присоединяются сами по себе? Так трубы стали "умнее". Теперь ты можешь присоединять только те трубы, которые ты хочешь, используя ключ. Тебе больше не нужны заплатки или фольга, чтобы недопустить соединение труб. Shift + Клик на конце трубы - отключит вход жидкости с этой стороны. Это очень полезно, например, чтобы не допустить утечку пара из угольных бойлеров в трубы с водой.%n%nСовет: если ты кликнешь одной трубой по другой трубе - они авто-присоединятся. 
+
+#Looting II
+#name
+tier0.5.quest3.name=§rДобыча II
+#description
+tier0.5.quest3.desc=Нож мясника из грега имеет добычу 2. Ступай собери ништяков во время твоего ночного мобо-руба.
+
+#More Compact Storage
+#name
+tier0.5.quest4.name=§rБолее Компактное Хранение
+#description
+tier0.5.quest4.desc=Собирая всё больше и больше железа, ты осознаешь, что твои сундуки не резиновые. Самое время улучшить их в железные сундуки. Ты можешь скрафтить железный сундук с нуля или улучшить текущий деревянный, используя "улучшение из деревянного в железный сундук".
+
+#Chad a better way to make Paper
+#name
+tier0.5.quest5.name=§rСахарный тростник - более выгодный способ изготовления Бумаги
+#description
+tier0.5.quest5.desc=Изготавливать бумагу из опилок и воды весьма нудно и трудоемко. Почему бы тебе не использовать сахарный тростник? Его можно подробить на маленькие кусочки и сжать между двумя каменными плитами, для производства бумаги. Позже ты сможешь использовать химическую ванну и получать бумагу с ещё более выгодным соотношением.
+
+#You shall proceed
+#name
+tier0.5.quest6.name=§rИдём дальше?
+#description
+tier0.5.quest6.desc=Поскольку ты собрал и скрафтил все материалы и интрументы, которые тебе понадобятся для простых паровых механизмов, - ты можешь перейти на следующий тир. Не забывай, что тебе понадобятся целые горы ресурсов, чтобы скрафтить даже самые простые вещи. Я бы рекомедовал тебе набить свои сундуки рудами из этого тира.Но решение, конечно, же за тобой.
+
+#Making bronze
+#name
+tier0.5.quest7.name=§rПроизводство бронзы
+#description
+tier0.5.quest7.desc=Из меди и олова, что ты нашел, тебе следует сделать бронзы. Используй свой изме... ступу, чтобы перемолоть медные и оловянные слитки и смешать их в однородную смесь.
+
+#Animal farms
+#name
+tier0.5.quest8.name=§rСарай для животных
+#description
+tier0.5.quest8.desc=Пытаешься добыть кожи или шерсти? Возможно ты тратишь кучу времени, бегая по местности, охотясь на животных. Почему бы тебе не разводить своих животных в сарае и получать с них достаточное количество кожи, шерсти и мяса?
+
+#Sheep hairdresser
+#name
+tier0.5.quest9.name=§rОвечья парикмахерская
+#description
+tier0.5.quest9.desc=Получать шерсть, убивая овец, весьма неэффективно. Крафт ножниц стал бы весьма разумным решением, если у тебя есть потребность в шерсти.
+
+#Important tools
+#name
+tier0.5.quest10.name=§rВажные инструменты
+#description
+tier0.5.quest10.desc=Чтобы соорудить даже самые простые механизмы - тебе нужны подходящие инструменты. Позже большинство из этих инструментов будут заменены механизмами. А пока, тебе следует ознакомиться с рецептом каждых из них, поскольку они будут расходоваться весьма активно, начиная прямо сейчас.%n%nТвои новые интрументы также можно использовать для изготовления жидкостных резервуаров из Railcraft, весьма полезных мульти-блок структур, учитывая не бесконечность воды.
+
+#Tanned leather
+#name
+tier0.5.quest11.name=§rДублёная кожа
+#description
+tier0.5.quest11.desc=Ты нашёл способ изготавливать более прочную кожу. Изготовь вязанной кожи из четырёх кусков кожи, некоторого количества ниток и тканного хлопка. Повесь её на доске для высушивания. Спустя 10 минут на доске будет готовая дублёная кожа.
+
+#Need more space?
+#name
+tier0.5.quest12.name=§rНужно больше места?
+#description
+tier0.5.quest12.desc=Наверняка ты в курсе: дублёная кожа куда более прочная и отлично сгодится для рюкзака. Скрафти рюкзаки землекопа и шахтёра. Каждый хранит разные предметы. Ступай, используй оба в своём первом упакованном шахтёрском походе.
+
+#You need them all!
+#name
+tier0.5.quest13.name=§rСобери коллекцию!
+#description
+tier0.5.quest13.desc=В сборке есть и другие рюкзаки, например: Охотника, строителя, лесника...
+
+#Basic processing
+#name
+tier0.5.quest14.name=§rПростая обработка
+#description
+tier0.5.quest14.desc=Большинство процессов недоступно на данный момент, так что давай начнем с чего-нибудь попроще. Обжарь булыжник в камень. И, поскольку, эта сборка сущий кошмар, тебе придется использовать дерево в качестве топлива. Весело, не так ли?!
+
+#Ready, set, go!
+#name
+tier0.5.quest15.name=§rНа старт, внимание, марш!
+#description
+tier0.5.quest15.desc=К этому времени у тебя уже должен быть дом. Стабильный источник продовольствия - это фундаментальное требование всех времен. В этом тире придется побегать, так что возьми этот мешочек для ланча, он поможет хранить некоторые твои продукты.
+
+#Gardener
+#name
+tier0.5.quest16.name=§rСадовник
+#description
+tier0.5.quest16.desc=На случай если ты гадаешь: Почему я ни разу не получил семена, сшибая траву? В этой сборке это немного иначе. Попробуй возделать землю, которая находится подальше от источника воды, своей новой мотыгой, чтобы получить семена.
+
+#Better storage
+#name
+tier0.5.quest17.name=§rПодходящее хранение
+#description
+tier0.5.quest17.desc=Обычные сундуки отлично справляются с хранением разнообразных предметов, однако они совсем не идеальны для хранения больших запасов руды. Тебе следует соорудить пару бочек для более удобного хранения руды.
+
+#Sleeping outside
+#name
+tier0.5.quest18.name=§rСон снаружи
+#description
+tier0.5.quest18.desc=Постоянно таскать по всюду свою кровать выглядит весьма забавно. Почему бы тебе не скрафтить спальный мешок, чтобы спать снаружи без необходимости установки кровати и постоянной смены точки спавна. Предупреждаю: Если ты играешь на сервере, лучше бы тебе спать ниже Y128, в горах ночью бывает прохладно...
+
+#Fallen from the sky
+#name
+tier0.5.quest19.name=§rУпавшие с небес
+#description
+tier0.5.quest19.desc=Повсюду валяются большие метеориты, и ты гадаешь на кой тебе нужно их выкапывать?%nНебесный камень - это хороший источник металлов редкой земли в эпохе низкого напряжения.%nВ самом метеоре ты можешь обнаружить сундук, содержащий некоторые прессы обработки. Сохрани их на потом, они действительно полезные.
+
+#Maceration v0.1 Alpha
+#name
+tier0.5.quest20.name=§rИзмельчение v0.1 Альфа
+#description
+tier0.5.quest20.desc=Это забавное небольшое устройство работает(почти...) как измельчитель. Некоторые скажут - да он даже лучше, поскольку не требует никакой энергии, юху! На задание нужно скрафтить только один такой, но тебе возможно нужно сделать их с запасом, если позволяют ресурсы...
+
+#Clay: The Gathering
+#name
+tier0.5.quest21.name=§rГлина: Добыча
+#description
+tier0.5.quest21.desc=В скучные моменты, ты подумываешь, что было бы здорово заняться керамикой. Ступай собери глины. В реках должно быть некоторое количество.
+
+#Gravel: The Gathering
+#name
+tier0.5.quest22.name=§rГравий: Добыча
+#description
+tier0.5.quest22.desc=Со временем твои инструменты теряют прочность. Возможно было бы неплохо собрать гравия, чтобы пополнить свои запасы кремня, для изготовления новых.
+
+#Sand: The Gathering
+#name
+tier0.5.quest23.name=§rПесок: Добыча
+#description
+tier0.5.quest23.desc=В странном видении ты видел огромный мульти-блок, который бы позволял тебе производить древесный уголь. Наконец-то факела! По твоим расчётам, тебе понадобиться куча песка.
+
+#Better lunch bag
+#name
+tier0.5.quest24.name=§rУлучшенный мешочек для ланча
+#description
+tier0.5.quest24.desc=Твой мешочек для ланча исчерпал себя, да и весьма устарел. Самое время получить что-то лучшее. Скрафти коробку для ланча, которая сможет держать куда больше продуктов.
+
+#Iron shields
+#name
+tier0.5.quest25.name=§rЖелезные щиты
+#description
+tier0.5.quest25.desc=Ты весьма дольго использовал свой кожанный щит. После производства первых инструментов, возьми немного железной руды и скрафти отличный железный щит.
+
+#Stone spear
+#name
+tier0.5.quest26.name=§rКаменное копьё
+#description
+tier0.5.quest26.desc=Улучши свое деревянное копьё каменным наконечником и парой железных болтов. Такое копье имеет большую прочность.
+
+#XP usage?!
+#name
+tier0.5.quest27.name=§rПрименение Опыту?!
+#description
+tier0.5.quest27.desc=Исследуя подземелья или сражаясь с мобами, ты наверняка получил кучу опыта. Используй его, чтобы получить железную, медную, оловянную или любую другую полезную пыль, прежду чем ты потеряешь весь опыт от следующей неудачной битвы.%nРасположи резервуар на земле и поставь сверху всасыватель опыта. Теперь ты можешь заполнить его опытом.
+
+#Making a better sword
+#name
+tier0.5.quest28.name=§rИзготовление лучшего меча
+#description
+tier0.5.quest28.desc=Самое время соорудить твой первый Tinkers меч. Сначала изготавливаешь формы для острия, защиты для рук и рукояти. Расплавь некоторое количество бронзы в плавильне и отлей новые детали. Тадааам... вот и твой первый tinkers меч.
+
+#Don't burn your fingers!
+#name
+tier0.5.quest29.name=§rОсторожно, пальцы!
+#description
+tier0.5.quest29.desc=Ты решил, что самое время приготовить вкусненькой пиццы, в процессе ты серьезно обжог свои пальцы. Читая древнюю поварскую книгу, ты наткнулся на пару магических предметов, что позволили бы тебе переносить что-то горячее, даже раскалённую лаву в ведре.%n%nПерчатки следует расположить в слоты для колец из Thaumcraft.
+
+#Something to carry liquids
+#name
+tier0.5.quest30.name=§rЧто-то для переноса жидкости
+#description
+tier0.5.quest30.desc=Ты хотел перенести воды в ладонях, но похоже, это совсем не сработало. Повезло, что ты помнишь как делать ведро из глины.
+
+#Finite water!?
+#name
+tier0.5.quest31.name=§rНе бесконечная вода!?
+#description
+tier0.5.quest31.desc=Даа...не бесконечная вода это проблема. Прошлой ночью тебя посетила идея. Раз ты можешь пить кактусовый сок, значит ты способен сконцетрировать воду из 8 штук, и использовать ее для большинства рецептов, что требуют воду. Клёво, не так ли? Так что насчёт очередного обмена? 10 дерева за... 3 кактуса, чтобы ты смог наладить ферму. Договорились?
+
+#Another brick in the wall
+#name
+tier0.5.quest32.name=§rЕще один кирпичик в стену
+#description
+tier0.5.quest32.desc=Твой разум становится более ясным, тебе нужны кирпичи для твоей первой мульти-блок структуры. Ты думаешь, что порядка 104 кирпичей должно быть достаточно. Правда, кирпичи, что тебе нужны, - в некотором смысле особенные. Убедись, что крафтишь те, что надо!
+
+#Getting (char)coal
+#name
+tier0.5.quest33.name=§rПолучая уголь
+#description
+tier0.5.quest33.desc=Самое время запасись древесным углём. Для этого, мы построим коксовую печь. Здорово, что ты собрал кучу ресурсов!(Вот ведь совпадение...)
+
+#You need MOOOOOOORE wood
+#name
+tier0.5.quest34.name=§rНужно БООООООЛЬШЕ дерева
+#description
+tier0.5.quest34.desc=Самое время заполнить твою новенькую коксовую печь деревом, чтобы получить древесного угля. Ты гадаешь над самым эффективным способом посадки деревьев. Попробуй найти немного еловых и тропических саженцев. Оба могут быть посажены в 2х2 сетке для выращивания огромных деревьев.
+
+#Compact Drawers
+#name
+tier0.5.quest35.name=§rВместительные ящики
+#description
+tier0.5.quest35.desc=Они очень вместительные и добавляют красоту в твою восхитительную базу из грязи.
+
+#Better than barrels
+#name
+tier0.5.quest36.name=§rЛучше чем бочки
+#description
+tier0.5.quest36.desc=В то время как бочки предоставляют только одну ячейку для хранения, ящики могут вмещать вплоть до четырех ячеек каждый, 16 стаков в ячейке. Также они могут быть использованы для создания "подпольной МЕ системы хранения (Tec2k17)%nпозже в эпохе высокого напряжения с некоторой помощью ProjectRed Transportation.
+
+#Bronze javelin
+#name
+tier0.5.quest37.name=§rБронзовое копье
+#description
+tier0.5.quest37.desc=Бронзовое копье немного дороговато и имеет только 7 использований, однако это хорошее оружие средней дистанции. Затратив один слиток бронзы, ты сможешь восстановить все использования своего копья.
+
+#Making better tools
+#name
+tier0.5.quest38.name=§rИзготавливая лучшие инструменты
+#description
+tier0.5.quest38.desc=Из алюминия и меди ты можешь создать алюминиевую латунь и использовать ее как форму в плавильне.%n%nНо сначала тебе понадобиться сама плавильня. Загляни в главу "мульти-блок цели" в этой книжке, или укради плавильню в ближайшей деревне.
+
+#Punji Sticks
+#name
+tier0.5.quest39.name=§rПалочки панджи
+#description
+tier0.5.quest39.desc=Защитой начального уровня могут послужить палочки панджи. Они наносят урон и игрокам, и монстрам, а так же имеют свойство замедлять(зелье замедления 2). Сделай траншею вокруг своей базы и поставь туда палочки панджи.
+
+#Cotton, cotton and more cotton
+#name
+tier0.5.quest40.name=§rХлопок, хлопок и ещё хлопок
+#description
+tier0.5.quest40.desc=Оказывается, что хлопок очень полезен! С его помощью можно изготавливать нить, шерсть и другие полезные предметы. Посади небольшую хлопковую плантацию.
+
+#Book parts
+#name
+tier0.5.quest41.name=§rЧасти книжки
+#description
+tier0.5.quest41.desc=После обнаружения способа перемещать воду, у тебя появилась другая великолепная идея: Бумага! Бумага больше не делается из тростника, чтобы сделать ее - тебе нужны опилки. Тебе понадобиться целая куча опилок, так что хватай свой топор и вперед за работу.
+
+#Forming press v0.1
+#name
+tier0.5.quest42.name=§rФормировочный пресс v0.1
+#description
+tier0.5.quest42.desc=Как ты уже мог убедиться, ты не можешь напрямую получать кирпичи из глины. Если честно, этот рецепт изначально был так себе. Ты скорее всего получал бы кирпичи в форме хлеба. Так что для изготовления нормальных кирпичей, - тебе понадобиться форма. Скрафти себе нож и пустую схему. Затем вырежи из нее ножем кусок, похожий на кирпич. Вот так всё просто.
+
+#Creosote oil
+#name
+tier0.5.quest43.name=§rКреозотовое масло
+#description
+tier0.5.quest43.desc=Предположу, что ты уже получил некоторое количество древесного угля и гадаешь что же тебе делать с этим креозотовым маслом?%nНу... ты можешь использовать его в качестве топлива в обычной печке, чтобы готовить себе еду, или, например, делать факела. Позже в эпохе низкого напряжения ты сможешь запускать генераторы, работающие на этом масле.
+
+#Framing Drawers
+#name
+tier0.5.quest44.name=§rУкрашая Ящики
+#description
+tier0.5.quest44.desc=Теперь ты можешь делать действительно зачётные ящики, используя вот этот стол. Все что от тебя требуется - это добавить декоративных блоков(работает практически всё что угодно) и новый ящик позаимствует их текстуру. Верхний левый - это внешний квадрат. Нижний левый - это передняя часть ящика. Верхний правый - для окантовки.
+
+#Getting iron
+#name
+tier0.5.quest45.name=§rДобыча железа
+#description
+tier0.5.quest45.desc=Железно можно найти в куче разных жил. Магнетитовые жилы(y30-180), халькопиритовые жилы(y5-60), лимонитовые жилы(10-40) все они содержат железную руду.
+
+#Aluminini...um...?
+#name
+tier0.5.quest46.name=§rАлью...алюми..ниум?
+#description
+tier0.5.quest46.desc=Как бы ты его не произносил, он тебе нужен. Ты можешь найти его в кускай гравия на поверхности. Возможно стоит поискать в реках.(Это задание второстепенное, однако рекомендуемое.)
+
+#Copper
+#name
+tier0.5.quest47.name=§rМедь
+#description
+tier0.5.quest47.desc=Медные слитки могут быть выплавлены из медной, халькопиритовой или малахитовой руды.
+
+#Tin
+#name
+tier0.5.quest48.name=§rОлово
+#description
+tier0.5.quest48.desc=Оловянные слитки могут быть выплавлены из оловянной и касситеритовой руды.
+
+#Cow Tipper
+#name
+tier0.5.quest49.name=§rОпрокидыватель Коров
+#description
+tier0.5.quest49.desc=Тебе уже приходилось убивать свиней да овец, чтобы завершать задания. Теперь нужно убить коров, и желательно получить немного кожи. Если тебе повезет и ты получить коровий трофей, тебе, возможно, больше никогда не придется убивать коров.
+
+#Tinker-time
+#name
+tier0.5.quest50.name=§rTinker Время
+#description
+tier0.5.quest50.desc=Использовать кремниевые инструменты может быть весело, поджигая свиней да коров, однако они не особо то хороши, да и чинить их нельзя. Ты нашел способ крафтить инструменты, которые можно было бы чинить и улучшать, но для этого определенно нужна более продвинутая технология производства.
+
+#Your first bow
+#name
+tier0.5.quest51.name=§rТвой первый лук
+#description
+tier0.5.quest51.desc=Поскольку ванильные луки можно крафтить только в сборочной машине, а мобы не особо-то часто их роняют, - тебе придется сделать Tinkers лук. На данный момент дерево станет лучшим материалом. Так что скрафти конечности лука из дерева, а тетеву из ниток. Стрела, которая имеет наибольшую прочность - делается из кости. Скрафти палку из кости. Она гораздо легче чем обычная стрела, правда жертвует долговечностью. Используй кремниевый наконечник, чтобы её можно было чинить кремнем.%n%nТы можешь чинить свой лук точно так же, как ты чинишь любой другой Tinkers инструмент. Количество стрел можно вернуть, если починить их, или подобрать ранее выстрелленые стрелы.
+
+#Another fuel source
+#name
+tier0.5.quest52.name=§rОчередной источник топлива
+#description
+tier0.5.quest52.desc=Бурый и обычный уголь - источники топлива, которые тебе определенно пригодятся. Последний может быть преобразован в коксовый уголь, - он горит в два раза дольше обычного угля, и пригодится для пережарки твоей первой большой партии руды.
+
+#Upgrade 2.0
+#name
+tier0.5.quest53.name=§rUpgrade 2.0
+#description
+tier0.5.quest53.desc=Найди железную, медную и оловянную руды. Это смешно... Как ты можешь добывать их обыкновенной кремниевой киркой?%nУ меня есть идея. Принеси мне булыжника, что ты накопал своей киркой, я обменяю его на улучшенное оголовье кирки.
+
+#Your first tool
+#name
+tier0.5.quest54.name=§rТвой первый инструмент
+#description
+tier0.5.quest54.desc=Когда твои Tinkers столы будут готовы, ты сможешь собрать свой первый интрумент. Если ты еще не натыкался на деревню - ты можешь крафтить только кремниевые инструменты. Начнём с кирки, топора и лопаты. С этого момента мечи недосягаемы, посколько для их производства требуются металлы вроде железа или бронзы, которые ты определенно получишь, чуть позже. А пока, используй gregtech мечи. Твои новые инструменты не особо-то прочные по началу, но чем чаще ты ими пользуешься, тем лучше они становятся. Они будут улучшаться вплоть до 99 уровня, если ты, конечно, будет так долго играть. Части инструментов можно заменить ценой некоторого количества опыта, накопленного инструментом, а так же перед заменой инструмент должен быть в идеальном состоянии.
+
+#Your first flint throwing knife
+#name
+tier0.5.quest55.name=§rТвой первый кремниевый кидательный нож
+#description
+tier0.5.quest55.desc=Костяной лук слишком дорогой для тебя? Тогда сделай кремниевый кидательный ножик. Тебе понадобится кремень и палка, чтобы получить 12 ножей. Прочность и урон достаточно низки, но всё же лучше лупить мобов с безопасной дистанции.
+
+#Copper Ore
+#name
+tier0.5.quest56.name=§rМедная Руда
+#description
+tier0.5.quest56.desc=Её можно найти между y5 и y60 либо как "Медную руду", либо как "Халькопирит". Чаще всего ты встретишь ее вместе с "Железом" и "Пиритом".
+
+#Malachite
+#name
+tier0.5.quest57.name=§rМалахит
+#description
+tier0.5.quest57.desc=Очередной источник меди - это "малахит", его можно найти между y10 и y40. Данная жила содержит больше вариантов железных руд, вроде "коричневого лимонита", "жёлтого лимонита" и "полосчатое железо".
+
+#Iron Ore
+#name
+tier0.5.quest58.name=§rЖелезная Руда
+#description
+tier0.5.quest58.desc=Имея железные инструменты, ты способен добывать большинство overworld руд. Я думаю, что ты уже натыкался на железо или магнетит. Так что принеси мне немного руды, и выплавь некоторое количество железных слитков.
+
+#Copper sky, Iron curtain
+#name
+tier0.5.quest59.name=§rМедное небо, Железный занавес
+#description
+tier0.5.quest59.desc=С твоим свеже приобритенным топливом, ты теперь в состоянии обрабатывать более продвинутые материалы, чем камень или глина. Железо или медь, например. Вдруг ты не знал, - они появляются в огромных жилах. Используй данные задания, чтобы найти наиболее важные жилы.
+
+#Finally, some power
+#name
+tier0.5.quest60.name=§rНаконец-то, энергия
+#description
+tier0.5.quest60.desc=Имея коксовую печь тебе следует производить древесный уголь. Чем больше - тем лучше. Не думай о креозотовом масле, у меня есть еще одна сделка для тебя...
+
+#################
+#End Of Tier 0.5#
+#################
+
+
+########
+#Tier 1#
+########
+
+#Tier 1 - Steam
+#name
+tier1.name=Тир 1 - Пар
+#description
+tier1.desc=Цепочка заданий, основанная на паровых механизмах.
+
+########
+#Quests#
+########
+
+#Hoppers
+#name
+tier1.quest1.name=§rВоронка
+#description
+tier1.quest1.desc=Воронка может очень пригодиться при автоматизации твоих механизмов.%nТы можешь передавать предметы через воронку напрямую в трубы из GT, без необходимости использования конвеерной ленты.%nПри таком использовании предметы поступают в трубу гораздо медленее.
+
+#Upgrade: High speed alloys
+#name
+tier1.quest2.name=§rУлучшение: Скоростные сплавы
+#description
+tier1.quest2.desc=Как и для большинства механизмов, для сплавщика сплавов тоже есть улучшение. Улучшенные механизмы потребляют кучу пара, так что позаботься сперва о его получнии. (Данное задание опционально)
+
+#Upgrade: Better furnace
+#name
+tier1.quest3.name=§rУлучшение: Новая печка
+#description
+tier1.quest3.desc=Новая версия паровой печки. Потребляет кучу пара, однако работает почти в два раза быстрее. (Данное задание опционально)
+
+#Using steam to cook things
+#name
+tier1.quest4.name=§rГотовка на пару
+#description
+tier1.quest4.desc=Работает медленнее, зато куда эффективней обычной печки.
+
+#Welcome to Tier 1
+#name
+tier1.quest5.name=§rДобро Пожаловать в Тир 1
+#description
+tier1.quest5.desc=Прими мои поздравления, и привествую! Этот тир проведет тебя по первым механизмам, позволит выжать больше из руды, а так же научит изготавливать бронзу с большей выгодой.
+
+#More advanced alloys
+#name
+tier1.quest6.name=§rПродвинутые сплавы
+#description
+tier1.quest6.desc=Твоя пекарня отлично справляется с выплавкой сплавов в слитки, однако сам процесс трудоемок и не  особо эффективен. Тебе нужно что-то новое, так почему бы не подкинуть работёнки пару? Это также позволит удобнее обрабатывать сырьевую резину.
+
+#A very important alloy
+#name
+tier1.quest7.name=§rОчень важный сплав
+#description
+tier1.quest7.desc=Наиболее важным сплавом (пока ты не перейдешь в тир выше) является красный сплав. Повезло, у тебя есть сплавщик сплавов, так что бери медь, добавь к ней красной пыли и выплавь парочку.
+
+#Wire Cutter v.0.2alpha
+#name
+tier1.quest8.name=§rКусачки v.0.2 альфа
+#description
+tier1.quest8.desc=Для изготовления небольших шестерёнок тебе понадобятся кусачки. Скрафти.
+
+#The hell is that?
+#name
+tier1.quest9.name=§rЭто ещё что за?
+#description
+tier1.quest9.desc=Для изготовления механизмов тебе понадобятся поршни. Позволь мне научить тебя их изготавливать.
+
+#Macerator v1.0!
+#name
+tier1.quest10.name=§rИзмельчитель v1.0!
+#description
+tier1.quest10.desc=Наконец-то ты можешь создать механизм, что позволит тебе заменить твою ступу. За "бесконечную прочность" данной машины придется заплатить: Тебе нужно 2 алмаза для изготовления измельчительных головок. 
+
+#Upgrade: Better macerator
+#name
+tier1.quest11.name=§rУлучшение: Новый измельчитель
+#description
+tier1.quest11.desc=Новая версия парового измельчителя. Потребляет больше пара, однако практически вдвое быстрее. (Данное задание опционально)
+
+#The power of the sun
+#name
+tier1.quest12.name=§rЭнергия солнца
+#description
+tier1.quest12.desc=Солнце выделяет тепло, так почему бы не воспользоваться этим для получения пара?%n%nПодсказка: Солнечный бойлер со временем кальцифицирует и становится менее эффективным.
+
+#Steam alternatives
+#name
+tier1.quest13.name=§rПаровые альтернативы
+#description
+tier1.quest13.desc=Существует несколько способов получения пара. Данное опциональное задание покажет тебе альтернативные способы получение пара.
+
+#Redstone
+#name
+tier1.quest14.name=§rКрасная Пыль
+#description
+tier1.quest14.desc=Если ты ещё не находил жил с красной пылью, то самое время поискать. Испытай удачу на Y5-40 высоте.
+
+#Redstone, early game processing
+#name
+tier1.quest15.name=§rКрасная пыль, обработка ранней игры
+#description
+tier1.quest15.desc=Ты гадаешь как обработать красную пыль не имея измельчителя? Ты можешь воспользоваться gregtech молотом и разбить им руду. Затем использовать разбитую руду на верстаке вместе с молотом, чтобы получить грязной красной пыли. Затем заполни котёл водой и вымочи в нем руду. Так ты сможешь получить красной пыли для слитков красного сплава.
+
+#Upgrade: A better compressor
+#name
+tier1.quest16.name=§rУлучшение: Новый компрессор
+#description
+tier1.quest16.desc=Новая версия парового компрессора. Потребляет больше пара, однако практически вдвое быстрее. (Данное задание опционально)
+
+#Compressing stuff
+#name
+tier1.quest17.name=§rУплотняя всякое
+#description
+tier1.quest17.desc=Этот относительно простой механизм выполняет очень важную функцию: уплотнение. Его главная работа, - это сжатие 9 слитков в блок. Можно уплотнять и другие вещи, например мягкий тофу.
+
+#Extra Modifier
+#name
+tier1.quest18.name=§rДополнительный Модификатор
+#description
+tier1.quest18.desc=Если тебе нехватает модификатора на твоём инструменте, ты с лёгкость можешь его добавить.%nЗолотой блок и алмаз - всё что тебе понадобится.
+
+#Oh, shiny! (Not platinum!)
+#name
+tier1.quest19.name=§rУуу, блестяшка! (Не платина!)
+#description
+tier1.quest19.desc=Для изготовления твоего первого измельчителя тебе нужны два алмаза. Для похода в Twilight Forest тоже нужен один. Где искать алмазы? В алмазной жиле. Поищи на Y5-20 высоте.
+
+#A clear view
+#name
+tier1.quest20.name=§rХорошая видимость
+#description
+tier1.quest20.desc=Ты всё еще живешь в своем грязево/булыжниковом бункере? Не хочешь запустить немного дневнего света? Измельчи песка и кремня и скрафти стеклянный порошок. Положи его в плавильню и вылей в отливочную корзину, для получения чистого стекла.%n%nСовет: Чтобы использовать стекло в рецептах, тебе придется обработать его стамеской.
+
+#Lapis, Lazurite, Sodalite, Calcite
+#name
+tier1.quest21.name=§rЛапис, Лазурит, Содалит, Кальцит
+#description
+tier1.quest21.desc=Для постройки кирпичной доменной печки тебе придется поискать жилу лаписа с кальцитом.%nЖилу можно найти в overworld или Twilight Forest на Y20-50 высоте.
+
+#Gypsum
+#name
+tier1.quest22.name=§rГипс
+#description
+tier1.quest22.desc=Для изготовления кирпичей доменной печи тебе потребуется цемент и гипс. Гипс можно найти в жиле с базальтовым и гранитным минеральными песками, и валяльной глиной. Поищи на Y50-60 высоте в overworld.
+
+#Upgrade: Coal boiler
+#name
+tier1.quest23.name=§rУлучшение: Угольный бойлер
+#description
+tier1.quest23.desc=По сути - это просто лучшая версия твоего текущего угольного бойлера, однака он производит больше чем в два раза больше пара. Одназначно следует скрафтить, если ты планируешь улучшать другие механизмы.
+
+#Another use for Java, I mean Lava
+#name
+tier1.quest24.name=§rЕще одно применение для Джавы, в смысле для Лавы
+#description
+tier1.quest24.desc=С новым, более прочным стальным корпусом, ты можешь использовать лаву для производства пара.
+
+#Reinforced X? Unbreakable
+#name
+tier1.quest25.name=§rУкрепление X? Неразрушимый
+#description
+tier1.quest25.desc=С помощью стального инструмента ты в состоянии добывать обсидиан. Большие обсидиановые пластины добавляют модификатор укрепления. Он увеличивает прочность твоего инструмента.%nИнструмент с укреплением 10 уровня становиться неразрушимым.
+
+#Redstone? Haste!
+#name
+tier1.quest26.name=§rКрасная пыль? Скорость!
+#description
+tier1.quest26.desc=Копание и добыча могут быть ооооочень медленными. Добавь немного красной пыли своей кирке, лопате или топору, чтобы ускорить их.
+
+#Upgrade: Forge hammer
+#name
+tier1.quest27.name=§rУлучшение: Кузнечный молот
+#description
+tier1.quest27.desc=Новая версия парогово кузнечного молота. Потребляет больше пара, однако практически вдвое быстрее. (Данное задание опционально)
+
+#The Iron Guy
+#name
+tier1.quest28.name=§rЖелезный чувак
+#description
+tier1.quest28.desc=Тебе одиноко? Твоя база нуждается в защите?%nСкрафти Железных Големов и ты забудешь о проблеме с монстрами внутри своей базы.
+
+#The Cool Guy
+#name
+tier1.quest29.name=§rПрохладный чувак
+#description
+tier1.quest29.desc=Тебе одиноко? Находишься далеко от снежного биома?%n Скрафти Снежного Голема и если захочешь, вызови его на снежковую дуэль.
+
+#Lapis? Lucky!
+#name
+tier1.quest30.name=§rЛапис? Удача!
+#description
+tier1.quest30.desc=Возможно тебе повезло, и ты уже получил модификатор удачи на своей кирке. Если же нет, и у тебя есть не использованный модификатор - ты можешь добавить лаписа. Если модификатора нет, - его всегда можно добавить блоком золота и алмазом(единожды).
+
+#Iron Bolts
+#name
+tier1.quest31.name=§rЖелезные Болты
+#description
+tier1.quest31.desc=Для стрельбы твоему арбалету требуются патроны. Давай скрафтим деревянных болтов с железным наконечником.
+
+#Wooden Crosbow
+#name
+tier1.quest32.name=§rДеревянный Арбалет
+#description
+tier1.quest32.desc=У тебя появилась возможность сделать хорошее оружие дальнего боя. Арбалет. Используй дерево для основы и плеч арбалета. Обсидиан, для прочного крепления. Обыкновенные нити подойдут для тетевы.
+
+#Alumite
+#name
+tier1.quest33.name=§rАлюмит
+#description
+tier1.quest33.desc=Снова настоло время улучшений. Ты можешь изготовить алюмит путём смешивания обсидиана, стали и алюминия в плавильне. Алюмитовые кирки способны добывать ардайт и кобальт в Nether.
+
+#Upgrade of the upgrade of the...
+#name
+tier1.quest34.name=§rУлучшая улучшение улу...
+#description
+tier1.quest34.desc=Время улучшений. Позволь своим инструментам добывать обсидиан и красную пыль.
+
+#Submission Station
+#name
+tier1.quest35.name=§rСтанция Передачи
+#description
+tier1.quest35.desc=Не смотря на то, что большинство заданий могут быть подтверждены напрямую из твоего инверторя (включая жидкости), иногда тебе нужно более автоматизированное решение. Тут то и поможет Станция Передачи.%nЗадания, поддерживающие Станцию Передачи можно выбрать во встроенном интерфейсе, чтобы её активировать. После настройки предметы или жидкости могут быть доставлены с помощью труб или напрямую через слот ввода. Предметы и жидкости не испарятся, если ни одного задания не было выбрано, или если задание уже было завершено, что делает станцию относительно безопасной от случайного удаления предметов или жидкостей. Несколько Станций Передачи способны отслеживать разные под-задачи одного задания одновременно!
+
+#Hammer time v2
+#name
+tier1.quest36.name=§rКузнечный молот v2
+#description
+tier1.quest36.desc=Использовать 6 слитков для последующего крафта молота может выглядеть весьма растратно, поскольку молот не бесконечен. Было бы здорово иметь механизм, что позволит молотить всякое, только не используя прочность, а так же создавать две плиты из двух слитков...И что ты думаешь? Такой существует! И тебе определенно следует скрафтить такой.
+
+#One Anvil... Better make that two!
+#name
+tier1.quest37.name=§rОдна наковальня...Лучше сделаю две!
+#description
+tier1.quest37.desc=Используя твой новёханький уплотнитель ты способен сжать пару слитков в металлические блоки, для создания наковальни. И лучше сделать две наковальни, одна понадобиться для кузнечного молота.%n%nНа наковальне ты можешь чинить, переименовывать и зачаровывать броню и инструменты.
+
+#Better than iron
+#name
+tier1.quest38.name=§rЛучше железа
+#description
+tier1.quest38.desc=Укрепленное железо очень скоро станет важным слитком, когда у тебя появится немного стали и ты сможешь создавать механизмы высокого давления. Этот материал гораздо прочнее обычного железа, ты так же можешь делать из него инструменты.%nЧтобы изготовить укрепленное железо тебе нужно обжарить железные слитки в укрепленные железные самородки. Используя компрессор ты сможешь сжать самородки в слитки.%n%nСовет: измельченная или очищенная рудная пыль может быть обжарена прямиком в самородки.
+
+#Bookshelves...? Ah forestry... Multiblock farms!
+#name
+tier1.quest39.name=§rКнижные полки...? Ааа forestry... Мульти-блок фермы!
+#description
+tier1.quest39.desc=Книжные полки можно изготовить только с помощью деревянных пластин, которые делаются в уплотнителе. Возможно кто-то думает, что это чересчур.
+
+#Books
+#name
+tier1.quest40.name=§rКнижки
+#description
+tier1.quest40.desc=Книжки не сложно найти в деревнях или roguelike подземельях(кирпичный дом на поверхности).%nЯ уверен, что и рецепт у них есть.
+
+#Extracting stuff
+#name
+tier1.quest41.name=§rВыжимание всякого
+#description
+tier1.quest41.desc=С потребностью в резине для производства изолированных проводов тебе следует обзавестить паровым экстрактором. Ты также будешь получать больше красителей, выжимая цветы, или выжимать фруктовый сок.
+
+#Upgrade: Extractor
+#name
+tier1.quest42.name=§rУлучшение: Экстрактор
+#description
+tier1.quest42.desc=Новая версия парового экстрактора. Потребляет больше пара, однако практически вдвое быстрее. Ты наверняка захочешь скрафтить этот механизм, поскольку текущий экстрактор выжимает твои нервы... (Данное задание опционально)
+
+#Mining Dirt Block by Block is so Old School
+#name
+tier1.quest43.name=§rКопать землю по одному блоку - так старомодно
+#description
+tier1.quest43.desc=Сделав стальной экскаватор ты сможешь копать землю в 3х3 области. Не уничтожь свой собственный сад.
+
+#Tool Forge
+#name
+tier1.quest44.name=§rИнженерная Кузня
+#description
+tier1.quest44.desc=Наконец-то ты получил свой первый алюмит. Самое время скрафтить Инженерную Кузню для изготовления лучших Tinkers инструментов.
+
+#Barrel Upgrades Tier 2
+#name
+tier1.quest45.name=§rУлучения для Бочки Тир 2
+#description
+tier1.quest45.desc=Твои бочки с землей или булыжником снова забиты до отказа?%nНе проблема, улучши их ещё!
+
+#Barrel Upgrades
+#name
+tier1.quest46.name=§rУлучения для Бочки
+#description
+tier1.quest46.desc=Твои бочки с землей или булыжником забиты до отказа?%nНе проблема, улучши их!
+
+#Blastoff!
+#name
+tier1.quest47.name=§rПодрывай!
+#description
+tier1.quest47.desc=Самое время получить немного стали. Загляни во вкладку Мульти-блок Целей и построй кирпичную доменную печь. Возвращайся, когда добудешь как минимум 8 стальных слитков.
+
+#Flint and steel
+#name
+tier1.quest48.name=§rСталь да кремень
+#description
+tier1.quest48.desc=После налаженного производства стали ты способен скрафтить огниво. Я полагаю, ты хочешь отправиться в Nether как можно скорее, но будь осторожен. Nether - очень опасное место.
+
+#THE NETHER
+#name
+tier1.quest49.name=§rNETHER
+#description
+tier1.quest49.desc=Стало еще опаснее с новыми хардкорными инфернал монстрами. Веселись и будь осторожен.
+
+#How to make rubber
+#name
+tier1.quest50.name=§rКак изготавливать резину
+#description
+tier1.quest50.desc=Изготавливать резину куда сложнее, тебе нужна сырьевая резина и сера. Искать серу следует в Nether. Ищи на Y5-20 высоте.
+
+#Slime Island Journey
+#name
+tier1.quest51.name=§rПутешествие на Слизневый Остров
+#description
+tier1.quest51.desc=Резиновые деревья не единственный источник сырьевой резины. Ступай поищи слизневый остров высоко в небе. Слизневые шарики и слизневые листья также дают резину.%nТебе следует обзавестись фермой резиновых деревьев, позади твоей текущей фермы резины.
+
+#Cutting a Tree log by log is so Old School
+#name
+tier1.quest52.name=§rРубить деревья бревно за бревном - так старомодно
+#description
+tier1.quest52.desc=После производства стального лесоповального топора ты способен рубить деревья в один удар. Не забудь свой рюкзак, когда собираешься срубить священное дубовое дерево.
+
+#One Block mining is so Old School
+#name
+tier1.quest53.name=§rДобывать по одному блоку - так старомодно
+#description
+tier1.quest53.desc=После производства стального молота ты способен копать шахту 3х3 блока. Не свари себя в лаве, копая такие в Nether.
+
+#Iron spear
+#name
+tier1.quest54.name=§rЖелезное копьё
+#description
+tier1.quest54.desc=Улучши свое деревянное копье железным наконечником и двумя стальными винтами.%nЖелезное копье имеет лучшую прочность чем каменное.
+
+#More charcoal
+#name
+tier1.quest55.name=§rБольше древесного угля
+#description
+tier1.quest55.desc=Ты наткнулся на альтернативный способ получения древесного угля, используя "яму для производства древесного угля".%nЧего ты ждешь? Горы древесного угля ждут тебя!
+
+#Ardite and Cobalt
+#name
+tier1.quest56.name=§rАрдайт и Кобальт
+#description
+tier1.quest56.desc=Если ты выполнил все задания, ты можешь поискать кобальт и ардайт в Nether. Помни, что для обработки этих руд тебе понадобиться электрическая доменная печь.
+
+#Netherquartz? Sharpness
+#name
+tier1.quest57.name=§rNether-кварц? Острота
+#description
+tier1.quest57.desc=Твой меч туповат? Добудь Nether Кварца, чтобы заточить его.
+
+#Tetrahedrite, stibnite and copper
+#name
+tier1.quest58.name=§rТетраэдрит, антимонит и медь
+#description
+tier1.quest58.desc=На случай, если ты гадаешь зачем тебе тетраэдрит или антимонит. Ну, антимонит можно подвергнуть процедуре центрифугирования, в результате которой можно получить полезные материалы для аккумуляторов в эпохе низкого напряжения.%nЖилы можно найти на Y80-120 высоте.
+
+#Accelerated plant growth
+#name
+tier1.quest59.name=§rУскоренный рост растений
+#description
+tier1.quest59.desc=Растения не особо-то быстро растут. Так почему бы тебе не ускорить их рост? Лейка - отличный способ.
+
+#Basic crafting: Casings
+#name
+tier1.quest60.name=§rПростой крафт: Корпуса
+#description
+tier1.quest60.desc=Любые механизмы требуют корпус, для содержания их внутренностей в одном месте. Есть хорошая новость: Все корпуса крафтятся одинаково в любой эпохе, меняются только материалы.
+
+#Where can I put all the items in?
+#name
+tier1.quest61.name=§rКуда бы мне сложить предметы?
+#description
+tier1.quest61.desc=После получения стали, у тебя появилась возможность скрафтить небольшой рюкзак. В нём можно хранить кучу разных вещей. Вмещая 36 предметов - он даже больше обычного сундука.
+
+#Molds, molds, molds
+#name
+tier1.quest62.name=§rФормы, формы, формы
+#description
+tier1.quest62.desc=С помощью стали и Tinkers плавильни, ты можешь выплавить литейные формы. Их можно использовать в сплавщике сплавов и в затвердителе жидкостей. С их помощью ты сможешь изготавливать вакуумных трубки, слитки, шестеренки и ещё целую кучу всего.
+
+#Pollution what....?
+#name
+tier1.quest63.name=§rЗагрязнение...?
+#description
+tier1.quest63.desc=Если ты пользуешься своей кирпичной доменной печью достаточно продолжительное время - иногда тебя будут охватывать головокружения, головные боли и другие странные эффекты. Всё верно. Это - загрязнение... от изготовления кучи стали. Хорошо, если ты принесешь мне несколько резиновых пластин, я обменяю их на полный костюм химзащиты.
+
+#Wire-Wrap
+#name
+tier1.quest64.name=§rИзоляция проводов
+#description
+tier1.quest64.desc=Ставить провода без изоляции, возможно не лучшая затея. Имея экстрактор, способный выжимать сырьевую резину из липкой резины, и сплавщик сплавов позволяющий, используя серу, обрабатывать резину, тебе следует скрафтить несколько резиновых брусков.
+
+#Low tier wires
+#name
+tier1.quest65.name=§rПровода низкого тира
+#description
+tier1.quest65.desc=Низкоуровневые провода из красного сплава или олова можно получить на верстаке. Медные же провода уже требуют изоляции в сплавщике сплавов. Давай сделаем форму для резиновых плит.
+
+#The Plunger
+#name
+tier1.quest66.name=§rВантуз
+#description
+tier1.quest66.desc=С помощью вантуза можно прочищать трубы. А еще можно убирать вплоть до 1000mb жидкости из внутреннего хранилища механизма. Больше не требуется снимать и заного устанавливать механизм, для его очистки. Вантуз можно скрафтить из стержня желаемого материала и резиновых пластин.%n%nПодсказка: Вантуз получает 2.75-7.75 урона в зависимости от используемых материалов.
+
+#A quite different storage
+#name
+tier1.quest67.name=§rДругой тип хранения
+#description
+tier1.quest67.desc=Обыкновенные сундуки заполняются относительно быстро, если забивать их лутом с мобов вроде мечей или брони. Используя шкафчик, ты можешь хранить вплоть до 270 предметов одного типа.
+
+#Where I can put all the liquids?
+#name
+tier1.quest68.name=§rКуда девать жидкости?
+#description
+tier1.quest68.desc=С помощью сплавщика сплавов ты можешь соединять два разных материала. Что будет, если совместить обсидиановую пыль и стекло? Обсидиановое стекло. Великолепно. Твой первый резервуар, который ты сможешь скрафтить - станет Buildcraft резервуар. Он вмещает вплоть до 16 вёдер одинаковой жидкости. Его вместимость можно будет улучшить вплоть до 64 вёдер.
+
+#Packing your tanks chests and barrels
+#name
+tier1.quest69.name=§rУпаковывая резервуары, сундуки и бочки
+#description
+tier1.quest69.desc=Упаковать сундуки и бочки, не разлив и не расплескав их содержимое?%nНе проблема! Скрафти тележку и ты сможешь переносить заполненные сундуки, бочки или ящики куда угодно. Перенося какой-либо предмет накладывает на тебя дебаф замедления, так что, надеюсь, тебе не далеко нести. Не переносимые buildcraft и железные резервуары тоже можно переносить не теряя жидкости.
+
+#Time for some logic
+#name
+tier1.quest70.name=§rВремя для логики
+#description
+tier1.quest70.desc=Хорошие новости! Ты на этапе продвижения к следующему тиру! А вот плохие новости: Нужно скрафтить кучу всего, прежде чем ты сможешь начать. Не бойся, я проведу тебя по всем крафтам!
+
+#Wired, weird?!
+#name
+tier1.quest71.name=§rПроводка
+#description
+tier1.quest71.desc=Одним из самых простых материалов, крафт которых тебе следует запомнить, станут провода. По сути ты просто режешь плиту на провода с помощью кусачек. Позже будет более эффективный способ.
+
+#Basic crafting: Motors
+#name
+tier1.quest72.name=§rПростой крафт: Моторчики
+#description
+tier1.quest72.desc=Моторчики - небольшие устройства, которые позволяют переводить электрическую энергию во вращательную. Очень полезны для любых типов механизмов и не так сложны в производстве. Крафт всегда одинаков, меняются лишь материалы. На данном этапе ты можешь использовать красную пыль для намагничивания твоего железного стержня.%nПозже ты сможешь скрафтить электромагнитный поляризатор.
+
+#GT 6 styled Wires and Cables
+#name
+tier1.quest73.name=§rGT 6 Провода
+#description
+tier1.quest73.desc=Если ты гадаешь: "почему новые провода больше не авто-присоединяются?". Изменение было сделано, чтобы улучшить провода. Чтобы соединить провод тебе нужно использовать кусачки. Больше никаких сгоровших или неправильно соединённых проводов.%n%nПодсказка: Если ты кликнешь проводом по проводу - они авто-присоединятся.
+
+#Rubber Soft Mallet
+#name
+tier1.quest74.name=§rРезиновый Мягкий Молот
+#description
+tier1.quest74.desc=Деревянный мягкий молот ломается после пары использований. Теперь ты можешь скрафтить резиновый молот, с гораздо большей прочностью.
+
+#Better Tank... Iron Tank
+#name
+tier1.quest75.name=§rЛучший Резервуар...Железный Резервуар
+#description
+tier1.quest75.desc=Хранить больше 16 ведер жидкости в одном резервуаре? Да легко! Просто скрафти железный резервуар, или улучши текущий buildcraft резервуар.%nАлмазный резервуар хранит вплоть до 64 ведер, а обсидиановый ещё и взрывопрочный.
+
+#Circuit Boards
+#name
+tier1.quest76.name=§rПечатные Платы
+#description
+tier1.quest76.desc=Для каждой схемы тебе понадобится простая печатная плата. Скрафти обработанную деревянную пластину и используй медный провод для получения печатной платы.
+
+#Your first logic circuit
+#name
+tier1.quest77.name=§rПервая схема логики
+#description
+tier1.quest77.desc=Паровые механизмы - бестолковые. Они делают одно и тоже снова и снова. Прогрессируя в электрической эпохе, ты решил, сделать машины чуточку умнее. Например автоматический вывод, для создания простой автоматизации. И для этого тебе потребуются схемы логики.
+
+#Resistor
+#name
+tier1.quest78.name=§rРезистор
+#description
+tier1.quest78.desc=Любой печатной плате требуется пара резисторов для работы.
+
+#Better Tank... ULV Tank
+#name
+tier1.quest79.name=§rЛучший Резервуар... Резервуар Сверх Низкого Напряжения
+#description
+tier1.quest79.desc=Следующий шаг - хранить 32 ведра в резервуаре. РСНН из gregtech++ требует стальные, железные или оловянные пластины, глинянную трубу и ведро воды.
+
+#Basic crafting: Rotors
+#name
+tier1.quest80.name=§rПростой крафт: Роторы
+#description
+tier1.quest80.desc=У всех роторов идентичный рецепт крафта, за исключением материалов. На данный момент несколько муторный крафт, но тебе много и не нужно.
+
+#Steam-a-licious!
+#name
+tier1.quest81.name=§rПаро-пре-красно!
+#description
+tier1.quest81.desc=Ты на финишной черте. Еще один крафт, чтобы перейти в Тир 2. Продолжай!
+
+###############
+#End Of Tier 1#
+###############
+
+
+########
+#Tier 2#
+########
+
+#Tier 2 - 32 EU (LV)
+#name
+tier2.name=Тир 2 - 32 EU (Низкое Напряжение)
+#description
+tier2.desc=Первый тир "напряжения" этой сборки. Жить становится проще...
+
+########
+#Quests#
+########
+
+#Protect your base; Tier 1
+#name
+tier2.quest1.name=§rЗащити свою базу - Тир 1
+#description
+tier2.quest1.desc=База должна быть безопасной. Так почему бы тебе не обзавестись туррелями? На данный момент тебе доступны две туррели: "Картофельная" и "Предметная". Предположу, что ты знаешь как работает туррель...
+
+#Turret base
+#name
+tier2.quest2.name=§rПлатформа для Туррели
+#description
+tier2.quest2.desc=Туррели необходимо размещать на особые платформы. Только тот игрок, что разместил пушку на платформу может ее настраивать. Так что можешь не переживать, что другие игроки станут заимствовать аммуницию в твоей туррели.
+
+#Don't play with your food!
+#name
+tier2.quest3.name=§rНе играйся с едой!
+#description
+tier2.quest3.desc=Лучше используй её для убийства зомби. Урон, правда, не велик, но эй, пофиг а?
+
+#Magnetize your rods
+#name
+tier2.quest4.name=§rНамагничивай свои стержни
+#description
+tier2.quest4.desc=Для намагничивания стальных стержней требуется наличие электромагнитного поляризатора. Намагнить парочку для моторчиков.
+
+#Saving redstone
+#name
+tier2.quest5.name=§rЭкономя красную пыль
+#description
+tier2.quest5.desc=Надоело тратить 4 красной пыли для намагничивания одного железного стержня? У меня есть кое-что что для тебя! Электромагнитный поляризатор не требует красной пыли и потребляет немного энергии. Тебе даже не нужно устанавливать его к постоянному источнику энергии, он вполне неплохо работает и на аккумуляторе.
+
+#Basic transport: Fluids
+#name
+tier2.quest6.name=§rПростая транспортировка: Жидкости
+#description
+tier2.quest6.desc=Так же как и предметный узел, жидкостный передает... жидкости. А самое клёвое заключается в том, что: Они могут делить одну и ту же трубу для передачи и жидкостей и предметов.
+
+#Basic transport: Items
+#name
+tier2.quest7.name=§rПростая транспортировка: Предметы
+#description
+tier2.quest7.desc=Для передачи предметов тебе нужны так называемые "узлы передачи". Существует и такие, что передают предметы по трубам, и такие, что запрашивают эти предметы.
+
+#Who needs that dirt anyway
+#name
+tier2.quest8.name=§rДа кому нужна земля
+#description
+tier2.quest8.desc=У тебя наверняка целая куча ненужных блоков, разбросанных по всей базе. Так почему бы не использовать их для убийства недоброжелатей?
+
+#Upgrading intensifies
+#name
+tier2.quest9.name=§rУлучшая вместимость
+#description
+tier2.quest9.desc=Наверняка твоим туррелям не помешает пара лишних слотов под аммуницию, так почему бы их не скрафтить?
+
+#Transformer LV-MV
+#name
+tier2.quest10.name=§rТрансформатор Низкое - Среднее напряжение
+#description
+tier2.quest10.desc=Ты вполне можешь запускать механизмы среднего напряжения, находясь в эпохе низкого напряжения. Скрафти трансформатор и используй 4 источника энергии, производящие 32 eu/t, чтобы запитать один 128 eu/t механизм. Режим трансформатора можно сменить, кликнув по нему мягким молотом. Правда я бы не советовал этого делать на запитанном трансформаторе. Может получиться яма вместо базы.
+
+#Hey DJ, Mix it!
+#name
+tier2.quest11.name=§rЭй Диджей, мешай!
+#description
+tier2.quest11.desc=Микссер - очень полезный механизм. С его помощью ты можешь смешивать предметы и жидкости.
+
+#Damn you, wire cutter!
+#name
+tier2.quest12.name=§rЧёрт вас возми, кусачки!
+#description
+tier2.quest12.desc=Хватит, значит хватит. Больше никакой бестолковой траты слитков, для получения парочки проводов. Теперь, когда по твоим проводам течет электричество имеет смысл скрафтить машину, выдавливающую провода.
+
+#Alloy smelter
+#name
+tier2.quest13.name=§rСплавщик сплавов
+#description
+tier2.quest13.desc=Замени свой паровой сплавщик сплавов альтернативой из эпохи низкого напряжения.
+
+#Basic transport pipe
+#name
+tier2.quest14.name=§rПростая транспортировочная труба
+#description
+tier2.quest14.desc=Эти трубы относительно просты и не будут ничего передавать сами по себе. Но стоит их подключить к узлу передачи, ты сразу поймешь насколько они хороши. А если им ещё и подключить улучшения, они обойдут большинство других транспортировочных систем.
+
+#Passive defence
+#name
+tier2.quest15.name=§rПассивная защита
+#description
+tier2.quest15.desc=Более "пассивный" подход к защите базы - это стены и заборы. Но серьезно, разве это весело?
+
+#Your magic progression
+#name
+tier2.quest16.name=§rМагический прогресс
+#description
+tier2.quest16.desc=С налаженным производством алюминия, ты можешь перейти в магию. Если ты еще не разблокировал цепочку "Простого Таумкрафта", попробуй поискать саженцы серебрянного и великого дерева.
+
+#Get ready for Tier 3
+#name
+tier2.quest17.name=§rГотовимся к 3 Тиру.
+#description
+tier2.quest17.desc=Для дальшейшего продвижения тебе нужно наладить производство алюминия. Целую кучу. Наверное, лучший источник алюминия - это глина. Правда для его получения понадобиться механизм среднего напряжения. Так что пока тебе придется поискать альтернативные источники.
+
+#Welcome to Tier 2
+#name
+tier2.quest18.name=§rДобро Пожаловать в Тир 2
+#description
+tier2.quest18.desc=Ну привет! Похоже ты дошёл до электрической эпохи. Не торопись выбрасывать свои паровые механизмы, они наверняка пригодятся вплоть до 3 Тира.
+
+#Thermal centrifuge
+#name
+tier2.quest19.name=§rТепловая центрифуга
+#description
+tier2.quest19.desc=Опциональный механизм, позволяющий получить кучу побочных продуктов из перемолотых и очищенных рудных пылей. Данный механизм очень пригодится для переработки обедненных топливных стержней реактора.
+
+#A new alloy Cobalt Brass
+#name
+tier2.quest20.name=§rНовый сплав Кобальтовая Латунь
+#description
+tier2.quest20.desc=Для распиливания алмазных блоков в пластины, тебе придется получить новый сплав "кобальтовая латунь".%nДля начала тебе нужно получить латуни. Ее можно получить из цинка(можно найти в небольших жилах, или как побочный материал из олова или тетраэдрита в результате центрифугирования). Смешай латунь с алюминиевой и кобальтовой(тоже можно получить центрифугированием) пылью, для получения порошка кобальтовой латуни.%n%nРаз ты так далеко зашел, мы считаем, что ты и сам в состоянии посмотреть в NEI какие руды, что, и в результате чего дают.%n%n§aОт переводчика: порошок кобальтовой латуни также можно получить из 9 вёдер опыта.
+
+#You're gonna hate this #1
+#name
+tier2.quest21.name=§rТы это возненавидишь #1
+#description
+tier2.quest21.desc=Это первый предмет, которого понадобиться целая куча. Если ты захочешь забирать предметы из сундуков или бочек - конвеер это то, что тебе нужно.%n%nСовет: коневееры отлично работают с предметными трубами или с gt механизмами, настраивается отвёрткой.
+
+#Mjolnir!!! (electric forge hammer)
+#name
+tier2.quest22.name=§rМьёльнир!!! (электрический кузнечный молот)
+#description
+tier2.quest22.desc=Не то чтобы необходим, но он гораздо быстрее своего парового брата и его можно автоматизировать. Также если ты считаешь, что вымывать руду - не самый подходящий для тебе процесс - используй этот молот. Все кузнечные молоты после парового только ускоряют его работу, со всеми рецептами справляется и паровой вариант.
+
+#Sifting Machine
+#name
+tier2.quest23.name=§rПросеиватель
+#description
+tier2.quest23.desc=Нужны безупречные или изысканные алмазы, эмеральды, рубины или любые другие камни? В таком случае самое время обзавестить просеивателем.
+
+#Electric macerator
+#name
+tier2.quest24.name=§rЭлектрический измельчитель
+#description
+tier2.quest24.desc=Я особо рекомендую получить этот механизм, поскольку эффективность в плане уголь/пар использованная, при работе этого механизма, куда выше при использовании EU.
+
+#Find some Certus Quartz
+#name
+tier2.quest25.name=§rНайди немного Certus Кварца
+#description
+tier2.quest25.desc=Nether полон разничными типами кварца. Для эмиттера и датчика тебе понадобиться некоторое количество certus кварца.
+
+#Quartz and Quartzite Veins
+#name
+tier2.quest26.name=§rЖилы Кварца и Кварцита
+#description
+tier2.quest26.desc=Nether полон разничными типами кварца. Ступай поищи жилу кварца и кварцита. Их можно найти на Y40-80 высоте.
+
+#Hello Baron, how is your black gold today?
+#name
+tier2.quest27.name=§rЗдравствуйте, Магнат, как сегодня ваше золото?
+#description
+tier2.quest27.desc=Путешествуя по миру, ты наверняка натыкался на огромные, бьющие из земли, маслянные колодцы. Самое время обзавестись насосом и выкачать все чёрное золото в свои резервуары. Нефть можно сжечь в генераторе сгорания или обработать.%nДля выкачивания масла необходимы шахтёрские трубы.%n%nЗахвати с собой генератор сгорания для питания твоего насоса. (Спасибо достижениям технологии, насос авто-выкачивает жидкость через верхнюю плоскость.)
+
+#You're gonna hate this #2
+#name
+tier2.quest28.name=§rТы это возненавидишь #2
+#description
+tier2.quest28.desc=Следующий предмет, который тебе очень пригодится - электрический насос. Если захочешь перекачать жидкость из резервуаров - тебе такой пригодится.%n%nСовет: Здорово работает в сочетании с жидкостными трубами или gt механизмами, настраивается отвёрткой. Может быть улучшен в жидкостный регулятор, позволяющий настраивать объем выкачиваемой жидкости.
+
+#Suction device... nice
+#name
+tier2.quest29.name=§rСосущее приспособление... неплохо
+#description
+tier2.quest29.desc=Я надеюсь, ты не думаешь о чём я думаю, что ты думаешь...%n%nСовет:%nЯ особо рекомендую получить этот механизм, поскольку эффективность в плане уголь/пар использованная, при работе этого механизма, куда выше при использовании EU.
+
+#Compact? Or is it?
+#name
+tier2.quest30.name=§rКомпактно? Или..?
+#description
+tier2.quest30.desc=Да, он уплотняет, но это не означает уменьшение...%n%nСовет:%nЯ особо рекомендую получить этот механизм, поскольку эффективность в плане уголь/пар использованная, при работе этого механизма, куда выше при использовании EU.
+
+#Press all the things
+#name
+tier2.quest31.name=§rДави налево и направо
+#description
+tier2.quest31.desc=Имея простой формирочоный пресс, ты способен изготовливать еду, стекло, стреды, компоненты из project red.
+В эпохе среднего/высокого напряжения ты сможешь изготавливать роторы, различные AE компоненты, а так же изготавливать копии стальных и выдавливающих форм.
+
+#Lossless LV Cables
+#name
+tier2.quest32.name=§rПровода Низкого Напряжения без потерь
+#description
+tier2.quest32.desc=Как насчёт 32 EU проводов не имеющих потерь? Сплав красной пили это суперпроводник, способный передавать энергию без каких-либо потерь. Сплав Красной Пыли это новый сплав, требующий Электрической Доменной Печки. Смешай красную пыль кремний и уголь на верстаке, или в миксере для лучшего результата.
+
+#Basic monster protection
+#name
+tier2.quest33.name=§rПростая защита от монстров
+#description
+tier2.quest33.desc=Постоянное появление монстров вокруг твоей базы может надоедать. Особенно если тебе везет на инфернальных криперов. Повезло, что существует неплохой способ это остановить.
+
+#Gotta catch 'em all
+#name
+tier2.quest34.name=§rСоберу их всех
+#description
+tier2.quest34.desc=Да, ты всё также можешь использовать зерно/картошку/морковь, чтобы завлекать животных к себе на базу. Это может очень быстро утомить. Золотое лассо - адекватное решение транспортировки животных.
+
+#Try to dry out the Nether
+#name
+tier2.quest35.name=§rПопробуй осушить Nether
+#description
+tier2.quest35.desc=Насосы способны на большее, чем перекачка масла и воды. Ты можешь отправиться в nether и выкачать лавы из гигантских лавовых озёр.%nНе забудь захватить с собой парочку резервуаров.
+
+#New source of Glowstone
+#name
+tier2.quest36.name=§rНовый источник Светящейся Пыли
+#description
+tier2.quest36.desc=Поищи светящиеся цветы в nether и посади их в overworld. Больше не возникнет потребности идти в nether за светящейся пылью.
+
+#Better Tank... LV Tank
+#name
+tier2.quest37.name=§rЛучший Резервуар... Резервуар Низкого Напряжения
+#description
+tier2.quest37.desc=Следующий шаг - хранить вплоть до 64 вёдер в резервуаре. Для изготовления Резервуара Низкого Напряжения из Gt++ нужны стальные, железные, бронзовые пластины, огромная глиняная труба и насос низкого напряжения.
+
+#Dust to crystals
+#name
+tier2.quest38.name=§rПыль в кристаллы
+#description
+tier2.quest38.desc=Используя кристаллизатор ты можешь изготавливать сырьевой углеродную сетку из порошка углерода.
+
+#Simple Ore Washer
+#name
+tier2.quest39.name=§rПростейшая Промывка Руды
+#description
+tier2.quest39.desc=Слишком ленив, чтобы как следуют промывать руду. И бегать к котлу тоже совсем не хочется? В таком случае простая промывочная машина - то что тебе нужно! Она работает относительно быстро и использует 8eu в пике. Да, никаких побочных продуктов, но кому они нужны!
+
+#Basic ore washer
+#name
+tier2.quest40.name=§rПростая провымка руды
+#description
+tier2.quest40.desc=Измельчение руды обычно их удваивает. НО ЕСЛИ ТЫ ХОЧЕШЬ БООООЛЬШЕ, скрафти промывочный пункт и вымывай некоторые редкие материалы.
+
+#LV extruder
+#name
+tier2.quest41.name=§rВыдавливатель Низкого Напряжения
+#description
+tier2.quest41.desc=Выдавливатель не особо-то полезен в эпохе Низкого Напряжения. Но он сможет выдавить лодку следующих тиров или, например, некоторые части интрументов Tinkers Construct.
+
+#You're gonna hate this #3
+#name
+tier2.quest42.name=§rТы это возненавидишь #3
+#description
+tier2.quest42.desc=Более "электрическая" версия поршня. Это третий предмет, которого понадобиться целая куча.
+
+#You're gonna hate this #4
+#name
+tier2.quest43.name=§rТы это возненавидишь #4
+#description
+tier2.quest43.desc=Четвертым предметом станет Рука Робота. Очевидно этот предмет крафтить сложнее всех предыдущих.%n%nПодсказка: Он работает как конвеерная лента, но может работать с выбранными слотами предметов, настраивается отвёрткой.
+
+#Avengers, assemble!
+#name
+tier2.quest44.name=§rМстители, собираемся!
+#description
+tier2.quest44.desc=Однозначный "маст хэв" фанатов фильма. А, ну и для производства всего подряд тоже, конечно.
+
+#Bzzz... Whoom...
+#name
+tier2.quest45.name=§rБззз....вууум...
+#description
+tier2.quest45.desc=Изготавление превосходных кристаллов требует наличие точного лазерного ЧПУ.%nВ эпохе Среднего Напряжения Лазерный ЧПУ становится более важной машиной.
+
+#Better Tank... MV Tank
+#name
+tier2.quest46.name=§rЛучший Резервуар... Резервуар Среднего Напряжения
+#description
+tier2.quest46.desc=Следующим шагом станет хранение 128 вёдер в резервуаре. Резервуар Среднего Напряжения из Gt++ требует пластины из стали, темной стали или бронзы, бронзовую трубу и насос Низкого Напряжения.
+
+#ULV Transformer
+#name
+tier2.quest47.name=§rТрансформатор Сверх Низкого Напряжения
+#description
+tier2.quest47.desc=Чтобы наладить работу твоего простейшего промывочного пункта тебе понадобится Трансформатор СНН. Промывочный пункт может работать только с 8 EU. Добавив большее напряжение ты рискуешь превратить свою базу в руины.
+
+#A new alloy Magnalium
+#name
+tier2.quest48.name=§rНовый сплав Магналий
+#description
+tier2.quest48.desc=Гадаешь зачем тебе магналий? Нет, на данный момент он не нужен для gt механизмов, но как улучшение для твоего арбалета - самое то.%nЭто очень хороший материал в эпохе Низкого Напряжения. Ступай в Twilight Forest и найди там жилу Оливина/Глауконита на Y10-40 высоте. Или в overworld в жиле Глауконита/Мыльного Камня на Y20-50 высоте, или в Гранитной Минеральной жиле на Y50-60 высоте.%nИспользуя промывочный пункт, ты можешь получить магний или алюминий(Магнезит для магния, Валяльная Глина для алюминия) и смешать все это в сплавщике сплавов в Магналий.%nМазнезит дает 10 крохотных кусочков магния, с каждого порошка, но валяльная глина дает лишь один крохотный кусочек алюминия.
+
+#Hydrogen, methane or some farts... (Natural gas) 
+#name
+tier2.quest49.name=§rВодород, метан или пердёж...(Природный газ)
+#description
+tier2.quest49.desc=Иногда, после центрифугирования остаются газы вроде водорода или метана. Если положить в центрифугу коричневые или жёлтые лимониты, можно получить водород. Если ненужную пищу - то метан. Дерево тоже будет оставлять метан, в количестве 60 mb за бревно. Возможно, настоло время фермы дерева из forestry.
+
+#Molten redstone?
+#name
+tier2.quest50.name=§rЖидкая красная пыль?
+#description
+tier2.quest50.desc=Ты где-то услышал, что для некоторых рецептов карпентера нужна жидкая красная пыль.%nПреобразование красной пыли в жидкость требует наличие жидкостного экстрактора. Давай скрафтим.
+
+#Diesel, oil or maybe creosote?
+#name
+tier2.quest51.name=§rДизель, нефть или, может, креозот?
+#description
+tier2.quest51.desc=Наверняка ты собрал целый вагон креозота, может даже уже собрал свою первую Электрическую Доменную Печь. Креозот может стать неплохим источником топлива. Попробуй сделать парочку генераторов сгорания и используй их параллельно с твоим паровым генератором, как запасной источник энергии.
+
+#Bow, arrows and quiver
+#name
+tier2.quest52.name=§rЛук, стрелы да колчан
+#description
+tier2.quest52.desc=Ого, твой первый ручной *кхм* машинной работы лук. Ты можешь расположить свой лук в слоты из мода mine and blade battlegears. Самое время сделать колчан со стрелами. Ты можешь вместить вплоть дл 4 стаков стрел в колчане.%n%nПойдем поохотимся.
+
+#You're gonna hate this #5
+#name
+tier2.quest53.name=§rТы это возненавидишь #5
+#description
+tier2.quest53.desc=Пятый супер нужный предмет - передатчик. Он понадобиться для изготовления микроволновки, сканера, лазерного ЧПУ...
+
+#Auto Mining
+#name
+tier2.quest54.name=§rАвто-Шахтёр
+#description
+tier2.quest54.desc=Шахтёр в эпохе Низкого Напряжения? Вау! Эта крутая машина будет искать руды за тебя. Расположи пару стаков шахтёрских труб в нужный слот. Данный механизм потребляет 32 EU/t. Используя 8V солнечную панель он работает с 25% скоростью. Шахтёр ищет руды в радиусе 16 блоков.
+
+#Ardite Crossbow Body
+#name
+tier2.quest55.name=§rАрдайтовый Корпус Арбалета
+#description
+tier2.quest55.desc=Чтобы сделать твой арбалет ещё лучше - скрафти ардайтовый корпус. Я дал тебе пару слитков в твоём предыдущем задании.%nДобавив красной пыли, ты сделаешь свой арбалет быстрее. Для этого понадобиться слот модификатора.
+
+#Fiery Bowstring
+#name
+tier2.quest56.name=§rПламенная Тетева
+#description
+tier2.quest56.desc=Почему бы тебе не улучшить и тетеву твоего арбалета? Если ты не можешь найти ни одной пламенной нити в nether, я выдал тебе парочку за твоё прошлое задание. Скрафти пламенную тетеву.
+
+#Magnalium Crossbow
+#name
+tier2.quest57.name=§rМагналиевый Арбалет
+#description
+tier2.quest57.desc=Самое время скрафтить корпус и плечи для арбалета и улучшить твоего деревянного старичка.
+
+#Magnalium Crossbow Bolts
+#name
+tier2.quest58.name=§rМагналиевые Болты
+#description
+tier2.quest58.desc=Магналиевые болты куда лучше твоих деревянных.%nТы можешь использовать nether кварц, чтобы их заточить.%nДля этого нужен слот модификатора.
+
+#Basic Fluid Solidifier
+#name
+tier2.quest59.name=§rПростой Жидкостной Затвердитель
+#description
+tier2.quest59.desc=Чтобы вернуть твоим расплавленным жидкостям твердую форму, тебе нужен жидкостный затвердитель. С его помощью можно изготавливать арбалетные болты.
+
+#Scanning bees, crops and moooooore!
+#name
+tier2.quest60.name=§rСканирование пчёл, семян и проооочего!
+#description
+tier2.quest60.desc=Автоматизируй сканирование пчёл и растений. Позже, этот механизм становиться очень полезным для сканирования частей машин высокого тира, или для заполнения сфер информации, для производства материи. Емкостные стержни также требуют наличие сканера.
+
+#You're gonna hate this #6
+#name
+tier2.quest61.name=§rТы это возненавидишь #6
+#description
+tier2.quest61.desc=Шестым предметом станет датчик. Он понадобится для сканера или наблюдателя сейсмических изменений.
+
+#Sulfuric gas
+#name
+tier2.quest62.name=§rСерный газ
+#description
+tier2.quest62.desc=Еще один вид топлива для твоей газовой турбины ты можешь изготовить из масла. Цена сгорания такового за еденицу капсулы - 25.000 EU.
+
+#Glue
+#name
+tier2.quest63.name=§rКлей
+#description
+tier2.quest63.desc=Положив в центрифугу липкую резину ты получишь клей. Клей очень полезен в создании хороших печатных плат.
+
+#Empty Circuit Board
+#name
+tier2.quest64.name=§rПустая печатная плата
+#description
+tier2.quest64.desc=Хорошие печатные платы требуют опилок и обработанного клея для создания фенольных печатных плат. Добавив золотой провод у тебя получится Хорошая печатная плата.
+
+#Good Circuits
+#name
+tier2.quest65.name=§rХорошие схемы
+#description
+tier2.quest65.desc=Хорошие схемы это улучшение схем логики. Они являются компонентом всех механизмов Среднего Напряжения. Убедись, что у тебя есть электрическая доменная печь для производства алюминия.
+
+#Diode
+#name
+tier2.quest66.name=§rДиоды
+#description
+tier2.quest66.desc=Хорошим схемам нужны диоды. Существует два способа их получения. Использовав кремниевую пластину вместе с тонким оловянным проводом или арсенидом галлия. Жидкое стекло также требуется для производства.
+
+#Gallium Arsenide
+#name
+tier2.quest67.name=§rАрсенид Галлия
+#description
+tier2.quest67.desc=Для производства диодов необходим арсенид галлия. Так как же тебе его получить?%nПолучить галлий можно из измельченной цинковой руды, используя тепловую центрифугу. Малые цинковые жилы могут быть найдены в overworld или в nether на Y80-210 высоте. Чтобы получить больше цинка, тебе может понадобиться интрумент из tinkers construct, зачарованный на удачу. Сфалерит - альтернативный источник галлия.%nАрсенид можно получить из маленьких жил реальгара в nether на Y5-85 высоте. Добавь их в центрифугу. Еще один источник - кобальтовая руда в nether.%nСмешай две этих пыли в миксере для получения арсенида галлия.
+
+#Your oil is too Crude? Refine it!
+#name
+tier2.quest68.name=§rГрязная нефть? Так очисти её!
+#description
+tier2.quest68.desc=Сжигать нефть в генераторе сгорания очень неэффективный способ получения энергии. Каждое ведро/капсула нефти даёт лишь 20.000 EU. Самое время её обработать...
+
+#Sulfuric naphtha
+#name
+tier2.quest69.name=§rСернистый Лигроин
+#description
+tier2.quest69.desc=Ты можешь дистиллировать сернистый лигроин из масла, имеющий ценность сгорания 40.000 EU за капсулу в газовой турбине.
+
+#Naphtha
+#name
+tier2.quest70.name=§rЛигроин
+#description
+tier2.quest70.desc=Ты можешь обработать сернистый лигроин в жидкий лигроин, который имеет цену сгорания 320.000 EU за капсулу в газовой турбине.%nЛигроин также является основой для производства полиэтилена и поликапролактама.
+
+#Refinery gas
+#name
+tier2.quest71.name=§rОбработанный газ
+#description
+tier2.quest71.desc=Обработай свой газ в хим реакторе вместе с газом водорода, чтобы увеличить его сгораемую ценность и получить 160.000 EU за капсулу, с его помощью можно изготавливать метан.
+
+#Methane
+#name
+tier2.quest72.name=§rМетан
+#description
+tier2.quest72.desc=Если дистиллировать обработанные газы, ты получишь метан. Стоит упомянуть, что в сборке есть куча других методов и способов получения метана.
+
+#N like nitrogen... Hide, alphabet strikes again!
+#name
+tier2.quest73.name=§rА как Азот...
+#description
+tier2.quest73.desc=Ты можешь получить азот в центрефуге, используя... воздух. Это достаточно долгий процесс, особенно в эпохе низкого напряжения.
+
+#How to get sodium/lithium
+#name
+tier2.quest74.name=§rПолучение натрия/лития
+#description
+tier2.quest74.desc=Соляные жилы можно найти в overworld на Y50-70 высоте. Соль не единственный источник натрия. Соль играет большую роль в рецептах pam's harvestcraft.%n%nСовет: Лепидолит и сподумен - хорошие источники лития для твоих аккумуляторов.
+
+#Food 2.0
+#name
+tier2.quest75.name=§rЕда 2.0
+#description
+tier2.quest75.desc=Забудь всё что ты знал о еде и её ценности. Твоя новая упаковывающая машина способна консервировать любую съедобную пишу. Такой едой можно насытиться за считанные миллисекунды.
+
+#LPG
+#name
+tier2.quest76.name=§rСжиженный Нефтяной Газ
+#description
+tier2.quest76.desc=После центрифугирования бутана или пропана остается СНГ со стоимостью сгорания 320.000 EU за капсулу. С его помощью можно получить метан и эпихлоргидрин.
+
+#Butane and Propane
+#name
+tier2.quest77.name=§rБутан и Пропан
+#description
+tier2.quest77.desc=Ты можешь дистиллировать великое разнообразие газов из обработанного газа.%nМетан, бутан, пропан, гелий и этан.%n%nПодсказка:%nОбработанный газ не является лучшим  источником Пропана и Бутана. Их лучше получать из Лигроина.
+
+#H like Hydrogen... rest of the alphabet is too complicated...
+#name
+tier2.quest78.name=§rВ как водород...
+#description
+tier2.quest78.desc=Если положить в центрифугу коричневые или жёлтые лимониты, можно получить водород. Или можно использовать Электролизер с некоторым количеством воды и получить его в жидкой форме.
+
+#Round and round and round...
+#name
+tier2.quest79.name=§rКрутись крутись вертись...
+#description
+tier2.quest79.desc=После очищения руды, ты можешь подвергнуть её центрифугированию и получить еще больше побочных ресурсов.
+
+#Water and electricity, sounds fun and safe right?
+#name
+tier2.quest80.name=§rВода и электричество, звучит весело и безопасно, верно?
+#description
+tier2.quest80.desc=Использовав силу воды и электричества ты получишь еще больше побочных ресурсов.
+
+#IC2 Battery
+#name
+tier2.quest81.name=§rАккумулятор IC2
+#description
+tier2.quest81.desc=Некоторые рецепты требуют аккумуляторы из IC2. Заполни свой маленький корпус аккумулятора жидкой красной пылью, и ты получишь "перезаряжаемый аккумулятор". Раскалённые капсулы жгутся, так что осторожней.
+
+#Lithium
+#name
+tier2.quest82.name=§rЛитий
+#description
+tier2.quest82.desc=Литий можно промыть из Лепидолитовой руды или в процессе центрифугирования Сподумена.
+
+#Basic canner
+#name
+tier2.quest83.name=§rПростой консерватор
+#description
+tier2.quest83.desc=Главное назначение консерватора - заполнение оловянных капсул любым типом пищи, а так же для заполнения капсул и другими твердыми материалами, вроде лития, кадмия или натрия.
+
+#Reusable battery: Lithium
+#name
+tier2.quest84.name=§rАккумулятор: Литиевый
+#description
+tier2.quest84.desc=Натриевые, кадмиевые и литиевые батарейки - это перезаряжаемые аккумуляторы. Они крафтятся не имея никакого изначально сохраненного ресурса энергии, но могут быть заряжены в любом gt механизме. Если они больше не нужны, их можно выжать в экстракторе обратно в пустые аккумуляторные батареи. Всё содержимое будет утеряно.
+
+#Heavy Sulfuric fuel
+#name
+tier2.quest85.name=§rТяжёлое Сернистое топливо
+#description
+tier2.quest85.desc=Следующий шаг - дистилляция твоего масла в тяжелое сернистое топливо, с ценностью в 40.000 EU за капсулу.
+
+#Heavy fuel
+#name
+tier2.quest86.name=§rТяжёлое топливо
+#description
+tier2.quest86.desc=Добавив водород в тяжелое сернистое топливо в хим реакторе, ты сможешь получить некоторое количество тяжелого топлива с ценностью в 200.000 EU за капсулу.%n%nКапсулы с сероводородом можно будет использовать для получения сернистой кислоты для производства Динамита или кислотных батареек.%n%nВ эпохе среднего напряжения ты сможешь производить дизель из тяжелого или легкого топлива.
+
+#The missing one
+#name
+tier2.quest87.name=§rМне тебя так не хватало
+#description
+tier2.quest87.desc=Как однажды было сказано... <basdxz> Чёрт возьми, добавь сгибающее устройство в эпоху Низкого Напряжения ...и вот оно случилось.
+
+#Antimony
+#name
+tier2.quest88.name=§rСурьма
+#description
+tier2.quest88.desc=Наиболее эффективным способом получиния сурьмы для батареек является центрифугирование антимонита, вторым по эффективности является тетраэдрит.
+
+#Sodium
+#name
+tier2.quest89.name=§rНатрий
+#description
+tier2.quest89.desc=Натрий можно вымыть из Глауконитовой руды и песка. Его также можно добыть путем электролиза из соли.
+
+#How to get sodium
+#name
+tier2.quest90.name=§rГде взять натрий
+#description
+tier2.quest90.desc=Источником натрия является глауконитовая руда и песок. Данную жилу следует искать на Y20-50 высоте.
+
+#Reusable battery: Sodium
+#name
+tier2.quest91.name=§rАккумулятор: Натриевый
+#description
+tier2.quest91.desc=Натриевые, кадмиевые и литиевые батарейки - это перезаряжаемые аккумуляторы. Они крафтятся не имея никакого изначально сохраненного ресурса энергии, но могут быть заряжены в любом gt механизме. Если они больше не нужны, их можно выжать в экстракторе обратно в пустые аккумуляторные батареи. Всё содержимое будет утеряно.
+
+#Chemical rubber production
+#name
+tier2.quest92.name=§rХим продукция резины
+#description
+tier2.quest92.desc=Гораздо более эффективный способ получения изолированных проводов является изготовление жидкой резины в хим реакторе, которую затем можно нанести на провод в сборочном механизме. Если ты расположишь два механизма рядом, ты сможешь напрямую выводить жидкую резину в сборочный механизм, нажав на авто-выгрузку жидкостей из хим реактора. Убедись, что вывод механизма повернут в нужную сторону, используя гаечный ключ.
+
+#Empty Cells
+#name
+tier2.quest93.name=§rПустые Капсулы
+#description
+tier2.quest93.desc=Используя сгибающую машину ты можешь изготавливать пустые капсулы. Схему логики следует сконфигурировать на 12 режим, иначе ты получишь фольгу.
+
+#A lead about lead that leads to lead dust
+#name
+tier2.quest94.name=§rСвинец, что сведет в свинцовый порошок
+#description
+tier2.quest94.desc=Следующий шаг изготовления аккумуляторов - собрать свинцовой руды. Свинцовые и Галенитовые жилы можно найти в Twilight Forest на Y5-45 высоте.
+
+#Battery alloy
+#name
+tier2.quest95.name=§rАккумуляторный сплав
+#description
+tier2.quest95.desc=Смешав сурьму со свинцов в сплавщике сплавов можно получить аккумуляторный сплав.%nДобавив оловянных проводов ты получишь маленький аккумуляторный корпус.
+
+#A big meteorite
+#name
+tier2.quest96.name=§rБольшой метеор
+#description
+tier2.quest96.desc=Лучшим способом получения редкой земли, является раскопка метеоров из applied energistics 2, с их последующим измельчением. Возможно, ты завершал задание в паровой эпохе и у тебя где-то хранится измельченный небесный камень? Этот порошок можно центрифугировать в различные побочные ресурсы вроде натрия, неодия, цезия, лантана и иттрия.%n%nПодсказка: Красная пыль тоже имеет редкую землю как побочный ресурс. Халькопирит (Высокое Напряжение) и сфалерит(Низкое напряжение) имеют кадмий как побочный ресурс.
+
+#Reusable battery: Cadmium
+#name
+tier2.quest97.name=§rАккумулятор: Кадмиевый
+#description
+tier2.quest97.desc=Натриевые, кадмиевые и литиевые батарейки - это перезаряжаемые аккумуляторы. Они крафтятся не имея никакого изначально сохраненного ресурса энергии, но могут быть заряжены в любом gt механизме. Если они больше не нужны, их можно выжать в экстракторе обратно в пустые аккумуляторные батареи. Всё содержимое будет утеряно.
+
+#Cheaper Annealed Production
+#name
+tier2.quest98.name=§rБолее дешёвый обжиг
+#description
+tier2.quest98.desc=Куда быстрее и дешевле делать обожженную медь в электродуговой печи, нежели чем в электрической доменной печке. Обожженная медь славится своими проводами для Среднего Напряжения. Она теряет лишь 1 EU за блок.
+
+#Lubricant
+#name
+tier2.quest99.name=§rСмазка
+#description
+tier2.quest99.desc=Использовать смазку вместо воды или дистиллированной воды в твоем металлорежущем станке повысит его производство или скорость.%nСмазку можно изготовить из масла, раститольного масла, рыбьего жира или креозота. Если ты можешь себе позволить крафт пивоварного станка, тогда имеет смысл использовать тальк или мыльный камень, для получения ещё большего количества смазки за каждый цикл.
+
+#Light Sulfuric Fuel
+#name
+tier2.quest100.name=§rЛёгкое Сернистое топливо
+#description
+tier2.quest100.desc=Сначала ты дистиллируешь нефть в легкое сернистое топливо, ценой в 40.000 EU за капсулу.
+
+#Light fuel
+#name
+tier2.quest101.name=§rЛёгкое топливо
+#description
+tier2.quest101.desc=Добавив водород в лёгкое сернистое топливо в хим реакторе, ты произведешь некоторое количество легкого топлива ценой в 320.000 EU за капсулу.%n%nКапсулы с сероводородом можно будет использовать для получения сернистой кислоты для производства Динамита или кислотных батареек.%n%nВ эпохе среднего напряжения ты сможешь производить дизель из тяжелого или легкого топлива.
+
+#C9H8O4...NaCl...H2O...
+#name
+tier2.quest102.name=§rC9H8O4...NaCl...H2O...
+#description
+tier2.quest102.desc=Хочешь изготовить дизельное топливо с примесью цетана, пластик или хим краситель? Значит пора крафтить хим реактор.
+
+#No more filing
+#name
+tier2.quest103.name=§rБольше никакой опиловки
+#description
+tier2.quest103.desc=Зачем тратить целый слиток на производство стержня, используя инструмент, теряющий прочность, в результате чего, расходующий ЕЩЁ БОЛЬШЕ слитков? Имея этот механизм, все твои потребности в стержнях станут восполнены(пока что).
+
+#Portable mob spawners..? Cool!
+#name
+tier2.quest104.name=§rПереносить спавнеры монстров..? Клёво!
+#description
+tier2.quest104.desc=Хочешь перенести спавнер монстров в другое место и построить крутую мобо-ферму? Не вопрос, если ты скрафтишь алмазную тележку.
+
+#Diamond Chests... Oh shiny
+#name
+tier2.quest105.name=§rАлмазные Сундуки... Ух блестяшка
+#description
+tier2.quest105.desc=После установки в мастерской металлорежущего станка, ты способен распиливать алмазные блоки для производства больших алмазных сундуков.
+
+#LV Advanced Steam Boiler
+#name
+tier2.quest106.name=§rПаровой бойлер Низкого Напряжения
+#description
+tier2.quest106.desc=Паровой бойлер Низкого Напряжения из Gt++ - это следующая машина, которую ты можешь скрафтить для увеличения эффективности вырабатываемого пара.
+
+#Electrotine battery
+#name
+tier2.quest107.name=§rЭлектротиновые аккумуляторы
+#description
+tier2.quest107.desc=Электротиновые аккумуляторы используются только в project red механизмах и реактивном ранце.%nЭлектротин это смесь красной пыли и электрума.
+
+#Sulfuric acid
+#name
+tier2.quest108.name=§rСерная кислота
+#description
+tier2.quest108.desc=Соеденив триоксид серы с водой в хим реакторе ты получишь серную кислоту для одноразовых батареек. Если ранее ты делал тяжелое или легкое топливо, значит у тебя где-то остался сероводород. Если нет, ты всегда можешь получить серную кислоту смешав серу с водой в хим реакторе.
+
+#Fluid canner
+#name
+tier2.quest109.name=§rЖидкостный консерватор
+#description
+tier2.quest109.desc=Жидкостный консерватор - фундаментальный механизм, с его помощью можно перемещать жидкости по мастерской, или заполнять их в капсулы, ведра или аккумуляторы.%n%nИнтересный факт про жидкостный консерватор - его можно переделать в сборщик дождя, добавив слив к верхней крышке механизма (На самом деле любой механизм с емкостью может им стать...).
+
+#Single use battery: Acid
+#name
+tier2.quest110.name=§rОдноразовая батарейка: Кислота
+#description
+tier2.quest110.desc=Ртутные и кислотные батарейки являются одноразовыми. Они крафтятся полностью заряженными и их нельзя перезарядить. Как только их внутреннее хранилище заканчивается, их можно обратно конвертировать в пустые корпуса.%n%nБатарейки можно разместить в слот для аккумулятора в любом gregtech механизме Низкого Напряжения, в этом случае будет расходоваться их емкость, а не емкость самого механизма. Их также можно использовать в аккумуляторном буфере Низкого Напряжения.
+
+#Battery buffer
+#name
+tier2.quest111.name=§rАккумуляторный Буфер
+#description
+tier2.quest111.desc=Аккумуляторы можно устанавливать прямиком в механизмы. Чтобы перезарядить аккумулятор тебе понадобиться Аккумуляторный Буфер. Они бывают разных размеров: на 1, 4, 9 и 16 аккумуляторов.%n%n§aОт переводчика: Количество аккумуляторов, положенных в буфер определяют количество ампер, выдаваемых этим буфером.
+
+#LV battery buffer 9 slots
+#name
+tier2.quest112.name=§rАккумуляторный Буфер Низкого Напряжения на 9 слотов
+#description
+tier2.quest112.desc=Улучши свой аккумуляторный буфер, чтобы от вмещал вплоть до 9 аккумуляторов, что позволяет выдавать максимально 9 ампер.%nПолезно для твоей Электрической Доменной или Электодуговой печи.
+
+#Basic arc furnace
+#name
+tier2.quest113.name=§rПростая электродуговая печь
+#description
+tier2.quest113.desc=Электродуговая печь - это альтернативный способ выплавлять всякое обратно в компоненты или для производства укрепленного железа. Рецепты используют кислород и 3 ампера тока.
+
+#Faster steel production
+#name
+tier2.quest114.name=§rУскоренное производство стали
+#description
+tier2.quest114.desc=Ускоренная альтернатива производства стали - это использование электродуговой печи для укрепления железа. Затем измельчение его в порошок и последующее приготовление в сталь в ЭДП. (Известны случаи попытки изготовить сталь в электродуговой печи...)
+
+#A truly sharp saw blade
+#name
+tier2.quest115.name=§rОтлично заточенный пильный диск
+#description
+tier2.quest115.desc=Если соеденить кобальтовую латунь с алмазным порошком можно получить очень острый пильный диск для производства металлорежущего станка.
+
+#Cutting things apart
+#name
+tier2.quest116.name=§rВсё пополам
+#description
+tier2.quest116.desc=Однозначно обязательный механизм. Он распилит стержни в болты, пластины в корпуса, брусья в доски и всё это с максимально возможной эффективностью. Однозначно стоит того!%n%nСовет: Просто добавь воды.
+
+#Diamond Tanks... Oh shiny
+#name
+tier2.quest117.name=§rАлмазные Резервуары... Ух Блестяшка
+#description
+tier2.quest117.desc=После установки в мастерской металлорежущего станка, ты способен распиливать алмазные блоки для производства резервуаров, вмещающих 64 ведра.
+
+#Mercury
+#name
+tier2.quest118.name=§rРтуть
+#description
+tier2.quest118.desc=Ртуть можно добыть путем центрифугирования  красной пыли. Если ты нашел киноварь в жиле с красной пылью, его тоже можно использовать.
+
+#Single use battery: Mercury
+#name
+tier2.quest119.name=§rОдноразовая батарейка: Ртуть
+#description
+tier2.quest119.desc=Ртутные и кислотные батарейки являются одноразовыми. Они крафтятся полностью заряженными и их нельзя перезарядить. Как только их внутреннее хранилище заканчивается, их можно обратно конвертировать в пустые корпуса.%n%nБатарейки можно разместить в слот для аккумулятора в любом gregtech механизме Низкого Напряжения, в этом случае будет расходоваться их емкость, а не емкость самого механизма. Их также можно использовать в аккумуляторном буфере Низкого Напряжения.
+
+###############
+#End Of Tier 2#
+###############
+
+
+##################
+#Multiblock Goals#
+##################
+
+#Multiblock Goals
+#name
+multiblock.goals=Мульти-блок Цели
+#description
+multiblock.goals.desc=В данном разделе будут отображены основные мульти-блок цели. Ты можешь крафтить некоторые мульти-блок структуры гораздо ранее соответствующего им тира.
+
+########
+#Quests#
+########
+
+#Automation tier 1
+#name
+multiblock.goals.quest1.name=Automation tier 1
+#description
+multiblock.goals.quest1.desc=Do you want to automate your smeltery because you are planning to make stacks of glass blocks?%nNo problem, craft a large bronze pipe and place it under the faucet. Now the molten fluid will flow inside the pipe. Under the pipe you have to place the casting basins or tables.%n%nA hopper and a chest underneath would be good to auto-output products.
+
+#You are not prepared!!!
+#name
+multiblock.goals.quest2.name=You are not prepared!!!
+#description
+multiblock.goals.quest2.desc=It's time for something really big: A smeltery! There's a lot to craft, so better gather some resources...
+
+#The water dilemma
+#name
+multiblock.goals.quest3.name=The water dilemma
+#description
+multiblock.goals.quest3.desc=Finite water is a problem. But fear not, there are solutions! I shall guide you to a steady supply of water.
+
+#Multiblock tanks... Railcraft tanks
+#name
+multiblock.goals.quest4.name=Multiblock tanks... Railcraft tanks
+#description
+multiblock.goals.quest4.desc=576 buckets of fluid, that should be enough to store all the creosote you have accumulated thus far. If that isn't enough you can make this tank bigger. The smallest tanks are 3x3x4 while the biggest are 9x9x8.%n%nHint: Fluid will auto-output (without any pumps) if you place a valve on the bottom side of the tank.%n%nUse only Buckets to move fluids because cells get destroyed.
+
+#Why one coke oven when you can have ten
+#name
+multiblock.goals.quest5.name=Why one coke oven when you can have ten
+#description
+multiblock.goals.quest5.desc=Your bricked blast furnace uses coal like hell and your steam boiler too? Well it's time to make more coke ovens and automate them a bit. Wooden fluid pipes and tin item pipes will help you reach your goal.
+
+#Analyzing the soil
+#name
+multiblock.goals.quest6.name=Analyzing the soil
+#description
+multiblock.goals.quest6.desc=To determine which kind of oil or gas there is in the chunk you need to scan the soil by right clicking a seismic prospector with 8 dynamite, 4 TNT, 2 industrial TNT or 1 glyceryl. Then use a data stick to extract the data by right clicking on it after the animation has finished.%nProTip: you can do it more efficiently by only scanning every 8 chunks.%n%nNow you need to add the analyzed data stick to a scanner. Then place it in the bottom right slot of the printer and add 3 paper in the top left slot and make sure you have atleast 144 mb squid ink in it. (Only gregtech machines will work)%n%nAfter the process is done take the printed page and combine it with a piece of leather in an assembling machine filled with at least 20 mb of refined glue.%n%nTADA now you have a book with info about the chunk you scanned.  
+
+#Railcraft steam power
+#name
+multiblock.goals.quest7.name=Railcraft steam power
+#description
+multiblock.goals.quest7.desc=As an alternative way to steam you can use the railcraft boilers. They require at least one firebox.
+More than one size is possible: (1x1 mentioned above) 2x2 and 3x3. Each boiler needs 1, 2 or 3 layers of tanks on top, depending on the size.
+
+#Liquid fuelled firebox
+#name
+multiblock.goals.quest8.name=Liquid fuelled firebox
+#description
+multiblock.goals.quest8.desc=Cresosote oil into steam! After you make your first steel you are able to craft a liquid fueled firebox.%nDiesel, ethanol, creosote and biofuel all work well here.
+
+#It's time to get more steam
+#name
+multiblock.goals.quest9.name=It's time to get more steam
+#description
+multiblock.goals.quest9.desc=As soon as you have the ability to store energy in large quantities, it would be necessary to have a way to generate energy in large quantities. You need a large bronze boiler. But in order to make this boiler, you will need a mountain of bronze. This boiler produces 800 liters of steam per tick. This is enough to run 10 basic steam turbines.%n%nThe large boiler can uses either water or distilled water. Water is consumed at a rate of 1l of water per 150l of steam.%n%nTo make a large boiler you must make a 3x3x5 structure with pipe casings in the center of the middle 3 levels. The lowest level must contain at least 1 or 2 input hatches, 1 or 2 input buses, 3 or 4 fireboxes, 1 muffler, and one maintenance hatch. The lowest level can not contain any plated bricks. All hatches, buses, and mufflers must have their back side touching a firebox. The output hatch can be placed on any of the upper 4 levels.
+
+#Automation tier 2
+#name
+multiblock.goals.quest10.name=Automation tier 2
+#description
+multiblock.goals.quest10.desc=You want a better automation than using pipes? Sure, craft a comparator and link it with redstone dust placed on the ground. The redstone needs to be adjecent to the faucet to activate the crafting process.
+
+#Time to get some steel
+#name
+multiblock.goals.quest11.name=Time to get some steel
+#description
+multiblock.goals.quest11.desc=You need steel? Uhh... fine. Let's get busy...%n%nHint: The bricked blast furnace can share walls with other ones, just like most GT multi blocks. How will this affect the air quality though...
+
+#The "Waterproblems" are solved
+#name
+multiblock.goals.quest12.name=The "Waterproblems" are solved
+#description
+multiblock.goals.quest12.desc=Entering the HV age you found a way of making a water reservoir wich solves the finite water problem. Craft it with some fused quartz glass, HV pumps and cauldrons.
+
+#Steel multiblock tanks
+#name
+multiblock.goals.quest13.name=Steel multiblock tanks
+#description
+multiblock.goals.quest13.desc=Do you want to have tanks that can hold double the amount than that of the iron ones? Go ahead and make a steel tank. All sizes allowed from 3x3x4 to 9x9x8 blocks.%n%nHint: Fluid will auto-output (without any pumps) if you place a valve on the bottom side of the tank.%n%nOnly use buckets because cells get destroyed.
+
+#Smelt all the things...
+#name
+multiblock.goals.quest14.name=Smelt all the things...
+#description
+multiblock.goals.quest14.desc=Smelting up to nine items at once? With a bit of steel you can make a railcraft Steam Oven. 2x2x2%n%nHint: All furnace recipes work just fine, but you cannot use it to make charcoal from wood.
+
+#Low pressure boiler tank
+#name
+multiblock.goals.quest15.name=Low pressure boiler tank
+#description
+multiblock.goals.quest15.desc=The low pressure boiler tank is the easiest way to store steam. The firebox needs this tank on top to produce steam. The bigger the boiler the slower it heats up, but it will produce more steam when heated up.
+
+#High pressure boiler tank
+#name
+multiblock.goals.quest16.name=High pressure boiler tank
+#description
+multiblock.goals.quest16.desc=After you make steel you are able to craft a high pressure boiler tank. The upgraded version increases the temperature and produces more steam than the low pressure version.
+
+#Steam is never enough
+#name
+multiblock.goals.quest17.name=Steam is never enough
+#description
+multiblock.goals.quest17.desc=Now you can make advanced circuits, which means it's time to build a large steel boiler. This boiler is one and a half times more efficient than a bronze one, and that means we need 5 more steam turbines. Don't forget to monitor the water level!
+
+#We need big toys
+#name
+multiblock.goals.quest18.name=We need big toys
+#description
+multiblock.goals.quest18.desc=All your little turbines take up too much space? Are you running out of water? It is time to solve these problems. This large turbine can help you produce a tremendous amount of energy. . It will also distill water for you, so you can use the same water again inside your large boiler.  Don't forget to make a rotor for the turbine. At the initial stage the most suitable materials for the rotor are: vanadium steel (it has a very high durability, but slowly produces energy), cobalt (good combination of durability and performance) and ultimet (has higher efficiency, durability and performance).
+
+#Better than Duct Tape
+#name
+multiblock.goals.quest19.name=Better than Duct Tape
+#description
+multiblock.goals.quest19.desc=A soldering iron tool to remove the burned out circuits message is better than duct tape.%nThe soldering iron requires one soldering material item and 10,000 EU. Valid soldering materials are fine wires, rods, and ingots made from either tin, lead, or soldering alloy. The soldering iron will consume the first such material it finds in the player's inventory.%n%nFor the other problems other tools are necessary.%n%nPossible problems                  Tool to fix%n"Pipe is loose."                        Wrench%n"Screws are missing."             Screwdriver%n"Something is stuck."               Soft mallet%n"Platings are dented."            Hammer%n"Circuitry burned out."          Soldering Iron%n"That doesn't belong there." Crowbar%n
+
+#EBF-Time
+#name
+multiblock.goals.quest20.name=EBF-Time
+#description
+multiblock.goals.quest20.desc=In order to get alumin(i)um ingots, you need an electric blast furnace. It's another very important step towards victory, so let's get started.%n%nGetting the heating coils might be a little tricky...%n%n(You need 2 LV hatches with 4A of 32V total, or 3 LV hatches with MOOOORE power if the multiblock is not fully repaired)%n%nA few recipes produce CO2/SO2 as fluid. You need to add an additional fluid hatch to the top layer of the EBF to collect it otherwise it gets auto voided. It depends on the muffler hatch how much fluid you can recover. Max muffler recovers = 78%.
+
+#2x steel
+#name
+multiblock.goals.quest21.name=2x steel
+#description
+multiblock.goals.quest21.desc=Steel production is so slow. If you got enough bricks and clay, build a second BBF. Build it attached to the first one, so they can share a wall an you will save some bricks, clay and concrete.
+
+#4x steel
+#name
+multiblock.goals.quest22.name=4x steel
+#description
+multiblock.goals.quest22.desc=Not even two BBFs are fast enough...
+
+#An unexpected Bonus
+#name
+multiblock.goals.quest23.name=An unexpected Bonus
+#description
+multiblock.goals.quest23.desc=Because we're nice developers, we decided to add a little bonus if you happen to compress charcoal. Not only does it allow you to process more than 16 steel at a time (not in the bricked blast furnace), it also yields 10 times the burn time of a piece of charcoal. So one charcoal for free. This bonus only occurs on the first compression step. (But for fanciness, you should definitely get a quintuple one!)
+
+#Smelt all the things stack wise...
+#name
+multiblock.goals.quest24.name=Smelt all the things stack wise...
+#description
+multiblock.goals.quest24.desc=...with this great invention! Uses power to smelt up to 2 stacks of items at once! Can't go any faster!%n%nHint: Parallel smelting depends on coils, consult your local doctor before use.
+
+#Time to drill! 
+#name
+multiblock.goals.quest25.name=Time to drill! 
+#description
+multiblock.goals.quest25.desc=Pumps are nice but you're going to reach a point where you will want MOOOOOOOOOOOOORE oil. This multiblock will help with that but you will need to search for oil using a seismic prospector. You can find raw, light and heavy oil. There's also a chance to find natural gas.%n%nHigher tiers of power will drill faster. You need to upgrade the energy hatch coresponding to the power tier. 
+
+#Moooooore steam
+#name
+multiblock.goals.quest26.name=Moooooore steam
+#description
+multiblock.goals.quest26.desc=Stock up on titanium, it will be fun. A large titanium boiler produces 1600 litres of steam per tick. For this amount you need to choose the right rotors for your turbines. For example, 2 normal cobalt rotors will be just right. Optimal flow for such rotor is 800 liters per tick. If you have more than one boiler, you will need to make calculations in order to select the appropriate rotors.
+
+#Less Power loss
+#name
+multiblock.goals.quest27.name=Less Power loss
+#description
+multiblock.goals.quest27.desc=When you reach MV tier you can make your own duct tape in case you have to move your multiblock machines around. Duct tape will fix all maintenance problems in any multiblock machine.
+
+#EBF Infos
+#name
+multiblock.goals.quest28.name=EBF Infos
+#description
+multiblock.goals.quest28.desc=You can use a scanner to manually check how your EBF works, or you can make an informations panel from nuclear control and always see the status. Make a GT sensor kit and place the sensor card in your info panel. Enable it with a redstone signal.
+
+#Compress all the things
+#name
+multiblock.goals.quest29.name=Compress all the things
+#description
+multiblock.goals.quest29.desc=Martin's (DreamMasterXXL) favourite machine. Compress ALL the things! With explosives, of course.
+
+#Compress all the things
+#name
+multiblock.goals.quest30.name=You smell like a distillery!
+#description
+multiblock.goals.quest30.desc=This bad boy will tremendously boost the by-products of your cracked fuel by multiplying them by 5. This way you can make industrial TNT, polyethylene, polytetrafluoroethylene and other plastics more efficiently.%n%nYou will also need this for your automated setups.
+
+#Even more steam? Are you sure?
+#name
+multiblock.goals.quest31.name=Even more steam? Are you sure?
+#description
+multiblock.goals.quest31.desc=This boiler is the most efficient source of steam. It allows you to produce as much as 2000 litres of steam per tick. If you need more, then build a dual or even quad boiler.
+
+#Still not enough charcoal?
+#name
+multiblock.goals.quest32.name=Still not enough charcoal?
+#description
+multiblock.goals.quest32.desc=This oven is the best way to get charcoal and creosote (x50 faster than Railcraft's coke oven) and other byproducts. You will need tons of bronze, iron and steel to build it, but it's worth it. Finally, it will be possible to dismantle the charcoal pit.%nWith Cupronickel coils the oven is a bit slowlier. Each coil tier speed up the charcoal production.
+
+#Glyceryl trini...... what?
+#name
+multiblock.goals.quest33.name=Glyceryl trini...... what?
+#description
+multiblock.goals.quest33.desc=Kids, today we will make some glyceryl trinitrate with some glycerol.%n%n    - Chemistry 101
+
+#Powderbarrels
+#name
+multiblock.goals.quest34.name=Powderbarrels
+#description
+multiblock.goals.quest34.desc=Powderbarrels are twice as good as dynamite in the implosion compressor. Craft one stack.
+
+#TNT
+#name
+multiblock.goals.quest35.name=TNT
+#description
+multiblock.goals.quest35.desc=TNT is much more powerful than the powderbarrel but much harder to craft. There are LV and HV ways to craft. At LV you need heavy or light fuel to make some toluene wich can be solidified to gelled toluene. Alternatively you can use sugar and plastic dust in a chemical reactor to make toluene more efficient. Mix it with sulfuric acid to make TNT.%n%nThe HV way requires an oil cracking unit to make all kinds of cracked fuel or cracked naphta and a distillation tower to extract toluene from that.
+
+#Let's get it crackin!
+#name
+multiblock.goals.quest36.name=Let's get it crackin!
+#description
+multiblock.goals.quest36.desc=Cracking oil will result in better by-products in the distillation tower. It is a smart idea to get this multiblock since you are going to need TONS of industrial TNT for advanced tier rockets.%n%nIf you add steam the amout of EU/t will be reduced by 50% and if you add hydrogen the output will be increased by 30%
+
+#High speed charcoal
+#name
+multiblock.goals.quest37.name=High speed charcoal
+#description
+multiblock.goals.quest37.desc=Sure, those coke ovens are nice, but they aren't even remotely fast enough to keep up with a large steam boiler. Luckily, there is an upgrade available! The creosote oil will not be produced, but the process will speed up dramatically. Who needs that nasty yellowish flammable stuff anyway...
+
+#Upgrade #1: More heat
+#name
+multiblock.goals.quest38.name=Upgrade #1: More heat
+#description
+multiblock.goals.quest38.desc=Better materials need higher temperatures. You can just exchange the old coils with the new ones. You can even recycle the old coils, how fancy is that!
+
+#At the end of...
+#name
+multiblock.goals.quest39.name=At the end of...
+#description
+multiblock.goals.quest39.desc=...the universe everything freezes eventually. But waiting for the heat death of the universe might take too long. Therefore we present you the vacuum freezer. It should be good enough to cool your hot stuff. You will need a minimum of 16 frost proof machine casings, the rest depends on your setup.
+
+#Dynamite
+#name
+multiblock.goals.quest40.name=Dynamite
+#description
+multiblock.goals.quest40.desc=Dynamite is the most basic explosive you can use in the implosion compressor.%nMix some paper, string and glyceryl trinitrate in a chemical reactor to get dynamite.
+
+#iTNT
+#name
+multiblock.goals.quest41.name=iTNT
+#description
+multiblock.goals.quest41.desc=Industrial TNT is the HV variant of TNT. It explodes with more power, yet does not destroy blocks when it explodes.
+
+#Cleanroom
+#name
+multiblock.goals.quest42.name=Cleanroom
+#description
+multiblock.goals.quest42.desc=If you want to make more advanced circuits you need a cleanroom. The cleanroom is a multiblock between 3x4x3 and 15x15x15 (WxHxDx) blocks. Besides plascrete blocks you need a controller, filter casings on the top, an energy and maintenance hatch , a reinforced door and three machine hulls. For now you can use MV tier.%n%nLet's build a 5x5x5 room.
+
+#A very useful Scanner
+#name
+multiblock.goals.quest43.name=A very useful Scanner
+#description
+multiblock.goals.quest43.desc=The portable scanner is a tool capable of showing advanced information about almost every block in the game.%nIn order to function, the tool needs to be charged first. It can hold up to 400k EU and accept 128 EU/t or less. This is MV tier.%n%nIt can scan crops, which shows more information than the cropnalyzer does. The crop, which was scanned in the world, will drop a scanned seed bag.%nIt can scan machines from GregTech, giving information about current progress, the stored energy, efficiency, problems and CPU-load.%nFor any block in the game it scans, it gives information about its ID, Metadata, position in the world and hardness value.%nIt also gives information about pollution level in the chunk the scanned block belongs to.%nAdditional to that it shows when the clenroom has reached his 100% efficeny level.
+
+#Upgrade #2: Higher tier
+#name
+multiblock.goals.quest44.name=Upgrade #2: Higher tier
+#description
+multiblock.goals.quest44.desc=To reach the 3600k heat capacity of your EBF, so you can process high-tier materials like tungsten, you need nichrome heating coils.
+
+#Upgrade #3: Upgrade tier 4
+#name
+multiblock.goals.quest45.name=Upgrade #3: Upgrade tier 4
+#description
+multiblock.goals.quest45.desc=To process more advanced materials like enderium, enriched naquadah or niobium-titanium you need more than 3600K. Time to upgrade your EBF... again.
+
+#Upgrade #4: Upgrade tier 5
+#name
+multiblock.goals.quest46.name=Upgrade #4: Upgrade tier 5
+#description
+multiblock.goals.quest46.desc=To process more advanced materials like HSS-E, HSS-S, naquadah or draconium you need more than 4500K. Time to upgrade your EBF to 5400k.
+
+#Upgrade #6: Upgrade tier 7
+#name
+multiblock.goals.quest47.name=Upgrade #6: Upgrade tier 7
+#description
+multiblock.goals.quest47.desc=To process the most advanced materials like neutronium, fluxed-electrum or awakened draconium you need more than 7200K. Upgrade your EBF to 9001k. (OVER 9000!!!)
+
+#Upgrade #3: Upgrade tier 6
+#name
+multiblock.goals.quest48.name=Upgrade #3: Upgrade tier 6
+#description
+multiblock.goals.quest48.desc=To process more advanced materials like naquadah-alloy you need more than 5400K. Upgrade your EBF to 7200k to increase the heat.
+
+#########################
+#End Of Multiblock Goals#
+#########################
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
I have started localising/(swapping hardcoded english into .lang files) Quest Book.
The problem is which keyholders to use?
I personally don't really care but one who create quests may find it difficult to manage later.
So we have to aggree on how we are gonna "call" them.
I guess person who add's and creates them can still do it via ingame BQ editor.
But he'll have to message me every time he adds/changes quest. So i turned it into proper .lang file.
Reason being - you can't make .lang quests in ingame editor.

for now it's
"name": "tier0.quest3.name",
"description": "tier0.quest3.desc",

first dot - name of the tab
second dot - number of quest (i number them from left to right, from top to bottom).
last dot - name/description of the quest.

User dont have to do anything to see proper localisation. It's all ready and set.
So only thing he has to do is change the language of the game to beloved one.
![image](https://user-images.githubusercontent.com/32778092/40831751-82b46216-6592-11e8-91dd-8835b7cdf6bb.png)

first image shows numeration
![image](https://user-images.githubusercontent.com/32778092/40831852-c0ab95da-6592-11e8-9ee2-32d9bcdd82fc.png)

Second Img show's how quest look's for user
![image](https://user-images.githubusercontent.com/32778092/40831943-f7c003da-6592-11e8-8afb-dde44eb5ac76.png)

third img show's how quest look's for editor
![image](https://user-images.githubusercontent.com/32778092/40832038-33c45f2a-6593-11e8-968f-300fe7fce341.png)


and this img shows how quest looks in .lang file
