### PR TITLE
Gendustry log warns

### DIFF
--- a/config/gendustry/bees.cfg
+++ b/config/gendustry/bees.cfg
@@ -3795,7 +3795,7 @@ mutation: 8% "gendustry.bee.ThaumiumDust" + "gendustry.bee.ThaumiumShard" => "ge
 mutation: 7% "gendustry.bee.ThaumiumShard" + "gendustry.bee.SalisMundus" => "gendustry.bee.Tainted" Req Biome "Tainted Land"
 //new
 mutation: 8% "magicbees.speciesTCOrder" + "gendustry.bee.ThaumiumDust" => "gendustry.bee.Thauminite" Req Block B:thaumicbases:thauminiteBlock
-mutation: 6% "magicbees.speciesTCChaos" + "magicbees.speciesTCVoid" => "gendustry.bee.Shadowmetal" Req Block B:Taintedmagic:BlockShadowmetal
+mutation: 6% "magicbees.speciesTCChaos" + "magicbees.speciesTCVoid" => "gendustry.bee.Shadowmetal" Req Block B:TaintedMagic:BlockShadowmetal
 mutation: 3% "gendustry.bee.Platinum" + "gendustry.bee.ThaumiumDust" => "gendustry.bee.Mithril" Req Block B:gregtech:"gt.blockmetal4"@10
 mutation: 3% "gendustry.bee.Silver" + "gendustry.bee.Iron" => "gendustry.bee.AstralSilver" Req Block B:gregtech:"gt.blockmetal1"@6
 mutation: 2% "gendustry.bee.Diamond" + "gendustry.bee.Iron" => "gendustry.bee.Divided" Req Block B:ExtraUtilities:"decorativeBlock1"@5

--- a/config/gendustry/bees.cfg
+++ b/config/gendustry/bees.cfg
@@ -3876,7 +3876,7 @@ mutation: 15% "gendustry.bee.Jupiter" + "gendustry.bee.Titanium" => "gendustry.b
 mutation: 15% "gendustry.bee.Jupiter" + "extrabees.species.artic" => "gendustry.bee.Callisto" Req Block B:GalaxySpace:"callistoblocks" Req Temperature Icy
 
 mutation: 12.5% "gendustry.bee.Jupiter" + "gendustry.bee.Mithril" => "gendustry.bee.Venus" Req Block B:GalaxySpace:"venusblocks"
-mutation: 12.5% "gendustry.bee.Jupiter" + "gendustry.bee.Tungsten " => "gendustry.bee.Mercury" Req Block B:GalaxySpace:"venusblocks"
+mutation: 12.5% "gendustry.bee.Jupiter" + "gendustry.bee.Tungsten" => "gendustry.bee.Mercury" Req Block B:GalaxySpace:"venusblocks"
 
 mutation: 12.5% "gendustry.bee.Jupiter" + "gendustry.bee.Ledox" => "gendustry.bee.Saturn" Req Block B:dreamcraft:"tile.Quantinum"
 mutation: 12.5% "gendustry.bee.Saturn" + "gendustry.bee.Chrome" => "gendustry.bee.Enceladus" Req Block B:GalaxySpace:"enceladusblocks"


### PR DESCRIPTION
fixes for:
```
[Client thread/WARN]: Adding mutation failed: Block not found Taintedmagic:BlockShadowmetal (RsMutation(magicbees.speciesTCChaos,magicbees.speciesTCVoid,gendustry.bee.Shadowmetal,6.0,false,List(MReqBlock(StackBlock(Taintedmagic,BlockShadowmetal,32767)))))
[Client thread/WARN]: Adding mutation failed: Species 'gendustry.bee.Tungsten ' not found (RsMutation(gendustry.bee.Jupiter,gendustry.bee.Tungsten ,gendustry.bee.Mercury,12.5,false,List(MReqBlock(StackBlock(GalaxySpace,venusblocks,32767)))))
```