### PR TITLE
Bee adjustments and OCD cleanup

### DIFF
--- a/config/gendustry/bees.cfg
+++ b/config/gendustry/bees.cfg
@@ -838,9 +838,9 @@ cfg Bees {
         Branch = "brbees.gem"
         Products = DropsList( 
             30% S:gendustry:"HoneyComb.stone" 
+	    15% S:gendustry:"HoneyComb.redstone" 
             ) 
-        Specialty = DropsList(
-            15% S:gendustry:"HoneyComb.redstone" 
+        Specialty = DropsList(         
             15% S:gendustry:"HoneyComb.rareearth" 
             )
         cfg Traits {
@@ -936,7 +936,7 @@ cfg Bees {
             ) 
         Specialty = DropsList(
             15% S:gendustry:"HoneyComb.ruby"
-			5% S:gendustry:"HoneyComb.redgarnet"
+	    5% S:gendustry:"HoneyComb.redgarnet"
             )
         cfg Traits {
             Base = "forestry.speciesCommon"
@@ -1008,7 +1008,7 @@ cfg Bees {
             ) 
         Specialty = DropsList(
             15% S:gendustry:"HoneyComb.olivine"
-			5% S:gendustry:"HoneyComb.magnesium"
+	    5% S:gendustry:"HoneyComb.magnesium"
             )
         cfg Traits {
             Base = "forestry.speciesCommon"
@@ -1104,7 +1104,7 @@ cfg Bees {
             30% S:gendustry:"HoneyComb.stone" 
             ) 
         Specialty = DropsList(
-            10% S:gendustry:"HoneyComb.firestone"
+            15% S:gendustry:"HoneyComb.firestone"
             )
         cfg Traits {
             Base = "forestry.speciesCultivated"
@@ -1131,8 +1131,8 @@ cfg Bees {
             15% S:gendustry:"HoneyComb.copperdust" 
             ) 
         Specialty = DropsList(
-			5% S:gendustry:"HoneyComb.golddust" 
-			)
+	    5% S:gendustry:"HoneyComb.golddust" 
+	    )
         cfg Traits {
             Base = "forestry.speciesCommon"
             }
@@ -1156,8 +1156,8 @@ cfg Bees {
             15% S:gendustry:"HoneyComb.tindust" 
             ) 
         Specialty = DropsList(
-			5% S:gendustry:"HoneyComb.zincdust" 
-			)
+	    5% S:gendustry:"HoneyComb.zincdust" 
+	    )
         cfg Traits {
             Base = "forestry.speciesCommon"
             }
@@ -1181,8 +1181,8 @@ cfg Bees {
             15% S:gendustry:"HoneyComb.leaddust"
             ) 
         Specialty = DropsList(
-			5% S:gendustry:"HoneyComb.sulfurdust" 
-			)
+	    5% S:gendustry:"HoneyComb.sulfurdust" 
+	    )
         cfg Traits {
             Base = "forestry.speciesCommon"
             }
@@ -1206,8 +1206,8 @@ cfg Bees {
             15% S:gendustry:"HoneyComb.irondust" 
             ) 
         Specialty = DropsList(
-			5% S:gendustry:"HoneyComb.tindust" 
-			)
+	    5% S:gendustry:"HoneyComb.tindust" 
+	    )
         cfg Traits {
             Base = "forestry.speciesCommon"
             }
@@ -1231,8 +1231,8 @@ cfg Bees {
             15% S:gendustry:"HoneyComb.steeldust" 
             ) 
         Specialty = DropsList(
-			5% S:gendustry:"HoneyComb.irondust" 
-			)
+	    5% S:gendustry:"HoneyComb.irondust" 
+	    )
         cfg Traits {
             Base = "forestry.speciesCommon"
             }
@@ -1256,8 +1256,8 @@ cfg Bees {
             15% S:gendustry:"HoneyComb.nickeldust" 
             ) 
         Specialty = DropsList(
-			2% S:gendustry:"HoneyComb.platinum"
-			)
+	    2% S:gendustry:"HoneyComb.platinum"
+	    )
         cfg Traits {
             Base = "forestry.speciesCommon"
             }
@@ -1281,8 +1281,8 @@ cfg Bees {
             15% S:gendustry:"HoneyComb.zincdust" 
             ) 
         Specialty = DropsList(
-		    5% S:gendustry:"HoneyComb.galliumdust" 
-			)
+            5% S:gendustry:"HoneyComb.galliumdust" 
+	    )
         cfg Traits {
             Base = "forestry.speciesCommon"
             }
@@ -1306,8 +1306,8 @@ cfg Bees {
             15% S:gendustry:"HoneyComb.silverdust" 
             ) 
         Specialty = DropsList(
-			5% S:gendustry:"HoneyComb.sulfurdust" 
-			)
+	    5% S:gendustry:"HoneyComb.sulfurdust" 
+	    )
         cfg Traits {
             Base = "forestry.speciesCommon"
             }
@@ -1331,8 +1331,8 @@ cfg Bees {
             15% S:gendustry:"HoneyComb.golddust" 
             ) 
         Specialty = DropsList(
-			5% S:gendustry:"HoneyComb.nickeldust"
-			)
+	    5% S:gendustry:"HoneyComb.nickeldust"
+	    )
         cfg Traits {
             Base = "forestry.speciesCommon"
             }
@@ -1362,11 +1362,7 @@ cfg Bees {
             }
         }
         
-  
-       //<~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ brbees.raremetal Branch ~~~~~~~~~~~~~~~~~~~~~> 
-        
-
-    cfg Aluminium {
+	    cfg Aluminium {
         Dominant = Yes
         Glowing = No
         PrimaryColor = 0xB8B8FF
@@ -1380,15 +1376,20 @@ cfg Bees {
         Branch = "brbees.raremetal"
         Products = DropsList( 
             30% S:gendustry:"HoneyComb.slag"
+	    15% S:gendustry:"HoneyComb.aluminium"
             ) 
-        Specialty = DropsList(
-			15% S:gendustry:"HoneyComb.aluminium"
-			5% S:gendustry:"HoneyComb.bauxite" 			
-			)
+        Specialty = DropsList(	
+	    5% S:gendustry:"HoneyComb.bauxite" 			
+	    )
         cfg Traits {
             Base = "forestry.speciesCommon"
             }
         }
+  
+       //<~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ brbees.raremetal Branch ~~~~~~~~~~~~~~~~~~~~~> 
+        
+
+
         
     cfg Titanium {
         Dominant = Yes
@@ -1406,9 +1407,9 @@ cfg Bees {
             30% S:gendustry:"HoneyComb.slag"
             ) 
         Specialty = DropsList(
-			15% S:gendustry:"HoneyComb.titanium"
-			5% S:gendustry:"HoneyComb.almandine"
-			)
+	    15% S:gendustry:"HoneyComb.titanium"
+	    5% S:gendustry:"HoneyComb.almandine"
+	    )
         cfg Traits {
             Base = "forestry.speciesCommon"
             }
@@ -1431,9 +1432,9 @@ cfg Bees {
             30% S:gendustry:"HoneyComb.slag"
             ) 
         Specialty = DropsList(
-			15% S:gendustry:"HoneyComb.chrome" 
-			5% S:gendustry:"HoneyComb.magnesium"
-			)
+	    15% S:gendustry:"HoneyComb.chrome" 
+	    5% S:gendustry:"HoneyComb.magnesium"
+	    )
         cfg Traits {
             Base = "forestry.speciesCommon"
             }
@@ -1456,8 +1457,8 @@ cfg Bees {
             15% S:gendustry:"HoneyComb.manganese" 
             ) 
         Specialty = DropsList(
-			5% S:gendustry:"HoneyComb.irondust" 
-			)
+	   5% S:gendustry:"HoneyComb.irondust" 
+	   )
         cfg Traits {
             Base = "forestry.speciesCommon"
             }
@@ -1479,9 +1480,9 @@ cfg Bees {
             30% S:gendustry:"HoneyComb.slag"
             ) 
         Specialty = DropsList(
-			15% S:gendustry:"HoneyComb.tungsten"
-			5% S:gendustry:"HoneyComb.molybdenum"
-			)
+	    15% S:gendustry:"HoneyComb.tungsten"
+	    5% S:gendustry:"HoneyComb.molybdenum"
+	    )
         cfg Traits {
             Base = "forestry.speciesCommon"
             }
@@ -1504,9 +1505,9 @@ cfg Bees {
             30% S:gendustry:"HoneyComb.slag"
             ) 
         Specialty = DropsList(
-			15% S:gendustry:"HoneyComb.platinum"
-			2% S:gendustry:"HoneyComb.iridium"
-			)
+	    15% S:gendustry:"HoneyComb.platinum"
+	    2% S:gendustry:"HoneyComb.iridium"
+	    )
         cfg Traits {
             Base = "forestry.speciesCommon"
             }
@@ -1653,8 +1654,8 @@ cfg Bees {
             30% S:gendustry:"HoneyComb.slag"
             ) 
         Specialty = DropsList(
-			15% S:gendustry:"HoneyComb.uranium"
-			)
+	    15% S:gendustry:"HoneyComb.uranium"
+            )
         cfg Traits {
             Base = "forestry.speciesAvenging"
             }
@@ -1675,11 +1676,11 @@ cfg Bees {
         Branch = "brbees.radioactive"
         Products = DropsList( 
             30% S:gendustry:"HoneyComb.slag"
-			15% S:gendustry:"HoneyComb.leaddust"
+	    15% S:gendustry:"HoneyComb.leaddust"
             )
         Specialty = DropsList(
-			15% S:gendustry:"HoneyComb.plutonium"
-			)
+	    15% S:gendustry:"HoneyComb.plutonium"
+	    )
         cfg Traits {
             Base = "forestry.speciesAvenging"
             }
@@ -1702,8 +1703,8 @@ cfg Bees {
             30% S:gendustry:"HoneyComb.slag"
             )
         Specialty = DropsList(
-			15% S:gendustry:"HoneyComb.naquada" 
-			)
+	    15% S:gendustry:"HoneyComb.naquada" 
+	    )
         cfg Traits {
             Base = "forestry.speciesAvenging"
             }
@@ -1723,11 +1724,11 @@ cfg Bees {
         Branch = "brbees.radioactive"
         Products = DropsList( 
             30% S:gendustry:"HoneyComb.slag"
-			20% S:gendustry:"HoneyComb.naquada" 
+	    20% S:gendustry:"HoneyComb.naquada" 
             )
         Specialty = DropsList(
-			15% S:gendustry:"HoneyComb.naquadria" 
-			)
+	    15% S:gendustry:"HoneyComb.naquadria" 
+	    )
         cfg Traits {
             Base = "forestry.speciesAvenging"
             }
@@ -1747,7 +1748,7 @@ cfg Bees {
         Authority = GTNewHorizons
         Branch = "brbees.radioactive"
         Products = DropsList( 
-			75% S:gendustry:"HoneyComb.DOB" 
+	    75% S:gendustry:"HoneyComb.DOB" 
             )
         Specialty = DropsList()
         cfg Traits {
@@ -1769,7 +1770,7 @@ cfg Bees {
         Authority = GTNewHorizons
         Branch = "brbees.radioactive"
         Products = DropsList( 
-			75% S:gendustry:"HoneyComb.thorium" 
+	    75% S:gendustry:"HoneyComb.thorium" 
             )
         Specialty = DropsList()
         cfg Traits {
@@ -1790,7 +1791,7 @@ cfg Bees {
         Authority = GTNewHorizons
         Branch = "brbees.radioactive"
         Products = DropsList( 
-			15% S:gendustry:"HoneyComb.lutetium" 
+	    15% S:gendustry:"HoneyComb.lutetium" 
             )
         Specialty = DropsList()
         cfg Traits {
@@ -1811,7 +1812,7 @@ cfg Bees {
         Authority = GTNewHorizons
         Branch = "brbees.radioactive"
         Products = DropsList( 
-			5% S:gendustry:"HoneyComb.americium" 
+	    5% S:gendustry:"HoneyComb.americium" 
             )
         Specialty = DropsList()
         cfg Traits {
@@ -1832,7 +1833,7 @@ cfg Bees {
         Authority = GTNewHorizons
         Branch = "brbees.radioactive"
         Products = DropsList( 
-			0.01% S:gendustry:"HoneyComb.neutronium" 
+	    0.01% S:gendustry:"HoneyComb.neutronium" 
             )
         Specialty = DropsList()
         cfg Traits {
@@ -1858,8 +1859,8 @@ cfg Bees {
             2% S:gendustry:"HoneyComb.salismundus"
             ) 
         Specialty = DropsList(
-			10% S:gendustry:"HoneyComb.naga"
-			)
+	    10% S:gendustry:"HoneyComb.naga"
+	    )
         cfg Traits {
             Base = "forestry.speciesCultivated"
             }
@@ -1881,8 +1882,8 @@ cfg Bees {
             4% S:gendustry:"HoneyComb.salismundus"
             ) 
         Specialty = DropsList(
-			10% S:gendustry:"HoneyComb.lich"
-			)
+	    10% S:gendustry:"HoneyComb.lich"
+            )
         cfg Traits {
             Base = "forestry.speciesCultivated"
             }
@@ -1904,8 +1905,8 @@ cfg Bees {
             6% S:gendustry:"HoneyComb.salismundus"
             ) 
         Specialty = DropsList(
-			10% S:gendustry:"HoneyComb.hydra"
-			)
+	    10% S:gendustry:"HoneyComb.hydra"
+	    )
         cfg Traits {
             Base = "forestry.speciesCultivated"
             }
@@ -1927,8 +1928,8 @@ cfg Bees {
             8% S:gendustry:"HoneyComb.salismundus"
             ) 
         Specialty = DropsList(
-			10% S:gendustry:"HoneyComb.urghast"
-			)
+	    10% S:gendustry:"HoneyComb.urghast"
+	    )
         cfg Traits {
             Base = "forestry.speciesCultivated"
             }
@@ -1950,8 +1951,8 @@ cfg Bees {
             15% S:gendustry:"HoneyComb.salismundus"
             ) 
         Specialty = DropsList(
-			10% S:gendustry:"HoneyComb.snowqueen"
-			)
+	    10% S:gendustry:"HoneyComb.snowqueen"
+	    )
         cfg Traits {
             Base = "forestry.speciesCultivated"
             }
@@ -1997,8 +1998,8 @@ cfg Bees {
             4% S:gendustry:"HoneyComb.space"
             ) 
         Specialty = DropsList(
-		    10% S:gendustry:"HoneyComb.meteoriciron"
-			)
+	    10% S:gendustry:"HoneyComb.meteoriciron"
+	    )
         cfg Traits {
             Base = "forestry.speciesCultivated"
             }
@@ -2020,11 +2021,11 @@ cfg Bees {
             6% S:gendustry:"HoneyComb.space"
             ) 
         Specialty = DropsList(
-		    10% S:gendustry:"HoneyComb.desh"
-			)
+	    10% S:gendustry:"HoneyComb.desh"
+	    )
         cfg Traits {
             Base = "forestry.speciesCultivated"
-			Effect = "forestry.effectIgnition"
+	    Effect = "forestry.effectIgnition"
             }
         }
 		
@@ -2044,11 +2045,11 @@ cfg Bees {
             10% S:gendustry:"HoneyComb.space"
             ) 
         Specialty = DropsList(
-		    10% S:gendustry:"HoneyComb.ledox"
-			)
+            10% S:gendustry:"HoneyComb.ledox"
+	    )
         cfg Traits {
             Base = "forestry.speciesCultivated"
-			Effect = "forestry.effectIgnition"
+	    Effect = "forestry.effectIgnition"
             }
         }
 		
@@ -2068,8 +2069,8 @@ cfg Bees {
             10% S:gendustry:"HoneyComb.space"
             ) 
         Specialty = DropsList(
-		    10% S:gendustry:"HoneyComb.ledox"
-			)
+	    10% S:gendustry:"HoneyComb.ledox"
+	    )
         cfg Traits {
             Base = "extrabees.species.freezing"
             }
@@ -2091,8 +2092,8 @@ cfg Bees {
             10% S:gendustry:"HoneyComb.space"
             ) 
         Specialty = DropsList(
-		    10% S:gendustry:"HoneyComb.callistoice"
-			)
+            10% S:gendustry:"HoneyComb.callistoice"
+	    )
         cfg Traits {
             Base = "extrabees.species.freezing"
             }
@@ -2114,8 +2115,8 @@ cfg Bees {
             16% S:gendustry:"HoneyComb.space"
             ) 
         Specialty = DropsList(
-		    10% S:gendustry:"HoneyComb.mytryl"
-			)
+            10% S:gendustry:"HoneyComb.mytryl"
+	    )
         cfg Traits {
             Base = "forestry.speciesCultivated"
             }
@@ -2137,8 +2138,8 @@ cfg Bees {
             16% S:gendustry:"HoneyComb.space"
             ) 
         Specialty = DropsList(
-		    10% S:gendustry:"HoneyComb.quantium"
-			)
+	    10% S:gendustry:"HoneyComb.quantium"
+	    )
         cfg Traits {
             Base = "forestry.speciesCultivated"
             }
@@ -2160,8 +2161,8 @@ cfg Bees {
             26% S:gendustry:"HoneyComb.space"
             ) 
         Specialty = DropsList(
-		    10% S:gendustry:"HoneyComb.oriharukon"
-			)
+	    10% S:gendustry:"HoneyComb.oriharukon"
+	    )
         cfg Traits {
             Base = "forestry.speciesCultivated"
             }
@@ -2183,8 +2184,8 @@ cfg Bees {
             42% S:gendustry:"HoneyComb.space"
             ) 
         Specialty = DropsList(
-			10% S:gendustry:"HoneyComb.mysteriouscrystal"
-			)
+	    10% S:gendustry:"HoneyComb.mysteriouscrystal"
+	    )
         cfg Traits {
             Base = "forestry.speciesCultivated"
             }
@@ -2206,8 +2207,8 @@ cfg Bees {
             68% S:gendustry:"HoneyComb.space"
             ) 
         Specialty = DropsList(
-			10% S:gendustry:"HoneyComb.blackplutonium"
-			)
+	    10% S:gendustry:"HoneyComb.blackplutonium"
+	    )
         cfg Traits {
             Base = "forestry.speciesCultivated"
             }
@@ -2229,8 +2230,8 @@ cfg Bees {
             75% S:gendustry:"HoneyComb.space"
             ) 
         Specialty = DropsList(
-			10% S:gendustry:"HoneyComb.trinium"
-			)
+	    10% S:gendustry:"HoneyComb.trinium"
+	    )
         cfg Traits {
             Base = "forestry.speciesCultivated"
 			Speed = "magicbees.speedBlinding"
@@ -2254,8 +2255,8 @@ cfg Bees {
             25% S:gendustry:"HoneyComb.moon"
             ) 
         Specialty = DropsList(
-			10% I:dreamcraft:"item.MoonStoneDust"
-			)
+	    10% I:dreamcraft:"item.MoonStoneDust"
+	    )
         cfg Traits {
             Base = "forestry.speciesCultivated"
             }
@@ -2277,8 +2278,8 @@ cfg Bees {
             25% S:gendustry:"HoneyComb.mars"
             ) 
         Specialty = DropsList(
-			10% I:dreamcraft:"item.MarsStoneDust"
-			)
+	    10% I:dreamcraft:"item.MarsStoneDust"
+	    )
         cfg Traits {
             Base = "forestry.speciesCultivated"
             }
@@ -2300,8 +2301,8 @@ cfg Bees {
             25% S:gendustry:"HoneyComb.mars"
             ) 
         Specialty = DropsList(
-			10% I:dreamcraft:"item.PhobosStoneDust"
-			)
+	    10% I:dreamcraft:"item.PhobosStoneDust"
+	    )
         cfg Traits {
             Base = "forestry.speciesCultivated"
             }
@@ -2323,8 +2324,8 @@ cfg Bees {
             25% S:gendustry:"HoneyComb.mars"
             ) 
         Specialty = DropsList(
-			10% I:dreamcraft:"item.DeimosStoneDust"
-			)
+	    10% I:dreamcraft:"item.DeimosStoneDust"
+	    )
         cfg Traits {
             Base = "forestry.speciesCultivated"
             }
@@ -2346,8 +2347,8 @@ cfg Bees {
             25% S:gendustry:"HoneyComb.jupiter"
             ) 
         Specialty = DropsList(
-			10% I:dreamcraft:"item.CeresStoneDust"
-			)
+	    10% I:dreamcraft:"item.CeresStoneDust"
+	    )
         cfg Traits {
             Base = "forestry.speciesCultivated"
             }
@@ -2391,8 +2392,8 @@ cfg Bees {
             25% S:gendustry:"HoneyComb.jupiter"
             ) 
         Specialty = DropsList(
-		    10% I:dreamcraft:"item.IoStoneDust"
-			)
+            10% I:dreamcraft:"item.IoStoneDust"
+	    )
         cfg Traits {
             Base = "forestry.speciesCultivated"
             }
@@ -2414,9 +2415,9 @@ cfg Bees {
             25% S:gendustry:"HoneyComb.jupiter"
             ) 
         Specialty = DropsList(
-		    10% I:dreamcraft:"item.EuropaStoneDust"
-			10% I:dreamcraft:"item.EuropaIceDust"
-			)
+	    10% I:dreamcraft:"item.EuropaStoneDust"
+	    10% I:dreamcraft:"item.EuropaIceDust"
+	    )
         cfg Traits {
             Base = "forestry.speciesCultivated"
             }
@@ -2438,8 +2439,8 @@ cfg Bees {
             25% S:gendustry:"HoneyComb.jupiter"
             ) 
         Specialty = DropsList(
-		    10% I:dreamcraft:"item.GanymedStoneDust"
-			)
+            10% I:dreamcraft:"item.GanymedStoneDust"
+	    )
         cfg Traits {
             Base = "forestry.speciesCultivated"
             }
@@ -2461,9 +2462,9 @@ cfg Bees {
             25% S:gendustry:"HoneyComb.jupiter"
             ) 
         Specialty = DropsList(
-		    10% I:dreamcraft:"item.CallistoStoneDust"
-			10% I:dreamcraft:"item.CallistoIceDust"
-			)
+	    10% I:dreamcraft:"item.CallistoStoneDust"
+	    10% I:dreamcraft:"item.CallistoIceDust"
+	    )
         cfg Traits {
             Base = "forestry.speciesCultivated"
             }
@@ -2551,9 +2552,9 @@ cfg Bees {
             25% S:gendustry:"HoneyComb.saturn"
             ) 
         Specialty = DropsList(
-		    10% I:dreamcraft:"item.EnceladusStoneDust"
-			10% I:dreamcraft:"item.EnceladusIceDust"
-			)
+	    10% I:dreamcraft:"item.EnceladusStoneDust"
+	    10% I:dreamcraft:"item.EnceladusIceDust"
+	    )
         cfg Traits {
             Base = "forestry.speciesCultivated"
             }
@@ -2575,8 +2576,8 @@ cfg Bees {
             25% S:gendustry:"HoneyComb.saturn"
             ) 
         Specialty = DropsList(
-		    10% I:dreamcraft:"item.TitanStoneDust"
-			)
+	    10% I:dreamcraft:"item.TitanStoneDust"
+	    )
         cfg Traits {
             Base = "forestry.speciesCultivated"
             }
@@ -2598,9 +2599,9 @@ cfg Bees {
             50% S:gendustry:"HoneyComb.uranus"
             ) 
         Specialty = DropsList(
-			10% I:dreamcraft:"item.MirandaStoneDust"
-			10% I:dreamcraft:"item.OberonStoneDust"
-			)
+	    10% I:dreamcraft:"item.MirandaStoneDust"
+	    10% I:dreamcraft:"item.OberonStoneDust"
+	    )
         cfg Traits {
             Base = "forestry.speciesCultivated"
             }
@@ -2622,8 +2623,8 @@ cfg Bees {
             25% S:gendustry:"HoneyComb.uranus"
             ) 
         Specialty = DropsList(
-		    10% I:dreamcraft:"item.MirandaStoneDust"
-			)
+	    10% I:dreamcraft:"item.MirandaStoneDust"
+	    )
         cfg Traits {
             Base = "forestry.speciesCultivated"
             }
@@ -2645,8 +2646,8 @@ cfg Bees {
             25% S:gendustry:"HoneyComb.uranus"
             ) 
         Specialty = DropsList(
-		    10% I:dreamcraft:"item.OberonStoneDust"
-			)
+	    10% I:dreamcraft:"item.OberonStoneDust"
+	    )
         cfg Traits {
             Base = "forestry.speciesCultivated"
             }
@@ -2668,9 +2669,9 @@ cfg Bees {
             50% S:gendustry:"HoneyComb.neptune"
             ) 
         Specialty = DropsList(
-			10% I:dreamcraft:"item.TritonStoneDust"
-			10% I:dreamcraft:"item.ProteusStoneDust"
-			)
+	    10% I:dreamcraft:"item.TritonStoneDust"
+	    10% I:dreamcraft:"item.ProteusStoneDust"
+	    )
         cfg Traits {
             Base = "forestry.speciesCultivated"
             }
@@ -2692,8 +2693,8 @@ cfg Bees {
             25% S:gendustry:"HoneyComb.neptune"
             ) 
         Specialty = DropsList(
-			10% I:dreamcraft:"item.TritonStoneDust"
-			)
+	    10% I:dreamcraft:"item.TritonStoneDust"
+	    )
         cfg Traits {
             Base = "forestry.speciesCultivated"
             }
@@ -2715,8 +2716,8 @@ cfg Bees {
             25% S:gendustry:"HoneyComb.neptune"
             ) 
         Specialty = DropsList(
-				10% I:dreamcraft:"item.ProteusStoneDust"
-			)
+	    10% I:dreamcraft:"item.ProteusStoneDust"
+	    )
         cfg Traits {
             Base = "forestry.speciesCultivated"
             }
@@ -2738,9 +2739,9 @@ cfg Bees {
             50% S:gendustry:"HoneyComb.pluto"
             ) 
         Specialty = DropsList(
-			10% I:dreamcraft:"item.PlutoIceDust"
-			10% I:dreamcraft:"item.PlutoStoneDust"
-			)
+	    10% I:dreamcraft:"item.PlutoIceDust"
+	    10% I:dreamcraft:"item.PlutoStoneDust"
+	    )
         cfg Traits {
             Base = "forestry.speciesCultivated"
             }
@@ -2828,9 +2829,9 @@ cfg Bees {
             25% S:gendustry:"HoneyComb.centauri"
             ) 
         Specialty = DropsList(
-		    10% I:dreamcraft:"item.CentauriAStoneDust"
-			10% I:dreamcraft:"item.CentauriASurfaceDust"
-			)
+	    10% I:dreamcraft:"item.CentauriAStoneDust"
+	    10% I:dreamcraft:"item.CentauriASurfaceDust"
+	    )
         cfg Traits {
             Base = "forestry.speciesCultivated"
             }
@@ -2874,9 +2875,9 @@ cfg Bees {
             25% S:gendustry:"HoneyComb.tceti"
             ) 
         Specialty = DropsList(		    		   
-			0.001% I:dreamcraft:"item.TCetiESeaweedExtract"
-			10% I:dreamcraft:"item.TCetiEStoneDust"
-			)
+	    0.001% I:dreamcraft:"item.TCetiESeaweedExtract"
+	    10% I:dreamcraft:"item.TCetiEStoneDust"
+	    )
         cfg Traits {
             Base = "forestry.speciesCultivated"
             }
@@ -2942,8 +2943,8 @@ cfg Bees {
             50% S:gendustry:"HoneyComb.barnarda"
             ) 
         Specialty = DropsList(
-			10% I:dreamcraft:"item.BarnardaEStoneDust"
-			)
+	    10% I:dreamcraft:"item.BarnardaEStoneDust"
+	    )
         cfg Traits {
             Base = "forestry.speciesCultivated"
             }
@@ -2965,8 +2966,8 @@ cfg Bees {
             50% S:gendustry:"HoneyComb.barnarda"
             ) 
         Specialty = DropsList(
-			10% I:dreamcraft:"item.BarnardaFStoneDust"
-			)
+	    10% I:dreamcraft:"item.BarnardaFStoneDust"
+	    )
         cfg Traits {
             Base = "forestry.speciesCultivated"
             }
@@ -3010,8 +3011,8 @@ cfg Bees {
             25% S:gendustry:"HoneyComb.vega"
             ) 
         Specialty = DropsList(
-			10% I:dreamcraft:"item.VegaBStoneDust"			
-			)
+	    10% I:dreamcraft:"item.VegaBStoneDust"			
+	    )
         cfg Traits {
             Base = "forestry.speciesCultivated"
             }
@@ -3283,7 +3284,7 @@ centrifuge: S:gendustry:"HoneyComb.lignite", 30 cycles => {
 } 
 
 centrifuge: S:gendustry:"HoneyComb.coal", 40 cycles => {
-    100% I:gregtech:"gt.metaitem.01"@535  //tiny coal dust
+    100% I:gregtech:"gt.metaitem.01"@535  // Tiny Pile of Coal Dust
     5% S:minecraft:coal
     70% S:Forestry:beeswax
 }
@@ -3353,12 +3354,12 @@ centrifuge: S:gendustry:"HoneyComb.electricalsteel", 40 cycles => {
 // Thaumium Line
 
 centrifuge: S:gendustry:"HoneyComb.thaumiumshard", 40 cycles => {
-    5% I:MagicBees:propolis@1 // Air Propolis
-    5% I:MagicBees:propolis@2 // Fire Propolis
-    5% I:MagicBees:propolis@3 // Water Propolis    
-    5% I:MagicBees:propolis@4 // Earth Propolis
-    5% I:MagicBees:propolis@5 // Order Propolis
-    5% I:MagicBees:propolis@6 // Entropy Propolis
+    20% I:MagicBees:propolis@1 // Air Propolis
+    20% I:MagicBees:propolis@2 // Fire Propolis
+    20% I:MagicBees:propolis@3 // Water Propolis    
+    20% I:MagicBees:propolis@4 // Earth Propolis
+    20% I:MagicBees:propolis@5 // Order Propolis
+    20% I:MagicBees:propolis@6 // Entropy Propolis
 }
 
 //centrifuge: S:gendustry:"HoneyComb.thaumiumdust", 40 cycles => {
@@ -3389,22 +3390,26 @@ centrifuge: S:gendustry:"HoneyComb.tainted", 40 cycles => {
 // Gem Line
 centrifuge: S:gendustry:"HoneyComb.stone", 40 cycles => {
     70% I:gregtech:"gt.metaitem.01"@2299 //Stone Dust
-    30% S:Forestry:beeswax
+    50% I:gregtech:"gt.metaitem.01"@2844 //Basalt Dust
+    50% I:gregtech:"gt.metaitem.01"@2845 //Marble Dust
+    50% I:gregtech:"gt.metaitem.01"@2846 //Redrock Dust
+    50% I:gregtech:"gt.metaitem.01"@2849 //Black Granite Dust
+    50% I:gregtech:"gt.metaitem.01"@2850 //Red Granite Dust
 } 
 
 centrifuge: S:gendustry:"HoneyComb.certus", 40 cycles => {
-    100% I:gregtech:"gt.metaitem.01"@516 // Tiny Certus Dust
+    80% I:gregtech:"gt.metaitem.01"@2516 // Certus Dust
     50% I:gregtech:"gt.metaitem.01"@904 // Tiny Pile of Barite Dust
     30% S:Forestry:beeswax
 } 
 
 centrifuge: S:gendustry:"HoneyComb.fluix", 40 cycles => {
-    13% I:appliedenergistics2:"item.ItemMultiMaterial"@8 //Fluix Dust
+    25% I:appliedenergistics2:"item.ItemMultiMaterial"@8 //Fluix Dust
     30% S:Forestry:beeswax
 } 
 
 centrifuge: S:gendustry:"HoneyComb.redstone", 40 cycles => {
-    100% I:gregtech:"gt.metaitem.01"@810 // Tiny Pile of redstone
+    100% S:minecraft:redstone // Redstone
     30% S:Forestry:beeswax
 }
 
@@ -3414,26 +3419,26 @@ centrifuge: S:gendustry:"HoneyComb.rareearth", 40 cycles => {
 }
 
 centrifuge: S:gendustry:"HoneyComb.lapis", 40 cycles => {
-    100% I:gregtech:"gt.metaitem.01"@526 // Tiny Pile of lapis
-    20% I:gregtech:"gt.metaitem.01"@525 // Tiny Pile of sodalite
-	20% I:gregtech:"gt.metaitem.01"@524 // Tiny Pile of lazurite
+    100% I:gregtech:"gt.metaitem.01"@2526 // Lapis Dust
+    60% I:gregtech:"gt.metaitem.01"@2525 // Sodalite Dust
+    80% I:gregtech:"gt.metaitem.01"@2524 // Lazurite Dust
     30% S:Forestry:beeswax
 }
 
 centrifuge: S:gendustry:"HoneyComb.ruby", 40 cycles => {
-    100% I:gregtech:"gt.metaitem.01"@502 // Tiny Pile of ruby
+    100% I:gregtech:"gt.metaitem.01"@502 // Tiny Pile of Ruby Dust
     30% S:Forestry:beeswax
 }
 
 centrifuge: S:gendustry:"HoneyComb.sapphire", 40 cycles => {
-    50% I:gregtech:"gt.metaitem.01"@503 // Tiny Pile of blue Sapphire
-    50% I:gregtech:"gt.metaitem.01"@504 // Tiny Pile of green Sapphire
+    50% I:gregtech:"gt.metaitem.01"@503 // Tiny Pile of Blue Sapphire Dust
+    50% I:gregtech:"gt.metaitem.01"@504 // Tiny Pile of Green Sapphire Dust
     30% S:Forestry:beeswax
 }
 
 centrifuge: S:gendustry:"HoneyComb.diamond", 40 cycles => {
     100% I:gregtech:"gt.metaitem.01"@500 // Tiny Pile of Diamond Dust
-    20% I:gregtech:"gt.metaitem.01"@865 // Tiny Pile of Graphite Dust
+    75% I:gregtech:"gt.metaitem.01"@865 // Tiny Pile of Graphite Dust
     30% S:Forestry:beeswax
 }
 
@@ -3448,22 +3453,22 @@ centrifuge: S:gendustry:"HoneyComb.emerald", 40 cycles => {
 }
 
 centrifuge: S:gendustry:"HoneyComb.redgarnet", 40 cycles => {
-    90% I:gregtech:"gt.metaitem.01"@527 // Tiny Pile of Red Garnet
+    100% I:gregtech:"gt.metaitem.01"@527 // Tiny Pile of Red Garnet Dust
     30% S:Forestry:beeswax
 }
 
 centrifuge: S:gendustry:"HoneyComb.pyrope", 40 cycles => {
-    90% I:gregtech:"gt.metaitem.01"@835 // Tiny Pile of Pyrope Dust
+    100% I:gregtech:"gt.metaitem.01"@835 // Tiny Pile of Pyrope Dust
     30% S:Forestry:beeswax
 }
 
 centrifuge: S:gendustry:"HoneyComb.yellowgarnet", 40 cycles => {
-    80% I:gregtech:"gt.metaitem.01"@528 // Tiny Pile of Yellow Garnet
+    100% I:gregtech:"gt.metaitem.01"@528 // Tiny Pile of Yellow Garnet Dust
     30% S:Forestry:beeswax	
 }
 
 centrifuge: S:gendustry:"HoneyComb.grossular", 40 cycles => {
-    100% I:gregtech:"gt.metaitem.01"@831 // Tiny Pile of Grossular Dust
+    100% I:gregtech:"gt.metaitem.01"@831 // Tiny Pile of Grossular Dust Dust
     30% S:Forestry:beeswax	
 }
 
@@ -3480,207 +3485,206 @@ centrifuge: S:gendustry:"HoneyComb.slag", 40 cycles => {
 }
 
 centrifuge: S:gendustry:"HoneyComb.copperdust", 40 cycles => {
-    100% I:gregtech:"gt.metaitem.01"@35 // tiny pile of copper
+    100% I:gregtech:"gt.metaitem.01"@35 // Tiny Pile of Copper Dust
     30% I:Forestry:beeswax
 }
 
 centrifuge: S:gendustry:"HoneyComb.tindust", 40 cycles => {
-    100% I:gregtech:"gt.metaitem.01"@57 // tiny pile of tin
+    100% I:gregtech:"gt.metaitem.01"@57 // Tiny Pile of Tin Dust
     30% I:Forestry:beeswax
 }
 
 centrifuge: S:gendustry:"HoneyComb.leaddust", 40 cycles => {
-    100% I:gregtech:"gt.metaitem.01"@89 // tiny pile of lead
+    100% I:gregtech:"gt.metaitem.01"@89 // Tiny Pile of Lead Dust
     30% I:Forestry:beeswax
 }
 
 centrifuge: S:gendustry:"HoneyComb.sulfurdust", 40 cycles => {
-    100% I:gregtech:"gt.metaitem.01"@22 // tiny pile of sulfur
+    100% I:gregtech:"gt.metaitem.01"@22 // Tiny Pile of Sulfur Dust
     30% I:Forestry:beeswax
 }
 
 centrifuge: S:gendustry:"HoneyComb.irondust", 40 cycles => {
-    100% I:gregtech:"gt.metaitem.01"@32 // tiny pile of iron
+    100% I:gregtech:"gt.metaitem.01"@32 // Tiny Pile of Iron Dust
     30% I:Forestry:beeswax
 }
 
 centrifuge: S:gendustry:"HoneyComb.steeldust", 40 cycles => {
-    100% I:gregtech:"gt.metaitem.01"@305 // tiny pile of steel
+    100% I:gregtech:"gt.metaitem.01"@305 // Tiny Pile of Steel Dust
     30% I:Forestry:beeswax
 }
 
 centrifuge: S:gendustry:"HoneyComb.nickeldust", 40 cycles => {
-    100% I:gregtech:"gt.metaitem.01"@34 // tiny pile of nickel
+    100% I:gregtech:"gt.metaitem.01"@34 // Tiny Pile of Nickel Dust
     30% I:Forestry:beeswax
 }
 
 centrifuge: S:gendustry:"HoneyComb.zincdust", 40 cycles => {
-    100% I:gregtech:"gt.metaitem.01"@36 // tiny pile of zinc
+    100% I:gregtech:"gt.metaitem.01"@36 // Tiny Pile of Zinc Dust
     30% I:Forestry:beeswax
 }
 
 centrifuge: S:gendustry:"HoneyComb.galliumdust", 40 cycles => {
-    70% I:gregtech:"gt.metaitem.01"@37 // tiny pile of gallium
+    70% I:gregtech:"gt.metaitem.01"@37 // Tiny Pile of Gallium Dust
     30% I:Forestry:beeswax
 }
 
 centrifuge: S:gendustry:"HoneyComb.silverdust", 40 cycles => {
-    100% I:gregtech:"gt.metaitem.01"@54 // tiny pile of silver
+    100% I:gregtech:"gt.metaitem.01"@54 // Tiny Pile of Silver Dust
     30% I:Forestry:beeswax
 }
 
 centrifuge: S:gendustry:"HoneyComb.golddust", 40 cycles => {
-    100% I:gregtech:"gt.metaitem.01"@86 // tiny pile of gold
+    100% I:gregtech:"gt.metaitem.01"@86 // Tiny Pile of Gold Dust
     30% I:Forestry:beeswax
 }
 
 centrifuge: S:gendustry:"HoneyComb.arsenicdust", 40 cycles => {
-    80% I:gregtech:"gt.metaitem.01"@39 // tiny pile of arsic
+    80% I:gregtech:"gt.metaitem.01"@39 // Tiny Pile of Arsenic Dust
     30% I:Forestry:beeswax
 }
 
+centrifuge: S:gendustry:"HoneyComb.aluminium", 40 cycles => {
+    100% I:gregtech:"gt.metaitem.01"@19 // Tiny Pile of Aluminium Dust
+    30% I:Forestry:beeswax
+}
 
 // Rare Metals
 
-centrifuge: S:gendustry:"HoneyComb.aluminium", 40 cycles => {
-    50% I:gregtech:"gt.metaitem.01"@19 // tiny pile of aluminium
-    30% I:Forestry:beeswax
-}
-
 centrifuge: S:gendustry:"HoneyComb.bauxite", 40 cycles => {
-    50% I:gregtech:"gt.metaitem.01"@822 // tiny pile bauxite
+    50% I:gregtech:"gt.metaitem.01"@822 // Tiny Pile of Bauxite Dust
     30% I:Forestry:beeswax
 }
 
 centrifuge: S:gendustry:"HoneyComb.manganese", 40 cycles => {
-    50% I:gregtech:"gt.metaitem.01"@31 // tiny pile of manganese
+    50% I:gregtech:"gt.metaitem.01"@31 // Tiny Pile of Manganese Dust
     30% I:Forestry:beeswax
 }
 
 //centrifuge: S:gendustry:"HoneyComb.titanium", 40 cycles => {
-//  50% I:gregtech:"gt.metaitem.01"@28 // tiny pile of titanium
+//  50% I:gregtech:"gt.metaitem.01"@28 // Tiny Pile of Titanium Dust
 //  30% I:Forestry:beeswax
 //}
 
 centrifuge: S:gendustry:"HoneyComb.almandine", 40 cycles => {
-    50% I:gregtech:"gt.metaitem.01"@820 // tiny pile of almandine
+    50% I:gregtech:"gt.metaitem.01"@820 // Tiny Pile of Almandine Dust
     30% I:Forestry:beeswax
 }
 
 //centrifuge: S:gendustry:"HoneyComb.chrome", 40 cycles => {
-//  50% I:gregtech:"gt.metaitem.01"@30 // tiny pile of chrome
+//  50% I:gregtech:"gt.metaitem.01"@30 // Tiny Pile of Chrome Dust
 //  30% I:Forestry:beeswax
 //}
 
 centrifuge: S:gendustry:"HoneyComb.magnesium", 40 cycles => {
-    50% I:gregtech:"gt.metaitem.01"@18 // tiny pile of magnesium
+    50% I:gregtech:"gt.metaitem.01"@18 // Tiny Pile of Magnesium Dust
     30% I:Forestry:beeswax
 }
 
 //centrifuge: S:gendustry:"HoneyComb.tungsten", 40 cycles => {
-//  50% I:gregtech:"gt.metaitem.01"@81 // tiny pile of tungsten
+//  50% I:gregtech:"gt.metaitem.01"@81 // Tiny Pile of Tungsten Dust
 //  30% I:Forestry:beeswax
 //}
 
 centrifuge: S:gendustry:"HoneyComb.molybdenum", 40 cycles => {
-    50% I:gregtech:"gt.metaitem.01"@48 // tiny pile of molybdenum
+    50% I:gregtech:"gt.metaitem.01"@48 // Tiny Pile of Molybdenum Dust
     30% I:Forestry:beeswax
 }
 
 //centrifuge: S:gendustry:"HoneyComb.platinum", 40 cycles => {
-//  50% I:gregtech:"gt.metaitem.01"@85 // tiny pile of platinum
+//  50% I:gregtech:"gt.metaitem.01"@85 // Tiny Pile of Platinum Dust
 //  30% I:Forestry:beeswax
 //}
 
 //centrifuge: S:gendustry:"HoneyComb.iridium", 40 cycles => {
-//  20% I:gregtech:"gt.metaitem.01"@84 // tiny pile of iridium
-//  8% I:gregtech:"gt.metaitem.01"@83 // tiny pile of osmium
+//  20% I:gregtech:"gt.metaitem.01"@84 // Tiny Pile of Iridium Dust
+//  8% I:gregtech:"gt.metaitem.01"@83 // Tiny Pile of Osmium Dust
 //  30% I:Forestry:beeswax
 //}
 
 //centrifuge: S:gendustry:"HoneyComb.osmium", 40 cycles => {
-//  20% I:gregtech:"gt.metaitem.01"@83 // tiny pile of osmium
-//  10% I:gregtech:"gt.metaitem.01"@84 // tiny pile of iridium
+//  20% I:gregtech:"gt.metaitem.01"@83 // Tiny Pile of Osmium Dust
+//  10% I:gregtech:"gt.metaitem.01"@84 // Tiny Pile of Iridium Dust
 //  30% I:Forestry:beeswax
 //}
 
 // Radioactive Line
 
 //centrifuge: S:gendustry:"HoneyComb.uranium", 40 cycles => {
-//  25% I:gregtech:"gt.metaitem.01"@98  // tiny pile of uranium 238
-//	5% I:gregtech:"gt.metaitem.01"@97  // tiny pile of uranium 235
+//  25% I:gregtech:"gt.metaitem.01"@98  // Tiny Pile of Uranium 238 Dust
+//	5% I:gregtech:"gt.metaitem.01"@97  // Tiny Pile of Uranium 235 Dust
 //  30% I:Forestry:beeswax
 //}
 
 //centrifuge: S:gendustry:"HoneyComb.plutonium", 40 cycles => {
-//  16% I:gregtech:"gt.metaitem.01"@100 //tiny plutonium dust 244
-//	 4% I:gregtech:"gt.metaitem.01"@101 //tiny plutonium dust 241
+//  16% I:gregtech:"gt.metaitem.01"@100 // Tiny Pile of Plutonium 244 Dust
+//	 4% I:gregtech:"gt.metaitem.01"@101 // Tiny Pile of Plutonium 241 Dust
 //  30% I:Forestry:beeswax
 //}
 
 //centrifuge: S:gendustry:"HoneyComb.naquada", 40 cycles => {
-//  20% I:gregtech:"gt.metaitem.01"@324 //tiny Naquada dust
-//   5% I:gregtech:"gt.metaitem.01"@326 //tiny Enriched Naquada dust    
+//  20% I:gregtech:"gt.metaitem.01"@324 // Tiny Pile of Naquadah Dust
+//   5% I:gregtech:"gt.metaitem.01"@326 // Tiny Pile of Enriched Naquadah Dust    
 //    30% I:Forestry:beeswax
 //}
 
 //centrifuge: S:gendustry:"HoneyComb.naquadria", 40 cycles => {
-//  50% I:gregtech:"gt.metaitem.01"@324 //tiny Naquada dust
-//  15% I:gregtech:"gt.metaitem.01"@326 //tiny Enriched Naquada dust
-//   5% I:gregtech:"gt.metaitem.01"@327 //tiny Naquadria dust       
+//  50% I:gregtech:"gt.metaitem.01"@324 // Tiny Pile of Naquadah Dust
+//  15% I:gregtech:"gt.metaitem.01"@326 // Tiny Pile of Enriched Naquadah Dust
+//   5% I:gregtech:"gt.metaitem.01"@327 // Tiny Pile of Naquadria Dust       
 //  30% I:Forestry:beeswax
 //}
 
 centrifuge: S:gendustry:"HoneyComb.DOB", 40 cycles =>{
     15% S:IC2:itemHarz //Sticky Resen
     1% S:IC2:itemFuelPlantBall //Plant Ball
-	15% I:gregtech:"gt.metaitem.01"@2538
-	15% I:gregtech:"gt.metaitem.01"@535  //tiny coal dust
-    15% S:minecraft:coal
-	15% I:gendustry:HoneyDrop@2000
-	15% I:gregtech:"gt.metaitem.01"@308 
-	1% I:EnderIO:itemAlloy@1
-	15% I:EnderIO:itemMaterial@4
-	15% I:EnderIO:itemMaterial@3 
-	1% I:Thaumcraft:ItemShard // Air Shard
+    15% I:gregtech:"gt.metaitem.01"@2538 //Lignite Dust
+    15% I:gregtech:"gt.metaitem.01"@535  //Tiny pile of Coal Dust
+    15% S:minecraft:coal //Coal
+    15% I:gendustry:HoneyDrop@2000 //Honey Drop
+    15% I:gregtech:"gt.metaitem.01"@308 // Tiny Pile of Red Alloy Dust
+    1% I:EnderIO:itemAlloy@1 // Energetic Alloy Ingot
+    15% I:EnderIO:itemMaterial@4 // Vibrant Alloy Nugget
+    15% I:EnderIO:itemMaterial@3 // Pulsating Iron Nugget
+    1% I:Thaumcraft:ItemShard // Air Shard
     1% I:Thaumcraft:ItemShard@1 // Fire Shard
     1% I:Thaumcraft:ItemShard@2 // Water Shard    //slim all down -ALOT
     1% I:Thaumcraft:ItemShard@3 // Earth Shard
     1% I:Thaumcraft:ItemShard@4 // Order Shard
     1% I:Thaumcraft:ItemShard@5 // Entropy Shard
     1% I:Thaumcraft:ItemShard@6 // Balanced Shard
-	15% I:gregtech:"gt.metaitem.01"@330
-	7% I:gregtech:"gt.metaitem.01"@2299
-	15% I:gregtech:"gt.metaitem.01"@516
-	1% I:appliedenergistics2:"item.ItemMultiMaterial"@8 
-	15% I:gregtech:"gt.metaitem.01"@810
-	15% I:gregtech:"gt.metaitem.01"@526
-	15% I:gregtech:"gt.metaitem.01"@502
-	5% I:gregtech:"gt.metaitem.01"@503 // Tiny Pile of blue Sapphire
-    5% I:gregtech:"gt.metaitem.01"@504 
-	15% I:gregtech:"gt.metaitem.01"@500
-	15% I:gregtech:"gt.metaitem.01"@505 
-	15% I:gregtech:"gt.metaitem.01"@501
-	15% I:gregtech:"gt.metaitem.01"@35
-	15% I:gregtech:"gt.metaitem.01"@57 
-	15% I:gregtech:"gt.metaitem.01"@89
-	15% I:gregtech:"gt.metaitem.01"@32 
-	15% I:gregtech:"gt.metaitem.01"@305
-	15% I:gregtech:"gt.metaitem.01"@34
-	15% I:gregtech:"gt.metaitem.01"@36
-	15% I:gregtech:"gt.metaitem.01"@54
-	15% I:gregtech:"gt.metaitem.01"@86 
-	5% I:gregtech:"gt.metaitem.01"@19
-	5% I:gregtech:"gt.metaitem.01"@31 
-	5% I:gregtech:"gt.metaitem.01"@28
-	5% I:gregtech:"gt.metaitem.01"@30
-	5% I:gregtech:"gt.metaitem.01"@81
-	5% I:gregtech:"gt.metaitem.01"@85
-	5% I:gregtech:"gt.metaitem.01"@84 // tiny pile of iridium
-    1% I:gregtech:"gt.metaitem.01"@83 
-	5% I:gregtech:"gt.metaitem.01"@97
-	4% I:gregtech:"gt.metaitem.01"@10 
-	3% I:gregtech:"gt.metaitem.01"@324 
+    15% I:gregtech:"gt.metaitem.01"@330 // Tiny Pile of Thaumium Dust
+    7% I:gregtech:"gt.metaitem.01"@2299 // Stone Dust
+    15% I:gregtech:"gt.metaitem.01"@516 // Tiny Pile of Certus Quartz Dust
+    1% I:appliedenergistics2:"item.ItemMultiMaterial"@8 // Fluix Dust
+    15% I:gregtech:"gt.metaitem.01"@810 // Tiny Pile of Redstone Dust
+    15% I:gregtech:"gt.metaitem.01"@526 // Tiny Pile of Lapis Dust
+    15% I:gregtech:"gt.metaitem.01"@502 // Tiny Pile of Ruby Dust
+    5% I:gregtech:"gt.metaitem.01"@503 // Tiny Pile of Blue Sapphire Dust
+    5% I:gregtech:"gt.metaitem.01"@504 // Tiny Pile of Green Sapphire Dust
+    15% I:gregtech:"gt.metaitem.01"@500 // Tiny Pile of Diamond Dust
+    15% I:gregtech:"gt.metaitem.01"@505 // Tiny Pile of Olivine Dust
+    15% I:gregtech:"gt.metaitem.01"@501 // Tiny Pile of Emerald Dust
+    15% I:gregtech:"gt.metaitem.01"@35 // Tiny Pile of Copper Dust
+    15% I:gregtech:"gt.metaitem.01"@57 // Tiny Pile of Tin Dust
+    15% I:gregtech:"gt.metaitem.01"@89 // Tiny Pile of Lead Dust
+    15% I:gregtech:"gt.metaitem.01"@32 // Tiny Pile of Iron Dust
+    15% I:gregtech:"gt.metaitem.01"@305 // Tiny Pile of Steel Dust
+    15% I:gregtech:"gt.metaitem.01"@34 // Tiny Pile of Nickel Dust
+    15% I:gregtech:"gt.metaitem.01"@36 // Tiny Pile of Zinc Dust
+    15% I:gregtech:"gt.metaitem.01"@54 // Tiny Pile of Silver Dust
+    15% I:gregtech:"gt.metaitem.01"@86 // Tiny Pile of Gold Dust
+    5% I:gregtech:"gt.metaitem.01"@19 // Tiny Pile of Aluminium Dust
+    5% I:gregtech:"gt.metaitem.01"@31 // Tiny Pile of Manganese Dust
+    5% I:gregtech:"gt.metaitem.01"@28 // Tiny Pile of Titanium Dust
+    5% I:gregtech:"gt.metaitem.01"@30 // Tiny Pile of Chrome Dust
+    5% I:gregtech:"gt.metaitem.01"@81 // Tiny Pile of Tungsten Dust
+    5% I:gregtech:"gt.metaitem.01"@85 // Tiny Pile of Platinum Dust
+    5% I:gregtech:"gt.metaitem.01"@84 // Tiny Pile of Iridium Dust
+    1% I:gregtech:"gt.metaitem.01"@83 // Tiny Pile of Osmium 
+    5% I:gregtech:"gt.metaitem.01"@97 // Tiny Pile of Uranium 235 Dust
+    4% I:gregtech:"gt.metaitem.01"@10 // Tiny Pile of Carbon Dust
+    3% I:gregtech:"gt.metaitem.01"@324 // Tiny Pile of Naquadah Dust
 
 }
 
@@ -3722,7 +3726,7 @@ centrifuge: S:gendustry:"HoneyComb.DOB", 40 cycles =>{
 
 // <~~~~~~~~~~~~~~~~~~~~~~~~~ Custom Squeezer Recipes  ~~~~~~~~~~~~~~~~~~~~~~~~>
 
-squeezer: I:gendustry:HoneyDrop@2000 , 200 cycles => oil 100 mb + 30% S:Forestry:propolis
+squeezer: I:gendustry:HoneyDrop@2000 , 200 cycles => liquid_heavy_oil 100 mb + 30% S:Forestry:propolis
 squeezer: I:gendustry:HoneyDrop@2002 , 200 cycles => ic2coolant 100 mb + 30% S:ExtraBees:propolis
 squeezer: I:gendustry:HoneyDrop@2003 , 200 cycles => ic2hotcoolant 100 mb + 30% I:MagicBees:propolis@2
 squeezer: I:gendustry:HoneyDrop@2004 , 200 cycles => fieryblood 50 mb + 30% I:MagicBees:propolis@2
@@ -3796,7 +3800,6 @@ mutation: 7% "gendustry.bee.ThaumiumShard" + "gendustry.bee.SalisMundus" => "gen
 //new
 mutation: 8% "magicbees.speciesTCOrder" + "gendustry.bee.ThaumiumDust" => "gendustry.bee.Thauminite" Req Block B:thaumicbases:thauminiteBlock
 mutation: 6% "magicbees.speciesTCChaos" + "magicbees.speciesTCVoid" => "gendustry.bee.Shadowmetal" Req Block B:TaintedMagic:BlockShadowmetal
-mutation: 3% "gendustry.bee.Platinum" + "gendustry.bee.ThaumiumDust" => "gendustry.bee.Mithril" Req Block B:gregtech:"gt.blockmetal4"@10
 mutation: 3% "gendustry.bee.Silver" + "gendustry.bee.Iron" => "gendustry.bee.AstralSilver" Req Block B:gregtech:"gt.blockmetal1"@6
 mutation: 2% "gendustry.bee.Diamond" + "gendustry.bee.Iron" => "gendustry.bee.Divided" Req Block B:ExtraUtilities:"decorativeBlock1"@5
 mutation: 1% "magicbees.speciesWithering" + "magicbees.speciesDraconic"  => "gendustry.bee.Sparkling" Req Block B:gregtech:"gt.blockgem3"@3 Req Biome Sky


### PR DESCRIPTION
Made Redstone Comb not a Special Product for Redstone Bees. 
Made Aluminium Comb not a Special Product for Aluminium Bees.
Changed output of Firestone Comb to 15%.
Increased Shard Comb output to 20%.
Added Basalt, Marble, Redrock, Red Granite, Black Granite to Stone Comb output (50%).
Changed output of Certus Comb to Certus Dust (80%).
Changed the output of Fluix Comb to Fluix Dust (25%).
Changed output of Redstone Comb to Redstone Dust (100%).
Changed output of Lapis Comb to Lapis Dust (100%), Lazurite Dust (80%) and Sodalite Dust (60%).
Changed output of Tiny Pile of Graphite Dust to 75% from Diamond Comb.
Changed output of Red/Yellow Garnet Comb, Pyrope Comb and Grossular Comb to 100% for main outputs.