### PR TITLE
Moron quest update q42018

### DIFF
--- a/config/betterquesting/Readme.md
+++ b/config/betterquesting/Readme.md
@@ -1,0 +1,17 @@
+# Updating the quests file #
+
+The quests file is now localized for different languages.  To do edits, copy the file DefaultQuests.json out of your git repo NewHorizons\config\betterquesting into the modpack config directory.  
+
+Delete the DefaultDatabase.json file in the world save (or create a new world).  
+
+Use `/bq_admin edit` to enable edit mode. 
+
+When editting quests, make sure that requirements are generally set to Retrieval and Consume: False. Update the quest icon. Change the Show setting to Unlocked. If you think it is a main quest that players should perform, mark it as main.  Link the requirements quests to your new quest. Add some appropriate rewards.
+
+Use `/bq_admin edit` to disable edit mode.
+
+When you have completed the changes, capture them from the modpack\saves\[world name]\QuestDatabase.json file and put them back into the DefaultQuests.json file in the repo.
+
+It's a good idea to do a compare vs the QuestDatabase.json file and the DefaultQuests.json file.  The only changes should be the changes you added.  Make sure you didn't leave the Edit mode enabled. A good tool to compare the files is Beyond Compare from http://www.scootersoftware.com .
+
+Once you have commited your DefaultQuests.json file, notify DreammasterXXL and he will accept your pull request and generate an updated en_US.lang file.


### PR DESCRIPTION
Major update with new IC2 quests and PTFE quests.  Re-ararnged some quests to make better sense. Fixed minor typos. Added super tank 2 and 3 quests. Addeed some more info for newbies to understand pipes and water generation. Added printer quest for Seismic Prospector. Added info on steam outputs cannot be blocked. Removed outdated oil cracker info. Added info on more ways to get gallium and arsenic.

Added readme.md file to BQ config directory with instructions on how to use it.  Plz keep up to date.