### PR TITLE
fix(ztones): myst block recipe

### DIFF
--- a/scripts/Ztones.zs
+++ b/scripts/Ztones.zs
@@ -58,8 +58,9 @@ recipes.remove(<Ztones:ofanix>);
 // --- Cobblestone
 recipes.removeShapeless(<minecraft:cobblestone>, [<Ztones:ofanix>]);
 
+// --- Myst Block
 
-
+recipes.remove(<Ztones:tile.mystBlock>);
 
 // --- Adding Recipes ---
 
@@ -87,6 +88,15 @@ recipes.addShaped(<Ztones:auroraBlock> * 8, [
 [<ore:blockGlass>, <ore:dye>, <ore:blockGlass>],
 [<ore:blockGlass>, <ore:blockGlass>, <ore:blockGlass>]]);
 
+// --- Myst Block
+
+val blockMushroom = <ore:blockMushroom>;
+blockMushroom.add(<minecraft:brown_mushroom_block:*>);
+blockMushroom.add(<minecraft:red_mushroom_block:*>);
+recipes.addShaped(<Ztones:tile.mystBlock:0> * 8, [
+  [blockMushroom, blockMushroom, blockMushroom],
+  [blockMushroom, <Ztones:auroraBlock>, blockMushroom],
+  [blockMushroom, blockMushroom, blockMushroom]]);
 
 
 


### PR DESCRIPTION
Add any mushroom block as ingredient rather than specific meta 0 brown mushroom block.

Address issue [Mushroom Block With Chisel Support](https://github.com/GTNewHorizons/NewHorizons/issues/5701).