### PR TITLE
Fixed quest typo and readme typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-
-
-
 # GT New Horizons Mod Pack
 
 Version 2.0.8.4 is out 15.02.2020
@@ -10,13 +7,13 @@ Version 2.0.8.4 is out 15.02.2020
 ## What is GT New Horizons?
 
 You are looking at a big progressive kitchensink pack for Minecraft 1.7.10 balanced around the mod GregTech.<BR>
-Over 3 years of developement (and still going) have formed a balance and refinement that only a handful of packs can keep up with. We are talking about thousands of recipe tweaks, a massive questbook with custom reward system, unique world generation, custom mods coded for the pack, custom Thauminomicon pages, and many more.
+Over 3 years of development (and still going) have formed a balance and refinement that only a handful of packs can keep up with. We are talking about thousands of recipe tweaks, a massive questbook with a custom reward system, unique world generation, custom mods coded for the pack, custom Thaumonomicon pages, and many more.
  
-The main intentions of the pack are a long lasting experience and tying mods together in a progressive fashion, making it feel more like a single game than a compilation of mods thrown together.<BR>
-To reach this goal GT New Horizons is using the tiers (basically ages of technology) from GregTech and allocates content of other mods to a fitting point within the progression. <BR>
-Starting in the stone age you will barely be able to survive until you get your first steam machines and eventually reach electricity. Later on you will have to visit other planets and dimensions to gather important ressources and fight mighty bosses to channel their magical power.
+The main intentions of the pack are a long-lasting experience and tying mods together in a progressive fashion, making it feel more like a single game than a compilation of mods thrown together.<BR>
+To reach this goal, GT New Horizons is using the tiers (basically ages of technology) from GregTech and allocates content of other mods to a fitting point within the progression. <BR>
+Starting in the stone age you will barely be able to survive until you get your first steam machines and, eventually, reach electricity. Later on, you will have to visit other planets and dimensions to gather important resources and fight mighty bosses to channel their magical power.
 
-If you are fan of expert mode packs and want to take it to the next level this pack will be your friend!
+If you are a fan of expert mode packs and want to take it to the next level this pack will be your friend!
 
 ## Quotes
 
@@ -45,30 +42,30 @@ If you are fan of expert mode packs and want to take it to the next level this p
 ## What does this pack have to offer?
 
 ***Technology***<BR>
-GregTech on its own comes with a huge tech tree using the EU system and the other technology based mods will open up while you are progressing through the tiers.<BR>
+GregTech on its own comes with a huge tech tree using the EU system and the other technology-based mods will open up while you are progressing through the tiers.<BR>
 The main cables of GregTech convert EU to RF so you don't have to worry about different energy systems and things feeling incompatible.<BR>
 
-Complex processing lines, automation, a large variety in power generation and a lot of materials to work with create an enviroment with many possibilities that the player has to explore.<BR>
-Crossbreeding plants, bees and crops with Forestry and IndustrialCraft2, setting up mobfarms using EnderIO and Draconic Evolution, and general infrastructure improvements with Railcraft and Applied Energistics - it's all there, anything you want (and need!) if you enjoy the technical aspect of modded Minecraft.
+Complex processing lines, automation, a large variety in power generation and a lot of materials to work with create an environment with many possibilities that the player has to explore.<BR>
+Crossbreeding plants, bees and crops with Forestry and IndustrialCraft2, setting up mob farms using EnderIO and Draconic Evolution, and general infrastructure improvements with Railcraft and Applied Energistics - it's all there, anything you want (and need!) if you enjoy the technical aspect of modded Minecraft.
  
 ***Magic***<BR>
 GT New Horizons comes with a variety of powerful magic mods. Your main access will be through the Thauminomicon which is modified to also feature custom sections for Blood Magic, Witchery, and other important things besides having the usual content of Thaumcraft and its add-ons.<BR>
 
-The Twilight Forest is the dimension linked to magic in this pack and you will have to explore and defeat the bosses to progress in magic. Later on there is power generation with essentia and options to store it using your AE system connecting technology with magic.
+The Twilight Forest is the dimension linked to magic in this pack and you will have to explore and defeat the bosses to progress in magic. Later on, there is power generation with essentia and options to store it using your AE system connecting technology with magic.
 
 ***Exploration***<BR>
-Using Realistic World Gen along with Biomes o'Plenty creates a beautiful terrain in the overworld.<BR>
+Using Realistic World Gen along with Biomes O' Plenty creates a beautiful terrain in the overworld.<BR>
 Besides all the biomes and natural structures you can find there will be challenging Rogue-like Dungeons that come with decent loot and spawners you might want to use in creative ways.<BR>
 
-In the early game, villages offer a nice resting spot while looking for the optimal base location. Later you will revisit the villages to trade for key items and scavenge for parts. Eventually you may end up relocating villagers closer to you - or taking over a village yourself.
+In the early game, villages offer a nice resting spot while looking for the optimal base location. Later you will revisit the villages to trade for key items and scavenge for parts. Eventually, you may end up relocating villagers closer to you - or taking over a village yourself.
  
 ***Put the mining back in Minecraft*** <BR>
 GregTech spawns ore in large localized veins rather than small clusters of everything, rewarding long searches with a huge vein that can sustain your base's growth for a long time.<BR>
 
-In most packs nearly everything spawns in the overworld which is not the case in GT New Horizons, and you are encouraged to mine in other dimensions such as the Twilight Forest, the nether, the end and (later on) even on other planets to make your way to the endgame. Unlocking things by mining for materials on other planets will create that situation where Galacticraft all of a sudden becomes important to progress which feels really rewarding.<BR>
+In most packs, nearly everything spawns in the overworld which is not the case in GT New Horizons, and you are encouraged to mine in other dimensions such as the Twilight Forest, the nether, the end and (later on) even on other planets to make your way to the endgame. Unlocking things by mining for materials on other planets will create that situation where Galacticraft all of a sudden becomes important to progress which feels really rewarding.<BR>
 
 ***Survival***<BR>
-The first few days and nights will be rough, in fact nights will stay rough for a while since hardcore darkness makes them pitch black without any light sources or potion effects, so you might want to get a bed quickly!<BR>
+The first few days and nights will be rough, in fact, nights will stay rough for a while since hardcore darkness makes them pitch black without any light sources or potion effects, so you might want to get a bed quickly!<BR>
 Food is a critical thing early game and you can't keep eating the same things because of Spice of Life. Better watch out for some gardens from Pam's Harvestcraft to get some variety into your nutrition!<BR>
 
 Be prepared to face strong mobs that can cause death quickly if you play without any strategy.<BR>
@@ -76,17 +73,17 @@ Facing them with better gear will make life easier once you progress but until t
 
 ***Questing***<BR>
 GT New Horizons comes with over 1300 quests that will guide the player through the maze that modded Minecraft can be.<BR>
-The texts will inform you what's required to progress so you don't have to watch tutorials or ask others as often. The questbook can even save you the time to type into NEI, just click the items displayed in the quest and it will display the recipe through NEI, quite handy right?
+The texts will inform you what's required to progress so you don't have to watch tutorials or ask others as often. The questbook can even save you the time to type into NEI, just click the items displayed in the quest and it will display the recipe through NEI, quite handy, right?
 
 Custom lootbags and the coin system make for unique and helpful rewards. And we all enjoy the gamble from time to time.
 
 ***Is this a game for newbies?*** <BR>
-Newbies to Minecraft? Definitely not. Newbies to modded Minecraft?  Maybe.  The questbook is a great introduction to the variety and type of mods available. With each mod gated players must learn about the mod to make the most of it while waiting for the next mod to unlock.
+Newbies to Minecraft? Definitely not. Newbies to modded Minecraft?  Maybe.  The questbook is a great introduction to the variety and type of mods available. With each mod, gated players must learn about the mod to make the most of it while waiting for the next mod to unlock.
 
 ***Is this modpack for me?*** <BR>
 Does the thought of earning that top-end gear over weeks or months appeal to you? The usual packs feel like they are over in 1 or 2 weeks since you get OP gear so quickly?
 
-How about designing a chemical processing system to rival a real oil refinery, with multiple inputs creating dozens of outputs and intermediate products to finally make a bar of plastic, rubber, explosives or other top end gear?
+How about designing a chemical processing system to rival a real oil refinery, with multiple inputs creating dozens of outputs and intermediate products to finally make a bar of plastic, rubber, explosives or other top-end gear?
 
 Does the sound of machinery processing ore via crushing, washing, centrifuging, smelting in a blast furnace, and cooling off in a vacuum freezer tickle your brain?
 
@@ -149,7 +146,7 @@ Wabulabudaba GTNH Server Russia
 Hitechmine.ru  GTNG Server Russia
 hitechmine.ru:25565
 
-Zvezdolet New fresh russian server Whitelisted
+Zvezdolet New fresh Russian server Whitelisted
 IP: gtnh.114-7.com
 
 


### PR DESCRIPTION
- quest 1780: find => found

- quest 1834: rwg => RWG | it's an acronym (tho "rwg" might have been intended)

- Readme: Corrected some typos, also checked with Grammarly for the commas