### PR TITLE
fix #5517 Conflicting recipes for leather and gold dust

### DIFF
--- a/scripts/CoreMod.zs
+++ b/scripts/CoreMod.zs
@@ -744,9 +744,9 @@ recipes.addShaped(<gregtech:gt.metaitem.01:37>, [
 
 // --- Leather out of XP 20 level
 recipes.addShaped(<minecraft:leather>, [
+[<OpenBlocks:filledbucket>, <OpenBlocks:filledbucket>, null],
 [<OpenBlocks:filledbucket>, <OpenBlocks:filledbucket>, <OpenBlocks:filledbucket>],
-[<OpenBlocks:filledbucket>, <OpenBlocks:filledbucket>, <OpenBlocks:filledbucket>],
-[<OpenBlocks:filledbucket>, null, <OpenBlocks:filledbucket>]]);
+[<OpenBlocks:filledbucket>, <OpenBlocks:filledbucket>, <OpenBlocks:filledbucket>]]);
 
 // --- Small Cobalt Bass Dust out of XP 25 level
 recipes.addShaped(<gregtech:gt.metaitem.01:1343>, [


### PR DESCRIPTION
Change recipe from shape:

B = XP Bucket

```none
╔═══╤═══╤═══╗
║ B │   │ B ║
╟───┼───┼───╢
║ B │ B │ B ║
╟───┼───┼───╢
║ B │ B │ B ║
╚═══╧═══╧═══╝
```
To this new recipe:
```none
╔═══╤═══╤═══╗
║ B │ B │   ║
╟───┼───┼───╢
║ B │ B │ B ║
╟───┼───┼───╢
║ B │ B │ B ║
╚═══╧═══╧═══╝
```