### PR TITLE
Fix Blast Furnace Glass Recipe

### DIFF
--- a/scripts/Minecraft.zs
+++ b/scripts/Minecraft.zs
@@ -3253,10 +3253,10 @@ Assembler.addRecipe(<minecraft:stone_pressure_plate> * 2, <minecraft:stone_slab>
 
 
 // --- Glass Block
-BlastFurnace.addRecipe([<minecraft:glass>], [<TConstruct:GlassBlock>, <gregtech:gt.integrated_circuit:1>], 100, 120, 1000);
+BlastFurnace.addRecipe([<minecraft:glass>], [<TConstruct:GlassBlock>, <gregtech:gt.integrated_circuit:1> * 0], 100, 120, 1000);
 
 // --- Clear Pane
-BlastFurnace.addRecipe([<minecraft:glass_pane>], [<TConstruct:GlassPane>, <gregtech:gt.integrated_circuit:1>], 100, 120, 1000);
+BlastFurnace.addRecipe([<minecraft:glass_pane>], [<TConstruct:GlassPane>, <gregtech:gt.integrated_circuit:1> * 0], 100, 120, 1000);
 
 
 


### PR DESCRIPTION
I just found an issue when tried to convert TiC glass to vanilla glass.
The old recipe consumed the GT chip, and I fixed that.