### PR TITLE
Made Mirrored Glass recipes compatible with Ordict

### DIFF
--- a/scripts/Thaumcraft-04-Artifice.zs
+++ b/scripts/Thaumcraft-04-Artifice.zs
@@ -277,9 +277,9 @@ mods.thaumcraft.Research.addArcanePage("BASICARTIFACE", <Thaumcraft:ItemBaubleBl
 
 // --- Mirrored Glass
 mods.thaumcraft.Arcane.addShaped("BASICARTIFACE", <Thaumcraft:ItemResource:10>, "aer 30, terra 30, ignis 30,", [
-[<TConstruct:buckets:23>, <ore:gemMercury>, <TConstruct:buckets:23>],
+[<ore:bucketEnder>, <ore:gemMercury>, <ore:bucketEnder>],
 [<ore:gemMercury>, <minecraft:glass_pane>, <ore:gemMercury>],
-[<TConstruct:buckets:23>, <ore:gemMercury>, <TConstruct:buckets:23>]]);
+[<ore:bucketEnder>, <ore:gemMercury>, <ore:bucketEnder>]]);
 mods.thaumcraft.Research.addArcanePage("BASICARTIFACE", <Thaumcraft:ItemResource:10>);
 
 // --- Arcane Stone

--- a/scripts/Tinkers-Construct.zs
+++ b/scripts/Tinkers-Construct.zs
@@ -4016,5 +4016,11 @@ oreDict.nuggetAluminium.remove(<TConstruct:oreBerries:4>);
 
 
 
+// --- Ordict add ---
+
+
+// --- Liquid Ender Bucket
+<ore:bucketEnder>.add(<TConstruct:buckets:23>);
+
 
 // --- Hiding Stuff ---


### PR DESCRIPTION
Because Mirrored Glass cann't be made with Resonant Ender Bucket of GT ++