### PR TITLE
apple core show tooltip always

### DIFF
--- a/config/AppleCore.cfg
+++ b/config/AppleCore.cfg
@@ -1,0 +1,42 @@
+# Configuration file
+
+##########################################################################################################
+# client
+#--------------------------------------------------------------------------------------------------------#
+# These config settings are client-side only
+##########################################################################################################
+
+client {
+    # If true, shows your food exhaustion as a progress bar behind the hunger bars
+    B:show.food.exhaustion.hud.underlay=true
+
+    # If true, adds a line that shows your hunger, saturation, and exhaustion level in the F3 debug overlay
+    B:show.food.stats.in.debug.overlay=true
+
+    # If true, shows the hunger (and saturation if show.saturation.hud.overlay is true) that would be restored by food you are currently holding
+    B:show.food.values.hud.overlay=true
+
+    # If true, shows the hunger and saturation values of food in its tooltip while holding SHIFT
+    B:show.food.values.in.tooltip=true
+
+    # If true, shows the hunger and saturation values of food in its tooltip automatically (without needing to hold SHIFT)
+    B:show.food.values.in.tooltip.always=true
+
+    # If true, shows your current saturation level overlayed on the hunger bar
+    B:show.saturation.hud.overlay=true
+}
+
+
+##########################################################################################################
+# server
+#--------------------------------------------------------------------------------------------------------#
+# These config settings are server-side only
+##########################################################################################################
+
+server {
+    # The maximum difference between the server's value for exhaustion and the client's before the value is syncronized from the server to the client.
+    # Raising this value will cause fewer packets to be sent, but will make the client's exhaustion values appear more choppy
+    D:exhaustion.sync.threshold=0.01
+}
+
+


### PR DESCRIPTION
If true, shows the hunger and saturation values of food in its tooltip automatically (without needing to hold SHIFT)
B:show.food.values.in.tooltip.always=true

How do you think @Dream-Master 