### PR TITLE
GraviSuite HUD

### DIFF
--- a/config/GraviSuite.cfg
+++ b/config/GraviSuite.cfg
@@ -9,7 +9,7 @@
 
 "hud settings" {
     B:"Display hud"=true
-    I:hudPosition=1
+    I:hudPosition=3
 }
 
 


### PR DESCRIPTION
Moves the GraviSuite HUD from the overloaded upper left corner to the bottom left corner (below the chat).
![gravihud](https://user-images.githubusercontent.com/19178671/42298266-358baa82-802f-11e8-8012-55b021e4dfd9.png)
