### PR TITLE
Updated IFU config with blacklisted blocks to prevent mineshaft/dunge…

### DIFF
--- a/config/GregTech/GregTech.cfg
+++ b/config/GregTech/GregTech.cfg
@@ -79,7 +79,7 @@ general {
     B:online=true
     I:oreveinAttempts_64=64
     I:oreveinMaxPlacementAttempts_8=8
-    I:oreveinPercentage_75=75
+    I:oreveinPercentage_75=100
     B:show_all_metaitems_in_creative_and_NEI=false
     B:smallerVanillaToolDurability=true
     B:sound_multi_threading=false

--- a/config/ifu.cfg
+++ b/config/ifu.cfg
@@ -3,6 +3,12 @@
 general {
     # List of GT ores that can't be readed by ore Finder. Use block unlocalizedName f.e. "gt.blockores.27" [default: ]
     S:"Blacklist " <
+    tile.rail
+    tile.fence
+    tile.stoneMoss
+    tile.chest
+    tile.torch
+    tile.endPortalFrame
      >
 
     # If true Ore finder Will play sounds [default: true]


### PR DESCRIPTION
…on exploiting. Updated gregtech orevein percentage to 100 in prep for changes.

seismic prospector - added that it also finds ores.
added quest that tells you ball of moss is not shown because of thaumcraft
Added quest talking about alternatives to aluminium gravel ore.  Made Alu gravel no longer required to progress Making Better Tools